### PR TITLE
fix(security): harden URL scheme and sanitizer checks

### DIFF
--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/security-gitleaks.yml
+++ b/.github/workflows/security-gitleaks.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-npm-audit.yml
+++ b/.github/workflows/security-npm-audit.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.3.0
         with:
           node-version: '20'
 

--- a/src/lib/astrological-report.ts
+++ b/src/lib/astrological-report.ts
@@ -58,7 +58,10 @@ const formatPosicaoLabel = (pos: string): string => {
 const sanitizeForEmail = (html: string): string =>
   html.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
       .replace(/on\w+="[^"]*"/gi, '')
-      .replace(/javascript:/gi, '')
+  .replace(/\s(href|src)\s*=\s*(['"])\s*(javascript|data|vbscript)\s*:[\s\S]*?\2/gi, '')
+  .replace(/javascript:/gi, '')
+  .replace(/data:/gi, '')
+  .replace(/vbscript:/gi, '')
 
 // ─── Text Report (WhatsApp-style) ────────────────────────────────
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -65,6 +65,13 @@ export function validateAdminActor(actor: string): ValidationResult {
 
 const DOMAIN_REGEX = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i
 const MX_HOSTNAME_REGEX = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(\s+\d+)?$/i
+const BLOCKED_URL_SCHEMES = ['javascript:', 'data:'] as const
+
+const normalizeSchemeInput = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[\u0000-\u001f\u007f\s]+/g, '')
 
 /**
  * Validates HTTP/HTTPS URL
@@ -76,6 +83,11 @@ export function validateUrl(url: string): ValidationResult {
 
   if (!trimmed) {
     return { valid: false, error: 'URL não pode estar vazia.' }
+  }
+
+  const normalized = normalizeSchemeInput(trimmed)
+  if (BLOCKED_URL_SCHEMES.some((scheme) => normalized.startsWith(scheme))) {
+    return { valid: false, error: 'URL com protocolo não permitido.' }
   }
 
   try {


### PR DESCRIPTION
## Summary\n- Block dangerous URL schemes (javascript:, data:) in URL validation\n- Harden HTML sanitizer for href/src dangerous schemes\n\n## Why\nAddresses CodeQL findings for incomplete URL scheme and sanitization checks.