### PR TITLE
chore(security): standardize DevSecOps baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a reproducible defect
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+
+
+## Steps to Reproduce
+
+1.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Environment
+
+- OS:
+- Browser/runtime:
+- Version/commit:
+
+## Security
+
+Do not include secrets, tokens, credentials, private URLs, or exploit details in public issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Private security report
+    url: https://github.com/LCV-Ideas-Software
+    about: Report vulnerabilities privately. Do not disclose secrets or exploit details in public issues.

--- a/.github/ISSUE_TEMPLATE/engineering_task.md
+++ b/.github/ISSUE_TEMPLATE/engineering_task.md
@@ -1,0 +1,22 @@
+---
+name: Engineering task
+about: Track implementation, maintenance, or hardening work
+title: "[Task]: "
+labels: ["maintenance"]
+assignees: []
+---
+
+## Objective
+
+
+## Scope
+
+-
+
+## Acceptance Criteria
+
+- [ ]
+
+## Validation
+
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] Relevant local checks were run or the change is documentation/configuration only.
+- [ ] GitHub Actions changes use least-privilege permissions and immutable action SHAs.
+- [ ] Dependabot automation remains non-blocking for routine patch/minor updates.
+
+## Security Notes
+
+- [ ] No secrets, credentials, tokens, or private infrastructure details were added.
+- [ ] New deployment or cloud access uses short-lived credentials or OIDC where practical.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,5 +1,4 @@
 name: Auto-release on version bump
-
 # Universal tag convention (operator directive 2026-04-28): vXX.XX.XX with
 # two-digit zero-padded segments. APP_VERSION (in src/App.tsx) is
 # the source of truth; the tag is derived as `v${digits-only-from-APP_VERSION}`
@@ -15,34 +14,27 @@ name: Auto-release on version bump
 # Inspired by maestro-app's release.yml (Codex 2026-04-26) and
 # cross-review-mcp's auto-tag.yml. Adapted for the 8 LCV-Ideas-Software
 # repos that ship APP_VERSION'd Node/Vite/Worker applications.
-
 on:
   push:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: write
-
 concurrency:
   group: auto-release-${{ github.ref }}
   cancel-in-progress: false
-
 env:
   # Path of the file containing `const APP_VERSION = 'APP vXX.YY.ZZ';`.
   VERSION_FILE: src/App.tsx
-
 jobs:
   auto-release:
     name: Create universal-format tag + GitHub Release if APP_VERSION was bumped
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout main with full history
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
       - name: Extract APP_VERSION + compute tags
         id: version
         run: |
@@ -67,7 +59,6 @@ jobs:
           echo "tag=$PAD" >> "$GITHUB_OUTPUT"
           echo "legacy_tag=$LEGACY" >> "$GITHUB_OUTPUT"
           echo "APP_VERSION='APP v${DIGITS}' → universal: $PAD, legacy: $LEGACY"
-
       - name: Check if either tag already exists on origin
         id: check
         env:
@@ -85,7 +76,6 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
             echo "Neither ${TAG} nor ${LEGACY_TAG} exists; will create universal-format tag ${TAG}."
           fi
-
       - name: Extract release notes from CHANGELOG.md
         id: notes
         if: steps.check.outputs.exists == 'false'
@@ -117,7 +107,6 @@ jobs:
             echo "$NOTES"
             echo "RELEASE_NOTES_EOF"
           } >> "$GITHUB_OUTPUT"
-
       - name: Create tag + GitHub Release
         if: steps.check.outputs.exists == 'false'
         env:
@@ -133,3 +122,4 @@ jobs:
             --notes "$NOTES" \
             --latest
           echo "Created release ${TAG} at ${GITHUB_SHA}."
+    timeout-minutes: 60

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,4 @@
 name: Dependabot Automerge
-
 on:
   pull_request_target:
     types:
@@ -7,11 +6,9 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-
 permissions:
   contents: write
   pull-requests: write
-
 jobs:
   enable-automerge:
     if: github.actor == 'dependabot[bot]'
@@ -25,4 +22,8 @@ jobs:
           if [ "$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')" = "true" ]; then
             exit 0
           fi
-          gh pr merge "$PR_URL" --auto --merge
+          gh pr merge "$PR_URL" --auto --squash --delete-branch
+    timeout-minutes: 15
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+on:
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+  pull-requests: read
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: always

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
 name: Deploy
-
 on:
   push:
     branches: [main]
@@ -14,14 +13,11 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_OPTIONS: "--no-deprecation"
   WRANGLER_VERSION: "latest"
-
 concurrency:
   group: deploy-main
   cancel-in-progress: true
-
 permissions:
   contents: read
-
 jobs:
   detect_tlsrpt:
     runs-on: ubuntu-latest
@@ -76,7 +72,7 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `reason=${reason}\n`);
           console.log(reason);
           NODE
-
+    timeout-minutes: 30
   deploy_tlsrpt:
     needs: detect_tlsrpt
     if: needs.detect_tlsrpt.outputs.deploy_tlsrpt == 'true'
@@ -86,21 +82,17 @@ jobs:
       deployments: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: ./tlsrpt-motor/package-lock.json
-
       - name: Install TLS-RPT Motor
         working-directory: ./tlsrpt-motor
         run: npm ci
-
       - name: Audit TLS-RPT Motor
         working-directory: ./tlsrpt-motor
         run: npm audit --audit-level=high
-
       - name: Inject D1 database_id from secret (tlsrpt-motor)
         run: |
           if [ -z "${D1_DATABASE_ID:-}" ]; then
@@ -117,54 +109,44 @@ jobs:
           fi
         env:
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
-
       - name: Deploy TLS-RPT Motor
         working-directory: ./tlsrpt-motor
         run: npx wrangler@${WRANGLER_VERSION} deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets['CLOUDFLARE_API_TOKEN'] }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets['CLOUDFLARE_ACCOUNT_ID'] }}
-
+    timeout-minutes: 30
   deploy_admin:
     needs: [detect_tlsrpt, deploy_tlsrpt]
     if: >
-      always() &&
-      github.event_name == 'push' &&
-      needs.detect_tlsrpt.result == 'success' &&
-      (needs.detect_tlsrpt.outputs.deploy_tlsrpt != 'true' || needs.deploy_tlsrpt.result == 'success')
+      always() && github.event_name == 'push' && needs.detect_tlsrpt.result == 'success' && (needs.detect_tlsrpt.outputs.deploy_tlsrpt != 'true' || needs.deploy_tlsrpt.result == 'success')
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       deployments: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
           cache-dependency-path: ./package-lock.json
-
       - name: Install Admin App
         run: npm ci
         working-directory: ./
-
       - name: Security Audit — Admin App
         run: npm audit --audit-level=high
         working-directory: ./
-
       - name: Lint Admin App
         run: npm run lint
         working-directory: ./
-
       - name: Test Admin App UI
         run: npm test
         working-directory: ./
-
       - name: Test Admin Motor
         run: npm run test:admin-motor
         working-directory: ./
-
       - name: Inject D1 database_id from secret (root + admin-motor)
         run: |
           if [ -z "${D1_DATABASE_ID:-}" ]; then
@@ -182,20 +164,18 @@ jobs:
           done
         env:
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
-
       - name: Deploy Admin Motor
         run: npx wrangler@${WRANGLER_VERSION} deploy --config admin-motor/wrangler.json
         working-directory: ./
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets['CLOUDFLARE_API_TOKEN'] }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets['CLOUDFLARE_ACCOUNT_ID'] }}
-
       - run: npm run build
         working-directory: ./
-
       - name: Deploy Admin App
         run: npx wrangler@${WRANGLER_VERSION} pages deploy dist --project-name=admin-app --branch=main --commit-dirty=true
         working-directory: ./
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets['CLOUDFLARE_API_TOKEN'] }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets['CLOUDFLARE_ACCOUNT_ID'] }}
+    timeout-minutes: 30

--- a/.github/workflows/format-public.yml
+++ b/.github/workflows/format-public.yml
@@ -1,14 +1,11 @@
 name: Public Format
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-
 permissions:
   contents: read
-
 jobs:
   prettier-public:
     name: Check index.html formatting
@@ -16,15 +13,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Setup Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
-
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
-
       - name: Check public page formatting
         run: npm run format:public:check
+    timeout-minutes: 15
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,4 @@
 name: Pages
-
 on:
   push:
     branches: ["main"]
@@ -7,16 +6,13 @@ on:
       - ".github/workflows/pages.yml"
       - "site/**"
   workflow_dispatch:
-
 permissions:
   contents: read
   pages: write
   id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
-
 jobs:
   deploy:
     name: Deploy GitHub Pages
@@ -24,21 +20,18 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
-
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+    timeout-minutes: 30

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,26 @@
+name: OpenSSF Scorecard
+on:
+  schedule:
+    - cron: "37 8 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  scorecard:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true


### PR DESCRIPTION
## Summary

Standardizes the repository DevSecOps baseline without changing application runtime code.

- adds missing community/health templates where absent
- adds Dependency Review and OpenSSF Scorecard workflows with SHA-pinned actions
- adds workflow permissions, concurrency, and timeout defaults
- keeps Dependabot non-blocking for routine updates by preserving zero reviewers and using `--auto --squash --delete-branch`

## Validation

- YAML parse passed for all GitHub workflow/config YAMLs.
- Workflow baseline scan passed: 0 missing top-level permissions, 0 missing concurrency groups, 0 missing job timeouts.
- Action pin scan passed: 0 unpinned third-party actions.
- Dependabot approval guardrail passed: 0 `reviewers` / `team-reviewers` entries and 0 legacy `--merge` automerge commands.
- cross-review-v2 session `586559d6-9759-4cb7-8109-398087235c37` converged READY.

## Operator Constraint

This PR intentionally does not add required reviewers, required CODEOWNERS review, environment approval gates, or rules that would force manual Dependabot approval.
