### PR TITLE
fix(maestro-ai): paginate Secret Store listing so key rotation updates existing secrets (v02.03.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.03.01] - 2026-07-05
+
+### Corrigido
+
+- **Maestro AI — troca de chave de agente falhava com "already exists" no Cloudflare Secrets Store**: `listSecretStoreSecrets` lia apenas a primeira página (padrão da API: 20 itens) de um endpoint paginado; como o store é compartilhado entre os apps (29 secrets) e as chaves `MAESTRO_*` ficam além da primeira página, a busca por nome nunca as encontrava e o salvamento caía no caminho de criação (POST), rejeitado pela Cloudflare como nome duplicado — o caminho de atualização (PATCH) existia, mas era inalcançável. A listagem agora pagina (`per_page=100`, acumula até página curta, teto de 50 páginas), restaurando o upsert correto. Teste de regressão cobre o cenário de secret existente além da primeira página (exige PATCH e proíbe POST).
+
 ## [v02.03.00] - 2026-06-12
 
 ### Adicionado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -444,7 +444,7 @@ describe('Maestro AI settings', () => {
   it('saves API keys through Cloudflare Secret Store and not into D1 settings JSON', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.endsWith('/secrets') && !init?.method) {
+      if (url.includes('/secrets?') && !init?.method) {
         return new Response(JSON.stringify({ success: true, result: [] }), { status: 200 });
       }
       return new Response(JSON.stringify({ success: true, result: [{ id: 'created' }] }), { status: 200 });
@@ -480,6 +480,54 @@ describe('Maestro AI settings', () => {
       },
     ]);
     expect(JSON.stringify(payload.settings)).not.toContain('new-secret-claude');
+    vi.unstubAllGlobals();
+  });
+
+  it('updates an existing Secret Store key even when it sits beyond the first list page', async () => {
+    const fillerPage = Array.from({ length: 100 }, (_, i) => ({
+      id: `filler-${i}`,
+      name: `FILLER_${i}`,
+      status: 'active',
+    }));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/secrets') && !url.includes('/secrets/') && (!init?.method || init.method === 'GET')) {
+        const page = new URL(url).searchParams.get('page');
+        const result =
+          page === '1'
+            ? fillerPage
+            : page === '2'
+              ? [{ id: 'sec-claude', name: 'MAESTRO_ANTHROPIC_API_KEY', status: 'active' }]
+              : [];
+        return new Response(JSON.stringify({ success: true, result }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ success: true, result: { id: 'sec-claude' } }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const response = await handleMaestroAiSettingsPut(
+      createContext(
+        {
+          protocol_text: protocolText,
+          max_cost_usd: 20,
+          max_runtime_minutes: null,
+          max_cycles: 2,
+          rates,
+          api_keys: { claude: 'rotated-secret-claude' },
+        },
+        {},
+        createMaestroDb(),
+      ),
+    );
+    const payload = (await response.json()) as { ok: boolean };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/secrets/sec-claude'),
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+    const postCall = fetchMock.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(postCall).toBeUndefined();
     vi.unstubAllGlobals();
   });
 });

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -759,10 +759,21 @@ async function cloudflareRequest<T>(env: MaestroAiEnv, path: string, init: Reque
 
 async function listSecretStoreSecrets(env: MaestroAiEnv): Promise<SecretStoreSecret[]> {
   const { accountId, storeId } = requireSecretStoreConfig(env);
-  return cloudflareRequest<SecretStoreSecret[]>(
-    env,
-    `/accounts/${encodeURIComponent(accountId)}/secrets_store/stores/${encodeURIComponent(storeId)}/secrets`,
-  );
+  // The store is shared with other apps, so the MAESTRO_* secrets can sit past
+  // the first page (the API defaults to per_page=20); read every page or the
+  // upsert below falls into the create branch and Cloudflare rejects the
+  // duplicate name.
+  const secrets: SecretStoreSecret[] = [];
+  const perPage = 100;
+  for (let page = 1; page <= 50; page += 1) {
+    const batch = await cloudflareRequest<SecretStoreSecret[]>(
+      env,
+      `/accounts/${encodeURIComponent(accountId)}/secrets_store/stores/${encodeURIComponent(storeId)}/secrets?page=${page}&per_page=${perPage}`,
+    );
+    secrets.push(...(batch ?? []));
+    if (!batch || batch.length < perPage) break;
+  }
+  return secrets;
 }
 
 async function upsertSecretStoreSecret(env: MaestroAiEnv, agent: ProviderKey, value: string): Promise<void> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.03.00';
+const APP_VERSION = 'APP v02.03.01';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary
- Fixes agent API key rotation in the Maestro AI settings failing with Cloudflare Secrets Store `already exists`.
- Root cause (verified against the live store): `listSecretStoreSecrets` read only page 1 (API default `per_page=20`) of a paginated endpoint; the shared store holds 29 secrets and all six `MAESTRO_*` keys sit on page 2, so the upsert name lookup always missed and the code took the POST/create branch — the PATCH/update branch existed but was unreachable.
- Fix: paginate inside `listSecretStoreSecrets` (`per_page=100`, accumulate until a short page, hard cap of 50 pages). Exactly one request for today's store size; correct for any future size.

## Testing
- New regression test written red-first against HEAD: existing secret beyond the first list page must be PATCHed and POST is forbidden (reproduced the bug, green after the fix).
- Full admin-motor suite 127/127; typecheck baseline clean; eslint/biome/prettier/markdownlint gates green.
- Cross-review: unanimous READY round 1 (caller + codex, gemini, deepseek, grok, perplexity), session 6738b768.

🤖 Generated with [Claude Code](https://claude.com/claude-code)