### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete multi-character sanitization

### DIFF
--- a/functions/api/news/feed.ts
+++ b/functions/api/news/feed.ts
@@ -139,17 +139,17 @@ function extractTag(block: string, tag: string): string {
 
 /**
  * Remove tags HTML e decodifica entidades comuns.
+ * Mantém &lt; e &gt; como entidades para evitar recriar tags.
  */
 function cleanHtml(text: string): string {
   return text
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/<\s*script[\s\S]*?>[\s\S]*?<\s*\/\s*script\s*>/gi, ' ')
-    .replace(/<\s*\/?\s*script\b[^>]*>/gi, ' ')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
+    // Decodifica entidades comuns seguras
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&nbsp;/gi, ' ')
+    // Remove qualquer tag HTML remanescente
+    .replace(/<[^>]*>/g, '')
+    // Garante que nenhum delimitador de tag reste
     .replace(/[<>]/g, '')
     .trim()
 }


### PR DESCRIPTION
Potential fix for [https://github.com/lcv-leo/admin-app/security/code-scanning/22](https://github.com/lcv-leo/admin-app/security/code-scanning/22)

In general, the safest fix is to avoid home-grown HTML sanitization and instead delegate to a well-maintained library that is designed to handle nested tags, encodings, and tricky edge cases; or, if you only need plain text, avoid HTML entirely by decoding entities and then stripping all tags and angle brackets using simple, robust operations that do not rely on complex multi-character patterns whose activities can interact.

For this specific `cleanHtml` function, the best non-breaking fix—while preserving its intent of returning safe, mostly plain text—is to: (1) avoid decoding `&lt;` and `&gt;` into literal `<`/`>` before removal, because that introduces new tag delimiters; (2) simplify the sanitization so that it does not depend on fragile script-specific multi-character regexes; and (3) ensure that after cleaning, there is no way any `<` or `>` remains, and that no `<script`-like constructs can be reconstituted through partial replacements. A straightforward way to do this within the shown code is:

- Remove the two `.replace` calls that turn `&lt;` and `&gt;` into `<` and `>`.
- Decode the safer entities (`&quot;`, `&#39;`, `&nbsp;`) as before.
- Strip any remaining HTML tags via a simple `<[^>]*>` pattern once.
- As a final safety net, strip any remaining `<` or `>` characters.
- Optionally, we can also make the tag-stripping regex slightly more tolerant without introducing multi-step interactions.

This preserves the original functionality of “get human-readable text without HTML” but removes the risky step of creating new `<`/`>` characters from entities prior to stripping tags. It also addresses CodeQL’s concern, because any user input such as `&lt;script&gt;alert(1)&lt;/script&gt;` will now remain as literal `&lt;script&gt;...`, which cannot become executable HTML, or, depending on how `cleanHtml` output is used, will be rendered as plain text or further escaped by the template engine.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
