### PR TITLE
fix(ci): make admin-motor typecheck baseline fingerprints OS-portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Corrigido
+
+- **Gate de typecheck do `admin-motor`**: os fingerprints da baseline-ratchet passam a remover o prefixo de caminho absoluto do repositório das mensagens do TypeScript. Sem isso, uma baseline gerada no Windows nunca coincidia com a recalculada no CI (Linux) — o caminho `import("…")` embutido na mensagem diferia —, gerando uma falsa regressão que travava o workflow de Deploy.
+
 ### Alterado
 
 - Sync inicial do MainSite grava `mainsite/ratelimit` apenas como toggles (`chatbot`, `email`, `comments`), alinhado ao rate limit nativo da Cloudflare; limites numericos nao sao mais semeados em D1.

--- a/admin-motor/.typecheck-baseline.json
+++ b/admin-motor/.typecheck-baseline.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "project": "admin-motor/tsconfig.json",
   "command": "npm run typecheck:admin-motor",
-  "generatedAt": "2026-05-21T18:38:08.055Z",
+  "generatedAt": "2026-05-21T19:14:17.863Z",
   "typescriptVersion": "6.0.3",
   "total": 245,
   "errors": [
@@ -1471,12 +1471,12 @@
       "message": "Property 'data' does not exist on type 'MainsiteContext'."
     },
     {
-      "fingerprint": "admin-motor/src/handlers/routes/mainsite/settings.ts:TS2345:Argument of type 'D1Database' is not assignable to parameter of type 'import(\"C:/Users/leona/lcv-workspace/admin-app/functions/api/_lib/operational\").D1Database'.#1",
+      "fingerprint": "admin-motor/src/handlers/routes/mainsite/settings.ts:TS2345:Argument of type 'D1Database' is not assignable to parameter of type 'import(\"/functions/api/_lib/operational\").D1Database'.#1",
       "file": "admin-motor/src/handlers/routes/mainsite/settings.ts",
       "line": 215,
       "column": 40,
       "code": "TS2345",
-      "message": "Argument of type 'D1Database' is not assignable to parameter of type 'import(\"C:/Users/leona/lcv-workspace/admin-app/functions/api/_lib/operational\").D1Database'."
+      "message": "Argument of type 'D1Database' is not assignable to parameter of type 'import(\"/functions/api/_lib/operational\").D1Database'."
     },
     {
       "fingerprint": "admin-motor/src/handlers/routes/mainsite/upload.ts:TS2345:Argument of type 'number | undefined' is not assignable to parameter of type 'number'.#1",

--- a/scripts/typecheck-admin-motor.mjs
+++ b/scripts/typecheck-admin-motor.mjs
@@ -21,7 +21,14 @@ function toRepoPath(filePath) {
 }
 
 function normalizeMessage(message) {
-  return message.replace(/\s+/g, ' ').trim();
+  const collapsed = message.replace(/\s+/g, ' ').trim();
+
+  // TypeScript embeds absolute paths in some messages (e.g. import("/abs/.../mod")).
+  // Strip the repo-root prefix — in both separator styles — so error fingerprints
+  // stay identical across machines and OSes (Windows dev vs Linux CI). Without
+  // this, a baseline generated on Windows never matches the one CI computes.
+  const repoRootForward = repoRoot.replaceAll('\\', '/');
+  return collapsed.replaceAll(repoRootForward, '').replaceAll(repoRoot, '');
 }
 
 function parseTypeScriptErrors(output) {


### PR DESCRIPTION
## Problema

O workflow **Deploy** falhou no gate `Typecheck Admin Motor` após o merge da v02.02.08 (#140), com uma regressão falsa:

```
admin-motor typecheck regression: 245 current error(s), 245 baseline error(s), 1 new fingerprint(s).
- admin-motor/src/handlers/routes/mainsite/settings.ts:215:40 TS2345 ...
```

## Causa-raiz

O fingerprint da baseline-ratchet inclui a mensagem completa do erro do TypeScript, e algumas mensagens embutem um caminho absoluto (`import("<abs>/functions/api/_lib/operational")`). A baseline da v02.02.08 foi gerada no Windows — gravando `C:/Users/leona/…` em um fingerprint. O CI (Linux) recalcula o mesmo erro com `/home/runner/work/…`, então essa única entrada nunca batia: regressão fantasma, embora o conjunto de erros seja idêntico (245 = 245).

## Correção

`normalizeMessage()` passa a remover o prefixo do repo-root (nos dois estilos de separador) das mensagens, tornando os fingerprints idênticos entre máquinas/SOs. Baseline regenerada — a única entrada alterada é o erro `D1Database` em `settings.ts`, cujo caminho embutido agora é relativo ao repositório.

## Validação

- `npm run typecheck:admin-motor`: `baseline clean: 245/245`.
- `git diff` da baseline confinado a 1 entrada (fingerprint + message) + metadata; nenhuma outra entrada de erro mudou.
- Baseline sem nenhum caminho absoluto (`grep` de `C:`/`/Users/`/`home/runner` → 0).

Hotfix de tooling de CI (gate consertando a si mesmo) para destravar o Deploy da v02.02.08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)