### PR TITLE
feat(maestro-ai): mirror desktop I/O contract semantics — parity Plan A (v02.04.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.04.00] - 2026-07-05
+
+### Alterado
+
+- **Maestro AI — paridade de contrato de I/O com o maestro-app (Plano A do roadmap de equiparação)**: o maestro-app (desktop) é a fonte canônica de comportamento; quatro rotinas do módulo web passam a espelhar a semântica dele byte-a-byte. (1) `MAESTRO_STATUS` agora é reconhecido em **qualquer linha** da resposta, mas exige a linha exata `MAESTRO_STATUS: READY`/`NOT_READY` (um espaço após os dois-pontos) — antes só a primeira linha era lida, com regex flexível e remoção de `<think>`. (2) Blocos `<maestro_final_text>`/`<maestro_revision_report>` duplicados resolvem para o **último** par completo (tolerância a eco), não mais o primeiro. (3) Mudança substantiva de custódia usa a normalização canônica (CRLF→LF + colapso de todo whitespace): diferenças só de espaçamento/quebras de linha não transferem custódia nem reiniciam a estabilidade; pontuação e capitalização seguem substantivas. (4) Tabela de aliases de agente completa (`agy`/`antigravity`→Gemini, `deepseek-api`, `grok-api`, `perplexity-api`). Roadmap completo em `docs/superpowers/plans/2026-07-05-maestro-ai-parity-roadmap.md`.
+
 ## [v02.03.01] - 2026-07-05
 
 ### Corrigido

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -532,6 +532,62 @@ describe('Maestro AI settings', () => {
   });
 });
 
+describe('Maestro AI desktop-parity parsing (Plan A)', () => {
+  it('extractStatus matches desktop exact-line semantics', () => {
+    const { extractStatus } = maestroAiTestHooks;
+    expect(extractStatus('intro line\nMAESTRO_STATUS: READY\nrest')).toBe('READY');
+    expect(extractStatus('maestro_status: ready')).toBe('READY');
+    expect(extractStatus('MAESTRO_STATUS : READY')).toBe('NOT_READY');
+    expect(extractStatus('prefix MAESTRO_STATUS: READY suffix')).toBe('NOT_READY');
+    expect(extractStatus('MAESTRO_STATUS: NOT_READY\nMAESTRO_STATUS: READY')).toBe('NOT_READY');
+    expect(extractStatus('no marker at all')).toBe('NOT_READY');
+  });
+
+  it('extractTagged resolves the LAST complete tag pair (desktop parity)', () => {
+    const { extractTagged } = maestroAiTestHooks;
+    expect(extractTagged('<t>first</t> and <t>second</t>', 't')).toBe('second');
+    expect(extractTagged('<t>  padded  </t>', 't')).toBe('padded');
+    expect(extractTagged('<t></t>', 't')).toBeNull();
+    expect(extractTagged('no tags', 't')).toBeNull();
+    expect(extractTagged('<t>x</t>', 'evil.*tag')).toBeNull();
+  });
+
+  it('isSubstantiveEditorialChange ignores whitespace-only differences (desktop parity)', () => {
+    const { isSubstantiveEditorialChange } = maestroAiTestHooks;
+    expect(isSubstantiveEditorialChange('a b', 'a\n\nb')).toBe(false);
+    expect(isSubstantiveEditorialChange('a  b', 'a b')).toBe(false);
+    expect(isSubstantiveEditorialChange('a b\r\n', 'a b')).toBe(false);
+    expect(isSubstantiveEditorialChange('a b.', 'a b')).toBe(true);
+    expect(isSubstantiveEditorialChange('A b', 'a b')).toBe(true);
+  });
+
+  it('mirrors Rust ASCII-uppercase and White_Space semantics exactly', () => {
+    const { extractStatus, extractTagged, isSubstantiveEditorialChange } = maestroAiTestHooks;
+    // Unicode uppercase must NOT apply: 'ſ' uppercases to 'S' in JS but
+    // not in Rust to_ascii_uppercase, so this line must not match the marker.
+    expect(extractStatus('maeſtro_status: ready')).toBe('NOT_READY');
+    // U+0085 (NEL) is Rust whitespace: trim strips it, the marker matches.
+    expect(extractStatus('MAESTRO_STATUS: READY')).toBe('READY');
+    // U+FEFF is NOT Rust whitespace: it survives trim and blocks the match.
+    expect(extractStatus('﻿MAESTRO_STATUS: READY')).toBe('NOT_READY');
+    // Rust charset guard does not reject an empty tag name.
+    expect(extractTagged('<>value</>', '')).toBe('value');
+    // U+0085 collapses as whitespace; U+FEFF is a regular character.
+    expect(isSubstantiveEditorialChange('ab', 'a b')).toBe(false);
+    expect(isSubstantiveEditorialChange('a﻿b', 'a b')).toBe(true);
+  });
+
+  it('sanitizeAgent honors the desktop alias table', () => {
+    const { sanitizeAgent } = maestroAiTestHooks;
+    expect(sanitizeAgent('agy', 'claude')).toBe('gemini');
+    expect(sanitizeAgent('antigravity', 'claude')).toBe('gemini');
+    expect(sanitizeAgent('deepseek-api', 'claude')).toBe('deepseek');
+    expect(sanitizeAgent('grok-api', 'claude')).toBe('grok');
+    expect(sanitizeAgent('perplexity-api', 'claude')).toBe('perplexity');
+    expect(sanitizeAgent('unknown', 'claude')).toBe('claude');
+  });
+});
+
 describe('Maestro AI autos/artifacts', () => {
   const session = {
     id: 'web-session-1',

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -289,6 +289,10 @@ function sanitizeAgent(value: unknown, fallback: ProviderKey): ProviderKey {
   if (normalized === 'google') return 'gemini';
   if (normalized === 'xai') return 'grok';
   if (normalized === 'sonar') return 'perplexity';
+  if (normalized === 'agy' || normalized === 'antigravity') return 'gemini';
+  if (normalized === 'deepseek-api') return 'deepseek';
+  if (normalized === 'grok-api') return 'grok';
+  if (normalized === 'perplexity-api') return 'perplexity';
   return fallback;
 }
 
@@ -859,15 +863,61 @@ function runtimeLimitExceeded(startedAtMs: number, maxRuntimeMinutes?: number | 
   return Date.now() - startedAtMs > Number(maxRuntimeMinutes) * 60_000;
 }
 
+// Rust char::is_whitespace / str::trim / split_whitespace use the Unicode
+// White_Space property, which differs from JS \s and String.trim(): it
+// INCLUDES U+0085 (NEL) and EXCLUDES U+FEFF (BOM/ZWNBSP). The parity port
+// must use this exact class, not \s.
+const RUST_WS_CLASS = '[\\t\\n\\u000B\\f\\r \\u0085\\u00A0\\u1680\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000]';
+const RUST_WS_RUN = new RegExp(`${RUST_WS_CLASS}+`, 'g');
+const RUST_WS_EDGES = new RegExp(`^${RUST_WS_CLASS}+|${RUST_WS_CLASS}+$`, 'g');
+
+function rustTrim(text: string): string {
+  return text.replace(RUST_WS_EDGES, '');
+}
+
+// Rust to_ascii_uppercase: only a-z are uppercased; Unicode case mappings
+// (e.g. 'ſ' -> 'S') must NOT apply.
+function asciiUppercase(text: string): string {
+  return text.replace(/[a-z]/g, (character) => character.toUpperCase());
+}
+
 function extractStatus(text: string): 'READY' | 'NOT_READY' {
-  const cleaned = text.replace(/^\s*<think>[\s\S]*?<\/think>\s*/i, '').trim();
-  const first = cleaned.split(/\r?\n/).find((line) => line.trim().length > 0) ?? '';
-  return /\bMAESTRO_STATUS\s*:\s*READY\b/i.test(first) ? 'READY' : 'NOT_READY';
+  // Desktop parity (editorial_io.rs extract_maestro_status): every line is
+  // scanned; the trimmed, ASCII-uppercased line must equal the marker exactly
+  // (single space after the colon); the first matching line decides.
+  for (const line of text.split(/\r?\n/)) {
+    const normalized = asciiUppercase(rustTrim(line));
+    if (normalized === 'MAESTRO_STATUS: READY') return 'READY';
+    if (normalized === 'MAESTRO_STATUS: NOT_READY') return 'NOT_READY';
+  }
+  return 'NOT_READY';
 }
 
 function extractTagged(text: string, tag: string): string | null {
-  const match = new RegExp(`<${tag}>\\s*([\\s\\S]*?)\\s*</${tag}>`, 'i').exec(text);
-  return match?.[1]?.trim() || null;
+  // Desktop parity (editorial_io.rs extract_tagged_block): resolve to the
+  // LAST complete <tag>..</tag> pair so a duplicated or echoed block yields
+  // the agent's final version instead of the echo. The Rust charset guard
+  // rejects only invalid characters — an empty tag name passes.
+  if (!/^[A-Za-z0-9_-]*$/.test(tag)) return null;
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+  const closeAt = text.lastIndexOf(close);
+  if (closeAt < open.length) return null;
+  const openAt = text.lastIndexOf(open, closeAt - open.length);
+  if (openAt === -1) return null;
+  const value = rustTrim(text.slice(openAt + open.length, closeAt));
+  return value || null;
+}
+
+// Desktop parity (session_orchestration.rs normalized_editorial_text):
+// peripheral whitespace, line breaks and redundant internal whitespace are
+// cosmetic; punctuation and capitalization are substantive.
+function normalizedEditorialText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split(RUST_WS_RUN).filter(Boolean).join(' ');
+}
+
+function isSubstantiveEditorialChange(before: string, after: string): boolean {
+  return normalizedEditorialText(before) !== normalizedEditorialText(after);
 }
 
 /**
@@ -1381,6 +1431,10 @@ export const maestroAiTestHooks = {
   buildProviderHttpRequest,
   publicApiHealthResult,
   validateRevisionGuard,
+  extractStatus,
+  extractTagged,
+  isSubstantiveEditorialChange,
+  sanitizeAgent,
   isBlockedAuditHost,
   extractUrls,
   checkOneLink,
@@ -1732,7 +1786,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             custody: 'unstructured_report_missing',
           });
         const revisedText = extractTagged(result.text, 'maestro_final_text');
-        const changedByReviewer = Boolean(revisedText && revisedText.trim() !== currentText.trim());
+        const changedByReviewer = Boolean(revisedText && isSubstantiveEditorialChange(currentText, revisedText));
         const candidateText = revisedText && changedByReviewer ? revisedText : currentText;
         const revisionGuardError = validateRevisionGuard(currentText, candidateText, status, revisionReport);
         if (revisionGuardError) {

--- a/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-a.md
+++ b/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-a.md
@@ -1,0 +1,201 @@
+# Maestro AI Parity Plan A — Contrato de I/O e Normalização
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fazer o parsing de status, a extração de tags, a detecção de mudança substantiva e os aliases de agente do Maestro AI web espelharem byte-a-byte a semântica canônica do maestro-app.
+
+**Architecture:** Todas as mudanças vivem em `admin-motor/src/handlers/routes/maestro-ai/sessions.ts` (funções puras já existentes são substituídas pela semântica do desktop) e seus testes em `sessions.test.ts`. Nenhuma mudança de lifecycle, retry ou convergência (Planos B/C).
+
+**Tech Stack:** Cloudflare Worker (TypeScript), Vitest.
+
+## Global Constraints
+
+- Fonte canônica: `maestro-app/src-tauri/src/editorial_io.rs:283-326` (parsers), `session_orchestration.rs:2551-2572` (normalização/tiers), `session_controls.rs:76-87` (aliases).
+- TDD: cada task escreve o teste antes, roda vermelho, implementa, roda verde.
+- Gates antes do ship: `npm run lint`, `npx biome check .`, `npm run typecheck:admin-motor`, `npx vitest run --config vitest.admin-motor.config.ts`, markdownlint central no CHANGELOG, cross-review ALL READY.
+- Bump: v02.03.01 → v02.04.00 (mudança de comportamento) + CHANGELOG.
+
+---
+
+### Task 1: extractStatus — linha exata, qualquer posição, sem strip de think
+
+**Files:**
+- Modify: `admin-motor/src/handlers/routes/maestro-ai/sessions.ts:851-855`
+- Test: `admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts`
+
+**Interfaces:**
+- Produces: `extractStatus(text: string): 'READY' | 'NOT_READY'` — varre cada linha; `line.trim().toUpperCase()` deve ser exatamente `MAESTRO_STATUS: READY` ou `MAESTRO_STATUS: NOT_READY` (um espaço após os dois-pontos); primeira linha que casar decide; ausente → `NOT_READY`. Exportar em `maestroAiTestHooks`.
+
+- [ ] **Step 1: teste vermelho** (usa `maestroAiTestHooks.extractStatus`)
+
+```ts
+describe('Maestro AI status/tag parsing parity', () => {
+  it('extractStatus matches desktop exact-line semantics', () => {
+    const { extractStatus } = maestroAiTestHooks;
+    expect(extractStatus('intro line\nMAESTRO_STATUS: READY\nrest')).toBe('READY');
+    expect(extractStatus('maestro_status: ready')).toBe('READY');
+    expect(extractStatus('MAESTRO_STATUS : READY')).toBe('NOT_READY');
+    expect(extractStatus('prefix MAESTRO_STATUS: READY suffix')).toBe('NOT_READY');
+    expect(extractStatus('MAESTRO_STATUS: NOT_READY\nMAESTRO_STATUS: READY')).toBe('NOT_READY');
+    expect(extractStatus('no marker at all')).toBe('NOT_READY');
+  });
+});
+```
+
+- [ ] **Step 2: rodar e ver falhar** — `npx vitest run --config vitest.admin-motor.config.ts -t "exact-line semantics"` → FAIL (hoje: 1ª linha flexível com regex).
+
+- [ ] **Step 3: implementação** (substitui o corpo atual em sessions.ts:851-855)
+
+```ts
+function extractStatus(text: string): 'READY' | 'NOT_READY' {
+  // Desktop parity (editorial_io.rs extract_maestro_status): every line is
+  // scanned; the trimmed, uppercased line must equal the marker exactly
+  // (single space after the colon); the first matching line decides.
+  for (const line of text.split(/\r?\n/)) {
+    const normalized = line.trim().toUpperCase();
+    if (normalized === 'MAESTRO_STATUS: READY') return 'READY';
+    if (normalized === 'MAESTRO_STATUS: NOT_READY') return 'NOT_READY';
+  }
+  return 'NOT_READY';
+}
+```
+
+Adicionar `extractStatus` a `maestroAiTestHooks` (sessions.ts:1380-1391).
+
+- [ ] **Step 4: rodar verde** — mesmo comando do Step 2 → PASS.
+
+### Task 2: extractTagged — último par completo + guard de charset
+
+**Files:**
+- Modify: `admin-motor/src/handlers/routes/maestro-ai/sessions.ts:857-860`
+- Test: `admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts`
+
+**Interfaces:**
+- Produces: `extractTagged(text: string, tag: string): string | null` — tag restrita a `[A-Za-z0-9_-]`; resolve o ÚLTIMO par completo `<tag>…</tag>`; conteúdo trimado; vazio → null. Exportar em `maestroAiTestHooks`.
+
+- [ ] **Step 1: teste vermelho**
+
+```ts
+it('extractTagged resolves the LAST complete tag pair (desktop parity)', () => {
+  const { extractTagged } = maestroAiTestHooks;
+  expect(extractTagged('<t>first</t> and <t>second</t>', 't')).toBe('second');
+  expect(extractTagged('<t>  padded  </t>', 't')).toBe('padded');
+  expect(extractTagged('<t></t>', 't')).toBeNull();
+  expect(extractTagged('no tags', 't')).toBeNull();
+  expect(extractTagged('<t>x</t>', 'evil.*tag')).toBeNull();
+});
+```
+
+- [ ] **Step 2: rodar e ver falhar** — hoje a regex resolve a PRIMEIRA ocorrência → `'first'`.
+
+- [ ] **Step 3: implementação**
+
+```ts
+function extractTagged(text: string, tag: string): string | null {
+  // Desktop parity (editorial_io.rs extract_tagged_block): resolve to the
+  // LAST complete <tag>..</tag> pair so a duplicated or echoed block yields
+  // the agent's final version instead of the echo.
+  if (!/^[A-Za-z0-9_-]+$/.test(tag)) return null;
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+  const closeAt = text.lastIndexOf(close);
+  if (closeAt < open.length) return null;
+  const openAt = text.lastIndexOf(open, closeAt - open.length);
+  if (openAt === -1) return null;
+  const value = text.slice(openAt + open.length, closeAt).trim();
+  return value || null;
+}
+```
+
+Adicionar `extractTagged` a `maestroAiTestHooks`.
+
+- [ ] **Step 4: rodar verde.**
+
+### Task 3: mudança substantiva — normalização canônica
+
+**Files:**
+- Modify: `admin-motor/src/handlers/routes/maestro-ai/sessions.ts` (novas funções + call site linha 1735)
+- Test: `admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts`
+
+**Interfaces:**
+- Produces: `normalizedEditorialText(text: string): string` e `isSubstantiveEditorialChange(before: string, after: string): boolean`; o call site `changedByReviewer` passa a usar `isSubstantiveEditorialChange` no lugar de comparação `trim()`. Exportar `isSubstantiveEditorialChange` em `maestroAiTestHooks`.
+
+- [ ] **Step 1: teste vermelho**
+
+```ts
+it('isSubstantiveEditorialChange ignores whitespace-only differences (desktop parity)', () => {
+  const { isSubstantiveEditorialChange } = maestroAiTestHooks;
+  expect(isSubstantiveEditorialChange('a b', 'a\n\nb')).toBe(false);
+  expect(isSubstantiveEditorialChange('a  b', 'a b')).toBe(false);
+  expect(isSubstantiveEditorialChange('a b\r\n', 'a b')).toBe(false);
+  expect(isSubstantiveEditorialChange('a b.', 'a b')).toBe(true);
+  expect(isSubstantiveEditorialChange('A b', 'a b')).toBe(true);
+});
+```
+
+- [ ] **Step 2: rodar e ver falhar** (função não existe).
+
+- [ ] **Step 3: implementação** (junto às demais funções puras, antes de `validateRevisionGuard`)
+
+```ts
+// Desktop parity (session_orchestration.rs normalized_editorial_text):
+// peripheral whitespace, line breaks and redundant internal whitespace are
+// cosmetic; punctuation and capitalization are substantive.
+function normalizedEditorialText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split(/\s+/).filter(Boolean).join(' ');
+}
+
+function isSubstantiveEditorialChange(before: string, after: string): boolean {
+  return normalizedEditorialText(before) !== normalizedEditorialText(after);
+}
+```
+
+Call site (linha 1735): `const changedByReviewer = Boolean(revisedText && isSubstantiveEditorialChange(currentText, revisedText));`
+
+- [ ] **Step 4: rodar verde + suíte completa** (turnos com mudança só cosmética agora contam como custódia inalterada — verificar que nenhum teste existente quebre).
+
+### Task 4: aliases de agente — tabela canônica completa
+
+**Files:**
+- Modify: `admin-motor/src/handlers/routes/maestro-ai/sessions.ts:284-293`
+- Test: `admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts`
+
+**Interfaces:**
+- Consumes: `sanitizeAgent(value: unknown, fallback: ProviderKey): ProviderKey` (assinatura inalterada).
+- Produces: aliases adicionais `agy`/`antigravity`→gemini, `deepseek-api`→deepseek, `grok-api`→grok, `perplexity-api`→perplexity (session_controls.rs:76-87).
+
+- [ ] **Step 1: teste vermelho**
+
+```ts
+it('sanitizeAgent honors the desktop alias table', () => {
+  const { sanitizeAgent } = maestroAiTestHooks;
+  expect(sanitizeAgent('agy', 'claude')).toBe('gemini');
+  expect(sanitizeAgent('antigravity', 'claude')).toBe('gemini');
+  expect(sanitizeAgent('deepseek-api', 'claude')).toBe('deepseek');
+  expect(sanitizeAgent('grok-api', 'claude')).toBe('grok');
+  expect(sanitizeAgent('perplexity-api', 'claude')).toBe('perplexity');
+  expect(sanitizeAgent('unknown', 'claude')).toBe('claude');
+});
+```
+
+- [ ] **Step 2: rodar e ver falhar** (`agy` cai no fallback hoje).
+
+- [ ] **Step 3: implementação** — acrescentar em `sanitizeAgent` (mantendo as linhas existentes):
+
+```ts
+  if (normalized === 'agy' || normalized === 'antigravity') return 'gemini';
+  if (normalized === 'deepseek-api') return 'deepseek';
+  if (normalized === 'grok-api') return 'grok';
+  if (normalized === 'perplexity-api') return 'perplexity';
+```
+
+Adicionar `sanitizeAgent` a `maestroAiTestHooks`.
+
+- [ ] **Step 4: rodar verde.**
+
+### Task 5: gates + ship
+
+- [ ] Suíte completa + typecheck + eslint + biome + prettier public + markdownlint CHANGELOG.
+- [ ] Bump `APP_VERSION` → `APP v02.04.00` (src/App.tsx:35) + entrada no CHANGELOG.
+- [ ] Cross-review ALL READY do diff.
+- [ ] Branch `feat/maestro-ai-parity-plan-a` → PR → automerge → GHA verde.

--- a/docs/superpowers/plans/2026-07-05-maestro-ai-parity-roadmap.md
+++ b/docs/superpowers/plans/2026-07-05-maestro-ai-parity-roadmap.md
@@ -1,0 +1,51 @@
+# Maestro AI Web ↔ maestro-app Parity Roadmap
+
+**Decisão do operador (2026-07-05):** o maestro-app (Tauri/Rust) é a fonte de referência canônica; o módulo Maestro AI do admin-app (Worker/TS) é um port à web e deve espelhá-lo. Onde seguir o desktop literalmente for impossível na plataforma Workers ou danoso ao produto web, a exceção é sinalizada e depende de confirmação do operador.
+
+**Base:** auditoria de paridade de 2026-07-05 (workflow `wf_b401bd60-9d2`, 31 agentes) — 28 divergências comportamentais confirmadas adversarialmente entre `admin-app/admin-motor/src/handlers/routes/maestro-ai/sessions.ts` e `maestro-app/src-tauri/src/*`; nenhuma das 12 dimensões livre de divergência. As 4 diferenças inerentes à plataforma (D1 vs arquivos locais, sweeper cron vs reparo on-exit, roteamento cli/api/hybrid, caps de custo isentos em CLI) **não** são escopo deste programa.
+
+Cada plano é um ship independente: TDD red-first, gates completos (eslint + biome + prettier + markdownlint central + typecheck + vitest), cross-review ALL READY, bump de versão + CHANGELOG.
+
+## Plano A — Contrato de I/O e normalização (este ship)
+
+Divergências cobertas: parsing do `MAESTRO_STATUS` (linha exata, qualquer posição, sem strip de `<think>`), extração de tag duplicada (último par completo), normalização de mudança substantiva (`normalized_editorial_text`), tabela de aliases de agentes.
+Arquivo: `2026-07-05-maestro-ai-parity-plan-a.md`.
+
+## Plano B — Semântica de turno e convergência
+
+- Convergência cumulativa por aprovações estáveis (`current_version_has_all_independent_approvals`, session_orchestration.rs:2595): set de aprovadores limpo em qualquer mudança substantiva/violação; finaliza quando todos os agentes ativos não-autores aprovaram a mesma versão.
+- Inversão dos bans de outcome: aceitar READY+`<maestro_final_text>` como turno de revisão normal; tratar NOT_READY sem mudança como violação de contrato (acoplado ao retry corretivo abaixo).
+- Retry corretivo: violação de contrato → reclassificar artefato como CONTRACT_VIOLATION → até 3 tentativas do mesmo reviewer com seção "Mandatory Corrective Retry" → turno pulado como falha operacional (não terminal).
+- Anti-empobrecimento por tier (`editorial_quality_tier`/`quality_guard_blocks_revision`, session_orchestration.rs:2565-2593): dispara só quando tier do reviewer < tier do autor, before ≥ 400 chars e encolhimento > 15%; consequência = rejeitar a revisão e continuar.
+- Validação estrutural do relatório de revisão (tags balanceadas, campo custody `revised`/`unchanged` com consistência cruzada, anti-eco de protocolo).
+- **Stopgap:** `max_cycles` (1–5) permanece como limite externo até o Plano C entregar estados pausáveis/retomáveis — desktop não tem cap de rounds, tem cap de turnos com pausa retomável.
+
+## Plano C — Lifecycle e resiliência
+
+- Família de estados PAUSED_*/STOPPED/LIMIT retomáveis + rotina de resume no admin-motor; apenas convergência unânime é terminal.
+- Retry de provider (2 tentativas, backoff 1500 ms, 429 honra Retry-After com default 30 s / cap 120 s, cancel-aware).
+- 3 falhas operacionais consecutivas → pausa (não morte da sessão).
+- Draft com fallback serial pelos agentes ativos restantes antes de pausar.
+- Estouro de custo no draft → status dedicado retomável (equivalente a COST_LIMIT_REACHED), não `error` genérico.
+- Cancelamento aborta chamada em voo via AbortController e resulta em estado retomável.
+- Limite de tempo: checado antes do draft e de cada turno (remaining < 2 s), timeout por chamada acoplado ao tempo restante; override por sessão.
+
+## Plano D — Link audit, gate bibliográfico e SSRF
+
+- Auditoria HTTP só na finalização e em turnos READY-unchanged, atrás do gate em 3 estágios (bibliográfico → capacidade >30 URLs únicos hard-fail → HTTP); 3xx = ok; timeout 15 s; 5 hops; fallback HEAD→GET; sem retry por link.
+- Portar o gate bibliográfico (inexistente no web).
+- SSRF: faixas adicionais (100.64/10, 192.0.0/24, 192.0.2/24, 198.18/15, 198.51.100/24, 203.0.113/24, ≥224.0.0.0, ff00::/8, 2001:db8::/32) + pré-verificação de DNS via DoH. **Exceção de plataforma:** resolver acoplado à conexão (anti-rebinding fail-closed) não existe em Workers; aproximação via DoH pré-flight, resíduo documentado.
+- Extração de URL alinhada (strip `.,;:` sem `!?`, 80 matches / ≤30 únicos).
+
+## Plano E — Custo, tempo e defaults financeiros
+
+- **Exceção proposta (confirmar):** manter o termo `request_usd_per_1k` no web (o desktop não o tem, mas removê-lo perde a contabilidade real do Perplexity).
+- **Exceção proposta (confirmar):** manter DEFAULT_RATES semeadas no web (desktop exige configuração explícita).
+- Intake com <2 agentes: desktop aceita e pausa após o draft; web rejeita pré-start sem custo. **Exceção proposta (confirmar):** manter a rejeição pré-start do web.
+
+## Plano F — Superfície de providers e prompts
+
+- Prompt de revisão alimentado com relatórios anteriores (cap 12.000 chars cada) em vez dos últimos 12 eventos; adicionar Evidence and Bibliographic Integrity Gate e regras de citação §-ID.
+- Modelos default alinhados aos hints do desktop + resolução viva via /v1/models onde aplicável.
+- Sequenciamento: portar `select_serial_reviewer_index` (incl. caminho de redraw).
+- **Exceção proposta (confirmar):** manter DEFAULT_PROTOCOL semeado no web (desktop exige importação de protocolo ≥100 chars).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.03.01';
+const APP_VERSION = 'APP v02.04.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary
Operator decision: the maestro-app desktop is the canonical Maestro behavior source; the web module mirrors it. Plan A (of the A–F parity roadmap added in this PR under `docs/superpowers/plans/`) ports four deterministic routines byte-exactly to the desktop semantics:

- **`extractStatus`** — every line scanned; exact trimmed + ASCII-uppercased line must equal `MAESTRO_STATUS: READY`/`NOT_READY`; first match wins; absent → NOT_READY; no `<think>` stripping (mirrors `editorial_io.rs::extract_maestro_status`).
- **`extractTagged`** — resolves the LAST complete `<tag>…</tag>` pair (echo tolerance) with a charset-only tag guard (mirrors `editorial_io.rs::extract_tagged_block`).
- **Substantive-change detection** — canonical whitespace normalization (CRLF→LF + collapse of the exact Unicode White_Space class) now gates custody transfer; cosmetic whitespace edits no longer transfer custody (mirrors `session_orchestration.rs::normalized_editorial_text`).
- **Agent alias table** — adds `agy`/`antigravity`→gemini, `deepseek-api`, `grok-api`, `perplexity-api` (mirrors `session_controls.rs::canonical_editorial_agent_key`).

Includes Rust-exact helpers (White_Space set with U+0085 in / U+FEFF out; ASCII-only uppercase) after peer review caught the JS-Unicode divergences.

## Testing
- 5 red-first regression tests (incl. `ſ`-uppercase, U+0085/U+FEFF whitespace-class and empty-tag edge cases); full admin-motor suite 132/132.
- Typecheck baseline clean; eslint/biome/prettier/markdownlint gates green.
- Cross-review session 3aa1c062: round 1 caught the Unicode-semantics gaps (codex NOT_READY), fixes applied, **round 2 unanimous READY** (caller + codex, gemini, deepseek, grok, perplexity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)