### PR TITLE
chore(repo): finalize organization migration metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
 github: lcv-leo
-custom: ['https://lcv-leo.github.io/admin-app/']
+custom: ['https://admin-app.lcv.app.br/']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -26,8 +24,6 @@ updates:
       - "dependencies"
       - "npm"
       - "frontend"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -83,8 +79,6 @@ updates:
       - "dependencies"
       - "npm"
       - "worker"
-    assignees:
-      - "lcv-leo"
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+name: Dependabot Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
+            exit 0
+          fi
+          gh pr merge "$PR_URL" --auto --merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — Admin App
 
+## [v01.99.06] - 2026-04-27
+### Alterado — migração GitHub org + Pages/Sponsors custom domain
+- Repositório transferido para `LCV-Ideas-Software/admin-app`; README e rodapé de compliance apontam para o repositório público da organização.
+- `.github/FUNDING.yml` passa a usar `https://admin-app.lcv.app.br/` como link custom do botão Sponsor, preservando `github: lcv-leo`.
+- Dependabot deixa de atribuir PRs ao usuário e ganha workflow `Dependabot Automerge` restrito a `dependabot[bot]`, sem checkout de código de PR.
+### Validação
+- `npm run lint`.
+- `npm run build`.
+- YAML dos workflows/dependabot parseado via `js-yaml`.
+- Pages custom domain `https://admin-app.lcv.app.br/` respondeu HTTP 200.
+
 ## [v01.99.05] - 2026-04-27
 ### Corrigido — regressão pós-flip-público no sanitizer de posts MainSite
 - `admin-motor/src/handlers/routes/mainsite/_lib/sanitize-post-html.ts`: hardening introduzido em v01.97.00 (commit `2f27dba`, "audit Phase 0 — sanitize posts") restringiu `allowedStyles['*']` a uma única propriedade (`text-align`) e omitiu `h1..h6`, `li`, `ul`, `ol`, `iframe`, `figure`, `mark` de `allowedAttributes`. Resultado: tudo que as extensões Tiptap emitem como inline `style` em headings, lists, figures e media (TextAlign em headings; EditorSpacing line-height/margin-top/margin-bottom em paragraphs+headings+listItem+bulletList+orderedList — listas eram a falha mais grave por afetar todos os posts com listas; FontSize, FontFamily, Color em spans; TextIndent em paragraphs+headings; CustomResizableImage width/height em img; FigureImageNode width/max-width/display em figure+img; Table width/min-width em table+col) era silenciosamente descartado pelo `sanitize-html` no `POST/PUT /api/mainsite/posts` antes de chegar à D1. Operador relatou: alinhamento de H3 perdido, espaçamento entre linhas/parágrafos não persistia, font-size e inserção de linhas em branco descartados, re-edição não restaurava o estado das ferramentas — sintomas consistentes com persistência incompleta sem qualquer erro visível.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You will need:
 ### 1. Clone + install
 
 ```bash
-git clone https://github.com/lcv-leo/admin-app.git
+git clone https://github.com/LCV-Ideas-Software/admin-app.git
 cd admin-app
 npm ci
 ```

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import type { ModuleId } from './moduleId';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v01.99.05';
+const APP_VERSION = 'APP v01.99.06';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   'ai-status': 'AI Status',

--- a/src/components/ComplianceBanner.tsx
+++ b/src/components/ComplianceBanner.tsx
@@ -48,7 +48,12 @@ export const ComplianceBanner: React.FC<ComplianceBannerProps> = ({ onViewLicens
         Licenças (GNU AGPLv3 + Apache 2.0)
       </a>
       <span aria-hidden="true">|</span>
-      <a href="https://github.com/lcv-leo/admin-app" target="_blank" rel="noopener noreferrer" style={linkStyle}>
+      <a
+        href="https://github.com/LCV-Ideas-Software/admin-app"
+        target="_blank"
+        rel="noopener noreferrer"
+        style={linkStyle}
+      >
         Código Fonte (GitHub)
       </a>
     </footer>


### PR DESCRIPTION
## Summary
- finalize repository metadata after transfer to LCV-Ideas-Software
- keep compliance footer pointing to public GitHub source and Sponsors button pointing to the custom Pages domain through FUNDING.yml
- remove personal Dependabot assignees and add Dependabot-only auto-merge workflow
- bump app version to APP v01.99.06 and document validation in CHANGELOG

## Validation
- npm run lint
- npm run build
- npx --yes js-yaml .github/dependabot.yml
- npx --yes js-yaml .github/workflows/dependabot-automerge.yml
- GitHub Pages API checked custom domain HTTPS approval/enforcement

Note: cross-review-mcp is temporarily paused because long rounds are being diagnosed separately.