### PR TITLE
feat(maestro-ai): desktop serial-turn contract, corrective retry and tier quality guard — parity Plan B1 (v02.05.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.05.00] - 2026-07-05
+
+### Alterado
+
+- **Maestro AI — contrato de turno serial, retry corretivo e trava de qualidade por tier (Plano B1 da equiparação com o maestro-app)**: o turno de revisão agora valida a saída do agente contra o contrato estrutural canônico do desktop (`validate_serial_turn_output`): eco de prompt/protocolo, tags balanceadas, relatório obrigatório, declaração de custódia `revised`/`unchanged` com consistência cruzada (texto final presente ⇔ custódia revised; `changes` não-vazio exige revisão) e gate de integridade bibliográfica (`[EVIDENCIA_PENDENTE]`, lacunas como `[s.d.]`, `[S. l.]`, `[entre N e M]`, datas incertas). Violação vira **CONTRACT_VIOLATION com até 3 retries corretivos do mesmo reviewer** (seção "Mandatory Corrective Retry" injetada no prompt, idêntica à do desktop); exaustão pula o turno sem voto em vez de matar a sessão. **Bans de outcome invertidos para a semântica canônica**: READY com texto revisado substantivo é turno normal (avança a custódia); NOT_READY sem texto corretivo é violação com retry; READY sobre custódia que ainda carrega bloqueador bibliográfico é reescrito para NOT_READY (ReadyRejected). O anti-empobrecimento passa a ser **por tier de qualidade** (Claude/Codex=3, Gemini=2, DeepSeek/Grok/Perplexity=1; dispara só quando reviewer de tier inferior encolhe >15% de texto ≥400 chars) e **rejeita a revisão continuando a sessão**, em vez de bloquear terminalmente. O guard antigo (`validateRevisionGuard`) foi substituído por essas rotinas. Micro-parser de campos do relatório portado byte-a-byte do Rust (JSON estrito primeiro, depois varredura escalar/array com regras de posição de chave).
+
 ## [v02.04.00] - 2026-07-05
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -588,6 +588,147 @@ describe('Maestro AI desktop-parity parsing (Plan A)', () => {
   });
 });
 
+describe('Maestro AI serial turn contract (Plan B1)', () => {
+  it('reportDeclaresCustodyValue mirrors JSON-first then scalar-scan semantics', () => {
+    const { reportDeclaresCustodyValue } = maestroAiTestHooks;
+    expect(reportDeclaresCustodyValue('{"custody":"revised"}', 'revised')).toBe(true);
+    expect(reportDeclaresCustodyValue('{"custody":"REVISED"}', 'revised')).toBe(true);
+    expect(reportDeclaresCustodyValue('{"custody":"unchanged"}', 'revised')).toBe(false);
+    expect(reportDeclaresCustodyValue('custody: revised', 'revised')).toBe(true);
+    expect(reportDeclaresCustodyValue('"custody": \'Revised\'', 'revised')).toBe(true);
+    expect(reportDeclaresCustodyValue('notes\ncustody: unchanged\nmore', 'unchanged')).toBe(true);
+    expect(reportDeclaresCustodyValue('xcustody: revised', 'revised')).toBe(false);
+    expect(reportDeclaresCustodyValue('the custody was transferred', 'revised')).toBe(false);
+  });
+
+  it('reportDeclaresNonemptyChanges detects non-empty arrays only', () => {
+    const { reportDeclaresNonemptyChanges } = maestroAiTestHooks;
+    expect(reportDeclaresNonemptyChanges('{"changes":["fixed typo"]}')).toBe(true);
+    expect(reportDeclaresNonemptyChanges('{"changes":[]}')).toBe(false);
+    expect(reportDeclaresNonemptyChanges('changes: ["a"]')).toBe(true);
+    expect(reportDeclaresNonemptyChanges('changes: []')).toBe(false);
+    expect(reportDeclaresNonemptyChanges('no such field')).toBe(false);
+  });
+
+  it('containsFinalReleaseBlocker flags evidence markers and bibliographic lacunae', () => {
+    const { containsFinalReleaseBlocker } = maestroAiTestHooks;
+    expect(containsFinalReleaseBlocker('texto com [EVIDENCIA_PENDENTE] no meio')).toBe(true);
+    expect(containsFinalReleaseBlocker('nota [Edição consultada não identificada]')).toBe(true);
+    expect(containsFinalReleaseBlocker('obra rara [s.d.] citada')).toBe(true);
+    expect(containsFinalReleaseBlocker('publicado [S. l.] em 1990')).toBe(true);
+    expect(containsFinalReleaseBlocker('datado [entre 1990 e 1995]')).toBe(true);
+    expect(containsFinalReleaseBlocker('lançado [1990?]')).toBe(true);
+    expect(containsFinalReleaseBlocker('impresso [sine data]')).toBe(true);
+    expect(containsFinalReleaseBlocker('publicado em [2001]')).toBe(false);
+    expect(containsFinalReleaseBlocker('fonte [IBGE Censo 2020]')).toBe(false);
+    expect(containsFinalReleaseBlocker('texto limpo sem marcadores')).toBe(false);
+  });
+
+  it('containsPromptOrProtocolEcho matches the seven markers case-insensitively', () => {
+    const { containsPromptOrProtocolEcho } = maestroAiTestHooks;
+    expect(containsPromptOrProtocolEcho('...\n## Required Output Contract\n...')).toBe(true);
+    expect(containsPromptOrProtocolEcho('# MAESTRO EDITORIAL AI - SERIAL REVIEW-REWRITE TURN')).toBe(true);
+    expect(containsPromptOrProtocolEcho('## Current Text Under Custody')).toBe(true);
+    expect(containsPromptOrProtocolEcho('normal reviewer output')).toBe(false);
+  });
+
+  it('validateSerialTurnOutput enforces the desktop output contract in order', () => {
+    const { validateSerialTurnOutput } = maestroAiTestHooks;
+    const wrap = (report: string, finalText?: string) =>
+      `MAESTRO_STATUS: READY\n<maestro_revision_report>${report}</maestro_revision_report>${
+        finalText === undefined ? '' : `\n<maestro_final_text>${finalText}</maestro_final_text>`
+      }`;
+    expect(validateSerialTurnOutput('x', 'MAYBE', 'r', null)).toBe('invalid serial status: MAYBE');
+    expect(
+      validateSerialTurnOutput(
+        '## Required Output Contract\n<maestro_revision_report>x</maestro_revision_report>',
+        'READY',
+        'x',
+        null,
+      ),
+    ).toBe('output appears to reproduce prompt/protocol scaffolding');
+    expect(validateSerialTurnOutput('no tags at all', 'READY', null, null)).toBe(
+      'missing maestro_revision_report block',
+    );
+    expect(validateSerialTurnOutput('<maestro_revision_report>x', 'READY', null, null)).toBe(
+      'incomplete maestro_revision_report block',
+    );
+    const ambiguous = 'custody: "revised"\ncustody: "unchanged"';
+    expect(validateSerialTurnOutput(wrap(ambiguous), 'READY', ambiguous, null)).toBe(
+      'ambiguous custody declaration in maestro_revision_report',
+    );
+    expect(
+      validateSerialTurnOutput(
+        wrap('custody: "unchanged"', 'novo texto'),
+        'READY',
+        'custody: "unchanged"',
+        'novo texto',
+      ),
+    ).toBe('maestro_final_text requires custody revised in the report');
+    expect(
+      validateSerialTurnOutput(
+        wrap('custody: "revised"', 'texto com [EVIDENCIA_PENDENTE]'),
+        'READY',
+        'custody: "revised"',
+        'texto com [EVIDENCIA_PENDENTE]',
+      ),
+    ).toBe(
+      'final candidate failed bibliographic integrity gate: unresolved evidence marker or bibliographic lacuna found',
+    );
+    expect(validateSerialTurnOutput(wrap('custody: "revised"'), 'READY', 'custody: "revised"', null)).toBe(
+      'revised custody requires a complete maestro_final_text block',
+    );
+    expect(validateSerialTurnOutput(wrap('relatorio sem custody'), 'READY', 'relatorio sem custody', null)).toBe(
+      'READY without maestro_final_text must explicitly declare custody unchanged',
+    );
+    const correctable = 'custody: "unchanged"\nchanges: ["algo corrigivel"]';
+    expect(validateSerialTurnOutput(wrap(correctable), 'NOT_READY', correctable, null)).toBe(
+      'correctable changes require custody revised and a complete maestro_final_text block',
+    );
+    const cleanUnchanged = 'custody: "unchanged"\nchanges: []';
+    expect(validateSerialTurnOutput(wrap(cleanUnchanged), 'READY', cleanUnchanged, null)).toBeNull();
+    expect(
+      validateSerialTurnOutput(
+        wrap('custody: "revised"', 'texto novo limpo'),
+        'NOT_READY',
+        'custody: "revised"',
+        'texto novo limpo',
+      ),
+    ).toBeNull();
+  });
+
+  it('treats complete-but-empty tag blocks exactly like the desktop (extract collapses to missing)', () => {
+    const { extractTagged, validateSerialTurnOutput } = maestroAiTestHooks;
+    // Canonical parity (editorial_io.rs:325): extract_tagged_block returns None
+    // for an empty body, so the desktop maps <t></t> to the MISSING error, and
+    // the "empty ... block" arms are unreachable on both platforms.
+    const emptyReport = 'MAESTRO_STATUS: READY\n<maestro_revision_report></maestro_revision_report>';
+    expect(extractTagged(emptyReport, 'maestro_revision_report')).toBeNull();
+    expect(validateSerialTurnOutput(emptyReport, 'READY', null, null)).toBe(
+      'missing complete maestro_revision_report block',
+    );
+    const emptyFinal =
+      'MAESTRO_STATUS: NOT_READY\n<maestro_revision_report>custody: "revised"\nchanges: ["x"]</maestro_revision_report>\n<maestro_final_text></maestro_final_text>';
+    expect(extractTagged(emptyFinal, 'maestro_final_text')).toBeNull();
+    expect(validateSerialTurnOutput(emptyFinal, 'NOT_READY', 'custody: "revised"\nchanges: ["x"]', null)).toBe(
+      'revised custody requires a complete maestro_final_text block',
+    );
+  });
+
+  it('qualityGuardBlocksRevision fires only for lower-tier shrinkage of long text', () => {
+    const { qualityGuardBlocksRevision } = maestroAiTestHooks;
+    const longText = 'x'.repeat(500);
+    const shrunk = 'x'.repeat(400);
+    expect(qualityGuardBlocksRevision('claude', 'gemini', longText, shrunk, true)).toBe(true);
+    expect(qualityGuardBlocksRevision('claude', 'codex', longText, shrunk, true)).toBe(false);
+    expect(qualityGuardBlocksRevision('gemini', 'claude', longText, shrunk, true)).toBe(false);
+    expect(qualityGuardBlocksRevision('claude', 'gemini', longText, shrunk, false)).toBe(false);
+    expect(qualityGuardBlocksRevision('claude', 'gemini', 'x'.repeat(399), 'x'.repeat(100), true)).toBe(false);
+    expect(qualityGuardBlocksRevision('claude', 'gemini', longText, 'x'.repeat(426), true)).toBe(false);
+    expect(qualityGuardBlocksRevision(null, 'gemini', longText, shrunk, true)).toBe(false);
+  });
+});
+
 describe('Maestro AI autos/artifacts', () => {
   const session = {
     id: 'web-session-1',
@@ -730,7 +871,9 @@ describe('runSession orchestrator', () => {
       if (hostOf(url) === 'api.openai.com') {
         return new Response(
           JSON.stringify({
-            output_text: opts.codexText ?? 'MAESTRO_STATUS: READY',
+            output_text:
+              opts.codexText ??
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
             usage: { input_tokens: 10, output_tokens: 20 },
           }),
           { status: 200 },
@@ -768,15 +911,103 @@ describe('runSession orchestrator', () => {
 
   it('converges when the sole reviewer returns READY without changing custody', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
-    vi.stubGlobal(
-      'fetch',
-      providerFetch({ claudeText: 'Texto de rascunho robusto e completo.', codexText: 'MAESTRO_STATUS: READY' }),
-    );
+    vi.stubGlobal('fetch', providerFetch({ claudeText: 'Texto de rascunho robusto e completo.' }));
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
     expect(db.__sessions.get('run-1')?.status).toBe('converged');
     expect(db.__sessions.get('run-1')?.final_text).toBe('Texto de rascunho robusto e completo.');
+  });
+
+  it('retries a NOT_READY-unchanged reviewer turn with the corrective section, then converges', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    let codexCalls = 0;
+    const codexBodies: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (hostOf(url) === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'Rascunho valido e completo.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (hostOf(url) === 'api.openai.com') {
+        codexCalls += 1;
+        codexBodies.push(String(init?.body ?? ''));
+        const text =
+          codexCalls === 1
+            ? 'MAESTRO_STATUS: NOT_READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nvague complaint without correction</maestro_revision_report>'
+            : 'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>';
+        return new Response(JSON.stringify({ output_text: text, usage: { input_tokens: 10, output_tokens: 20 } }), {
+          status: 200,
+        });
+      }
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    expect(codexCalls).toBe(2);
+    expect(codexBodies[1]).toContain('Mandatory Corrective Retry');
+    expect(db.__sessions.get('run-1')?.status).toBe('converged');
+  });
+
+  it('accepts READY with a substantive revision as a normal turn (desktop bans inversion)', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const revised = 'Texto revisado, mais preciso e completo, sem marcadores pendentes.';
+    const codexText = `MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "revised"\nchanges: ["improved precision"]\nprotocol basis: precision rule</maestro_revision_report>\n<maestro_final_text>${revised}</maestro_final_text>`;
+    vi.stubGlobal('fetch', providerFetch({ claudeText: 'Rascunho original razoavel e completo.', codexText }));
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    // The revision is accepted and takes custody; the new version has not yet
+    // earned a full approval pass, so the single-cycle session does not converge.
+    expect(row?.current_text).toBe(revised);
+    expect(row?.current_author).toBe('codex');
+    expect(row?.status).toBe('blocked_max_cycles');
+  });
+
+  it('rejects a lower-tier shrink revision and keeps custody unchanged (quality ratchet)', async () => {
+    const original = `Paragrafo extenso e detalhado. ${'Argumento com contexto e profundidade analitica. '.repeat(12)}`;
+    const shrunk = original.slice(0, Math.floor(original.length * 0.5));
+    const db = createInMemoryDb({
+      sessions: [runnableSession({ active_agents_json: JSON.stringify(['claude', 'deepseek']) })],
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (hostOf(url) === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: original }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (hostOf(url) === 'api.deepseek.com') {
+        const text = `MAESTRO_STATUS: NOT_READY\n<maestro_revision_report>custody: "revised"\nchanges: ["trimmed"]</maestro_revision_report>\n<maestro_final_text>${shrunk}</maestro_final_text>`;
+        return new Response(
+          JSON.stringify({
+            choices: [{ message: { content: text } }],
+            usage: { prompt_tokens: 10, completion_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, MAESTRO_DEEPSEEK_API_KEY: 'k-ds', BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    expect(row?.current_text).toBe(original.trim());
+    expect(row?.status).toBe('blocked_max_cycles');
   });
 
   it('marks the session as error when a reviewer returns empty text', async () => {
@@ -1574,42 +1805,5 @@ describe('maestro link-audit host safety (SSRF hardening)', () => {
     expect(hosts).toContain('[::ffff:7f00:1]'); // ::ffff:127.0.0.1 normalized by URL.hostname
     expect(hosts).toContain('[::1]');
     expect(urls).toContain('https://example.com/ok');
-  });
-});
-
-describe('maestro revision contract guard', () => {
-  it('blocks READY reviewers from changing custody text', () => {
-    const result = maestroAiTestHooks.validateRevisionGuard(
-      'Texto aprovado anterior.',
-      'Texto aprovado anterior com mudanca.',
-      'READY',
-      'Changed line 1 based on protocol rule.',
-    );
-
-    expect(result).toContain('READY reviewers cannot alter');
-  });
-
-  it('blocks material text impoverishment', () => {
-    const previous = `${'Paragrafo robusto com argumento, contexto e nuance. '.repeat(40)}`;
-    const candidate = 'Versao curta.';
-    const result = maestroAiTestHooks.validateRevisionGuard(
-      previous,
-      candidate,
-      'NOT_READY',
-      'Changed lines 1-20 based on protocol rule because the text needed correction.',
-    );
-
-    expect(result).toContain('anti-impoverishment');
-  });
-
-  it('allows a documented focused correction', () => {
-    const result = maestroAiTestHooks.validateRevisionGuard(
-      'Linha 1\nLinha 2 com erro factual.',
-      'Linha 1\nLinha 2 com correcao factual.',
-      'NOT_READY',
-      'Changed line 2 based on the protocol rule for factual precision; no other line was altered.',
-    );
-
-    expect(result).toBeNull();
   });
 });

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -832,32 +832,6 @@ function calculateObservedCost(result: ProviderCallResult, fallbackPrompt: strin
   return (inputTokens / 1_000_000) * inputRate + (outputTokens / 1_000_000) * outputRate + requestRate / 1000;
 }
 
-function validateRevisionGuard(
-  previousText: string,
-  candidateText: string,
-  status: string,
-  revisionReport: string,
-): string | null {
-  const previous = previousText.trim();
-  const candidate = candidateText.trim();
-  if (!candidate || candidate === previous) return null;
-  if (status === 'READY') {
-    return 'READY reviewers cannot alter custody text; READY means the current text is accepted unchanged.';
-  }
-  const previousLength = previous.length;
-  const candidateLength = candidate.length;
-  if (previousLength >= 1200 && candidateLength < previousLength * 0.85) {
-    return `Revision rejected by anti-impoverishment guard: candidate length ${candidateLength} is below 85% of previous length ${previousLength}.`;
-  }
-  if (revisionReport.trim().length < 80) {
-    return 'Revision changed custody text without a substantive revision report.';
-  }
-  if (!/(alter|change|linha|line|protocol|rule|corre|corrig|improv|melhor|justific|basis)/i.test(revisionReport)) {
-    return 'Revision report does not identify concrete changed lines, protocol basis, or correction rationale.';
-  }
-  return null;
-}
-
 function runtimeLimitExceeded(startedAtMs: number, maxRuntimeMinutes?: number | null): boolean {
   if (!Number.isFinite(Number(maxRuntimeMinutes)) || Number(maxRuntimeMinutes) <= 0) return false;
   return Date.now() - startedAtMs > Number(maxRuntimeMinutes) * 60_000;
@@ -918,6 +892,490 @@ function normalizedEditorialText(text: string): string {
 
 function isSubstantiveEditorialChange(before: string, after: string): boolean {
   return normalizedEditorialText(before) !== normalizedEditorialText(after);
+}
+
+// ── Plan B1: serial turn output contract (desktop parity) ───────────────────
+// Byte-exact ports of the session_orchestration.rs validators. The report
+// field scanning mirrors the Rust micro-parser (strict-JSON first, then a
+// quoted/bare scalar scan with line/brace key-position rules).
+
+const MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN = 3;
+
+const RUST_WS_START = new RegExp(`^${RUST_WS_CLASS}+`);
+
+function rustTrimStart(text: string): string {
+  return text.replace(RUST_WS_START, '');
+}
+
+// Rust to_ascii_lowercase: only A-Z are lowercased; Unicode case mappings
+// must NOT apply.
+function asciiLowercase(text: string): string {
+  return text.replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+function asciiEqualsIgnoreCase(a: string, b: string): boolean {
+  return asciiLowercase(a) === asciiLowercase(b);
+}
+
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let index = text.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = text.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+function requireBalancedTag(stdout: string, tag: string): string | null {
+  const open = countOccurrences(stdout, `<${tag}>`);
+  const close = countOccurrences(stdout, `</${tag}>`);
+  if (open === 0 && close === 0) return `missing ${tag} block`;
+  // Tolerate a duplicated/echoed block as long as it is balanced;
+  // extractTagged resolves to the last complete one.
+  if (open === close) return null;
+  return `incomplete ${tag} block`;
+}
+
+function requireBalancedOptionalTag(stdout: string, tag: string): string | null {
+  const open = countOccurrences(stdout, `<${tag}>`);
+  const close = countOccurrences(stdout, `</${tag}>`);
+  return open === close ? null : `incomplete ${tag} block`;
+}
+
+const PROMPT_ECHO_MARKERS = [
+  '# maestro editorial ai - serial review-rewrite turn',
+  '## full editorial protocol',
+  '## required output contract',
+  '## sovereign approved-content lock',
+  '## current text under custody',
+  '## prior serial revision reports',
+  'internal coordination, critique, changelog, and revision report',
+] as const;
+
+function containsPromptOrProtocolEcho(stdout: string): boolean {
+  const normalized = asciiLowercase(stdout);
+  return PROMPT_ECHO_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+function charAtOffset(value: string, offset: number): [string, number] | null {
+  if (offset >= value.length) return null;
+  const codePoint = value.codePointAt(offset);
+  if (codePoint === undefined) return null;
+  const character = String.fromCodePoint(codePoint);
+  return [character, offset + character.length];
+}
+
+function advancePastUnclosedQuoteLine(value: string, offset: number): number {
+  const newlineOffset = value.indexOf('\n', offset);
+  return newlineOffset === -1 ? value.length : newlineOffset + 1;
+}
+
+function isStructureStart(value: string, offset: number): boolean {
+  const before = value.slice(0, offset);
+  if (rustTrim(before) === '') return true;
+  const lastNewline = before.lastIndexOf('\n');
+  if (lastNewline !== -1) return rustTrim(before.slice(lastNewline + 1)) === '';
+  return false;
+}
+
+function isFieldKeyStart(value: string, offset: number): boolean {
+  const before = value.slice(0, offset);
+  if (rustTrim(before) === '') return true;
+  const lastNewline = before.lastIndexOf('\n');
+  if (lastNewline !== -1 && rustTrim(before.slice(lastNewline + 1)) === '') return true;
+  const braceOffset = before.lastIndexOf('{');
+  if (braceOffset !== -1) {
+    return rustTrim(before.slice(braceOffset + 1)) === '' && isStructureStart(value, braceOffset);
+  }
+  return false;
+}
+
+function parseQuotedToken(value: string, start: number, quote: string): [string, number] | null {
+  let token = '';
+  let offset = start + quote.length;
+  let escaped = false;
+  while (offset < value.length) {
+    const step = charAtOffset(value, offset);
+    if (!step) return null;
+    const [character, nextOffset] = step;
+    if (escaped) {
+      token += character;
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else if (character === quote) {
+      return [token, nextOffset];
+    } else {
+      token += character;
+    }
+    offset = nextOffset;
+  }
+  return null;
+}
+
+function isFieldNameCharacter(character: string): boolean {
+  return /^[A-Za-z0-9_]$/.test(character);
+}
+
+function isBareFieldBoundary(value: string, offset: number, fieldLen: number): boolean {
+  const beforeOk = offset === 0 || !isFieldNameCharacter(value.charAt(offset - 1));
+  const afterOffset = offset + fieldLen;
+  const afterOk = afterOffset >= value.length || !isFieldNameCharacter(value.charAt(afterOffset));
+  return beforeOk && afterOk;
+}
+
+function isScalarValueCharacter(character: string): boolean {
+  return /^[A-Za-z0-9_-]$/.test(character);
+}
+
+function arrayFieldHasContent(afterField: string): boolean {
+  const afterSeparator = rustTrimStart(afterField);
+  if (!afterSeparator.startsWith(':')) return false;
+  const afterColon = rustTrimStart(afterSeparator.slice(1));
+  if (!afterColon.startsWith('[')) return false;
+  return !rustTrimStart(afterColon.slice(1)).startsWith(']');
+}
+
+function scalarFieldMatchesValue(afterField: string, expected: string): boolean {
+  const afterSeparator = rustTrimStart(afterField);
+  if (!afterSeparator.startsWith(':')) return false;
+  const afterColon = rustTrimStart(afterSeparator.slice(1));
+  const first = charAtOffset(afterColon, 0);
+  if (first) {
+    const [quote] = first;
+    if (quote === '"' || quote === "'" || quote === '`') {
+      const parsed = parseQuotedToken(afterColon, 0, quote);
+      return parsed !== null && asciiEqualsIgnoreCase(rustTrim(parsed[0]), expected);
+    }
+  }
+  let actual = '';
+  for (const character of afterColon) {
+    if (!isScalarValueCharacter(character)) break;
+    actual += character;
+  }
+  return actual !== '' && asciiEqualsIgnoreCase(actual, expected);
+}
+
+function fieldPrefixMatches(text: string, offset: number, normalizedField: string): boolean {
+  return asciiLowercase(text.slice(offset, offset + normalizedField.length)) === normalizedField;
+}
+
+function reportDeclaresScalarFieldValue(report: string, field: string, expected: string): boolean {
+  const normalizedField = asciiLowercase(field);
+  let offset = 0;
+  while (offset < report.length) {
+    const step = charAtOffset(report, offset);
+    if (!step) break;
+    const [character, nextOffset] = step;
+    if (character === '"' || character === "'" || character === '`') {
+      const parsed = parseQuotedToken(report, offset, character);
+      if (!parsed) {
+        offset = advancePastUnclosedQuoteLine(report, nextOffset);
+        continue;
+      }
+      const [quoted, afterQuote] = parsed;
+      if (
+        isFieldKeyStart(report, offset) &&
+        asciiEqualsIgnoreCase(quoted, normalizedField) &&
+        scalarFieldMatchesValue(report.slice(afterQuote), expected)
+      ) {
+        return true;
+      }
+      offset = afterQuote;
+      continue;
+    }
+    if (
+      fieldPrefixMatches(report, offset, normalizedField) &&
+      isFieldKeyStart(report, offset) &&
+      isBareFieldBoundary(report, offset, field.length) &&
+      scalarFieldMatchesValue(report.slice(offset + field.length), expected)
+    ) {
+      return true;
+    }
+    offset = nextOffset;
+  }
+  return false;
+}
+
+function tryParseJsonObject(report: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(report);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not strict JSON — fall back to the scalar/array field scan.
+  }
+  return null;
+}
+
+function reportDeclaresNonemptyArrayField(report: string, field: string): boolean {
+  const parsedObject = tryParseJsonObject(report);
+  if (parsedObject) {
+    const items = parsedObject[field];
+    return Array.isArray(items) && items.length > 0;
+  }
+  const normalizedField = asciiLowercase(field);
+  let offset = 0;
+  while (offset < report.length) {
+    const step = charAtOffset(report, offset);
+    if (!step) break;
+    const [character, nextOffset] = step;
+    if (character === '"' || character === "'" || character === '`') {
+      const parsed = parseQuotedToken(report, offset, character);
+      if (!parsed) {
+        offset = advancePastUnclosedQuoteLine(report, nextOffset);
+        continue;
+      }
+      const [quoted, afterQuote] = parsed;
+      if (
+        isFieldKeyStart(report, offset) &&
+        asciiEqualsIgnoreCase(quoted, normalizedField) &&
+        arrayFieldHasContent(report.slice(afterQuote))
+      ) {
+        return true;
+      }
+      offset = afterQuote;
+      continue;
+    }
+    if (
+      fieldPrefixMatches(report, offset, normalizedField) &&
+      isFieldKeyStart(report, offset) &&
+      isBareFieldBoundary(report, offset, field.length) &&
+      arrayFieldHasContent(report.slice(offset + field.length))
+    ) {
+      return true;
+    }
+    offset = nextOffset;
+  }
+  return false;
+}
+
+function reportDeclaresCustodyValue(report: string, value: string): boolean {
+  const parsedObject = tryParseJsonObject(report);
+  if (parsedObject) {
+    const custody = parsedObject.custody;
+    return typeof custody === 'string' && asciiEqualsIgnoreCase(rustTrim(custody), value);
+  }
+  return reportDeclaresScalarFieldValue(report, 'custody', value);
+}
+
+function reportDeclaresNonemptyChanges(report: string): boolean {
+  return reportDeclaresNonemptyArrayField(report, 'changes');
+}
+
+function asciiFoldedAlnum(character: string): string | null {
+  if (/^[a-z0-9]$/.test(character)) return character;
+  switch (character) {
+    case 'á':
+    case 'à':
+    case 'ã':
+    case 'â':
+    case 'ä':
+      return 'a';
+    case 'é':
+    case 'è':
+    case 'ê':
+    case 'ë':
+      return 'e';
+    case 'í':
+    case 'ì':
+    case 'î':
+    case 'ï':
+      return 'i';
+    case 'ó':
+    case 'ò':
+    case 'õ':
+    case 'ô':
+    case 'ö':
+      return 'o';
+    case 'ú':
+    case 'ù':
+    case 'û':
+    case 'ü':
+      return 'u';
+    case 'ç':
+      return 'c';
+    default:
+      return null;
+  }
+}
+
+function compactAsciiSignature(value: string): string {
+  let compact = '';
+  for (const character of value.toLowerCase()) {
+    const folded = asciiFoldedAlnum(character);
+    if (folded) compact += folded;
+  }
+  return compact;
+}
+
+function asciiFoldedTokens(value: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  for (const character of value.toLowerCase()) {
+    const folded = asciiFoldedAlnum(character);
+    if (folded) {
+      current += folded;
+    } else if (current) {
+      tokens.push(current);
+      current = '';
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function containsUncertainDateMarker(raw: string, tokens: string[]): boolean {
+  if (!/[0-9]/.test(raw)) return false;
+  if (raw.includes('?') || raw.includes('--')) return true;
+  for (let index = 0; index + 3 < tokens.length; index += 1) {
+    if (
+      tokens[index] === 'entre' &&
+      /^[0-9]+$/.test(tokens[index + 1] ?? '') &&
+      tokens[index + 2] === 'e' &&
+      /^[0-9]+$/.test(tokens[index + 3] ?? '')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isBibliographicLacunaMarker(raw: string, compact: string): boolean {
+  if (
+    ['sd', 'nd', 'sl', 'sn', 'slsn', 'sineloco', 'sinenomine', 'sinedata'].includes(compact) ||
+    compact.includes('sinedata') ||
+    compact.includes('sineloco') ||
+    compact.includes('sinenomine')
+  ) {
+    return true;
+  }
+  const tokens = asciiFoldedTokens(raw);
+  for (let index = 0; index + 1 < tokens.length; index += 1) {
+    const first = tokens[index];
+    const second = tokens[index + 1];
+    if (
+      (first === 's' && second === 'd') ||
+      (first === 'n' && second === 'd') ||
+      (first === 's' && second === 'l') ||
+      (first === 's' && second === 'n')
+    ) {
+      return true;
+    }
+  }
+  return containsUncertainDateMarker(raw, tokens);
+}
+
+function containsFinalReleaseBlocker(text: string): boolean {
+  const compact = compactAsciiSignature(text);
+  if (compact.includes('evidenciapendente') || compact.includes('edicaoconsultadanaoidentificada')) {
+    return true;
+  }
+  let remaining = text;
+  for (;;) {
+    const open = remaining.indexOf('[');
+    if (open === -1) break;
+    const afterOpen = remaining.slice(open + 1);
+    const close = afterOpen.indexOf(']');
+    if (close === -1) break;
+    const bracketed = afterOpen.slice(0, close);
+    const marker = compactAsciiSignature(bracketed);
+    if (
+      isBibliographicLacunaMarker(bracketed, marker) ||
+      marker.includes('evidenciapendente') ||
+      marker.includes('edicaoconsultadanaoidentificada')
+    ) {
+      return true;
+    }
+    remaining = afterOpen.slice(close + 1);
+  }
+  return false;
+}
+
+function validateFinalReleaseCandidate(text: string): string | null {
+  if (containsFinalReleaseBlocker(text)) {
+    return 'final candidate failed bibliographic integrity gate: unresolved evidence marker or bibliographic lacuna found';
+  }
+  return null;
+}
+
+function validateSerialTurnOutput(
+  rawText: string,
+  status: string,
+  report: string | null,
+  finalText: string | null,
+): string | null {
+  if (status !== 'READY' && status !== 'NOT_READY') return `invalid serial status: ${status}`;
+  if (containsPromptOrProtocolEcho(rawText)) return 'output appears to reproduce prompt/protocol scaffolding';
+  const reportTagError = requireBalancedTag(rawText, 'maestro_revision_report');
+  if (reportTagError) return reportTagError;
+  const finalTagError = requireBalancedOptionalTag(rawText, 'maestro_final_text');
+  if (finalTagError) return finalTagError;
+  if (report === null) return 'missing complete maestro_revision_report block';
+  if (rustTrim(report) === '') return 'empty maestro_revision_report block';
+  const hasRevisedCustody = reportDeclaresCustodyValue(report, 'revised');
+  const hasUnchangedCustody = reportDeclaresCustodyValue(report, 'unchanged');
+  if (hasRevisedCustody && hasUnchangedCustody) return 'ambiguous custody declaration in maestro_revision_report';
+  if (finalText !== null) {
+    if (rustTrim(finalText) === '') return 'empty maestro_final_text block';
+    if (!hasRevisedCustody) return 'maestro_final_text requires custody revised in the report';
+    const releaseError = validateFinalReleaseCandidate(finalText);
+    if (releaseError) return releaseError;
+  }
+  if (finalText === null && hasRevisedCustody) return 'revised custody requires a complete maestro_final_text block';
+  if (finalText === null && !hasUnchangedCustody) {
+    return `${status} without maestro_final_text must explicitly declare custody unchanged`;
+  }
+  if (finalText === null && hasUnchangedCustody && reportDeclaresNonemptyChanges(report)) {
+    return 'correctable changes require custody revised and a complete maestro_final_text block';
+  }
+  return null;
+}
+
+function editorialQualityTier(agentKey: string): number {
+  switch (asciiLowercase(agentKey)) {
+    case 'claude':
+    case 'codex':
+      return 3;
+    case 'gemini':
+      return 2;
+    case 'deepseek':
+    case 'grok':
+    case 'perplexity':
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function qualityGuardBlocksRevision(
+  currentAuthorKey: string | null,
+  reviewerKey: string,
+  before: string,
+  after: string,
+  substantiveChange: boolean,
+): boolean {
+  if (!substantiveChange) return false;
+  if (currentAuthorKey === null) return false;
+  if (editorialQualityTier(reviewerKey) >= editorialQualityTier(currentAuthorKey)) return false;
+  const beforeChars = Array.from(before).length;
+  const afterChars = Array.from(after).length;
+  return beforeChars >= 400 && afterChars * 100 < beforeChars * 85;
+}
+
+// Desktop parity: the exact Mandatory Corrective Retry prompt section injected
+// on each corrective re-run of a contract-violating reviewer turn.
+function correctiveRetrySection(retryCount: number): string {
+  return [
+    '\n\n## Mandatory Corrective Retry\n',
+    `\nThis is corrective retry ${retryCount}/${MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN} for this same reviewer turn.`,
+    '\nYour previous answer failed the required output contract or identified a blocker without revising the article.',
+    '\nYou MUST resolve every correctable blocker in this turn by producing `custody: "revised"` and a complete `<maestro_final_text>`.',
+    '\nUnresolved evidence markers or bibliographic lacunae in the current text are correctable defects: if supplied evidence does not verify them, remove or rewrite the unsupported claim/reference in the article and explain the quarantine in the report. Do not preserve `[EVIDENCIA_PENDENTE]`, bracketed lacunae, or unverifiable reference placeholders in `<maestro_final_text>`.',
+    '\nOnly request operator evidence for a decision that cannot be made by deleting, narrowing, or quarantining the unsupported claim without harming the article.\n',
+  ].join('');
 }
 
 /**
@@ -1430,11 +1888,16 @@ function publicApiHealthResult(
 export const maestroAiTestHooks = {
   buildProviderHttpRequest,
   publicApiHealthResult,
-  validateRevisionGuard,
   extractStatus,
   extractTagged,
   isSubstantiveEditorialChange,
   sanitizeAgent,
+  reportDeclaresCustodyValue,
+  reportDeclaresNonemptyChanges,
+  containsFinalReleaseBlocker,
+  containsPromptOrProtocolEcho,
+  validateSerialTurnOutput,
+  qualityGuardBlocksRevision,
   isBlockedAuditHost,
   extractUrls,
   checkOneLink,
@@ -1565,6 +2028,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
   let currentAuthor: ProviderKey = initialAgent;
   let artifactTurn = 0;
   let previousArtifactId: string | null = null;
+  const correctiveRetryCounts = new Map<string, number>();
   const startedAtMs = Date.now();
 
   try {
@@ -1717,197 +2181,269 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
           return;
         }
         eligibleVotes += 1;
-        await pushEvent({
-          at: nowIso(),
-          agent: reviewer,
-          role: 'revision',
-          status: 'running',
-          message: `Serial revision turn started in cycle ${cycle}.`,
-        });
-        const prompt = buildRevisionPrompt({
-          input,
-          runId: id,
-          turn: events.length + 1,
-          currentText,
-          currentAuthor,
-          reviewer,
-          history: events,
-        });
-        const rates = input.rates?.[reviewer] ?? {};
-        const projected = estimateCost(prompt, MAX_OUTPUT_TOKENS, rates);
-        if (!Number.isFinite(projected) || observedCost + projected > Number(input.max_cost_usd)) {
+        let correctiveRetryCount = 0;
+        // Desktop parity: a contract-violating turn is retried with the SAME
+        // reviewer up to MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN times, with a
+        // Mandatory Corrective Retry section appended to the prompt; exhaustion
+        // skips the turn instead of killing the session (full desktop round
+        // accounting arrives with Plan B3).
+        for (;;) {
           await pushEvent({
             at: nowIso(),
             agent: reviewer,
             role: 'revision',
-            status: 'blocked',
-            message: `Cost guard blocked provider call before ${AGENT_LABELS[reviewer]}.`,
-            cost_usd: projected,
+            status: 'running',
+            message:
+              correctiveRetryCount > 0
+                ? `Corrective retry ${correctiveRetryCount}/${MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN} started in cycle ${cycle}.`
+                : `Serial revision turn started in cycle ${cycle}.`,
           });
-          await persistSession(
-            db,
-            id,
-            { status: 'blocked_cost', observed_cost_usd: observedCost },
-            { ifStatusIn: ['queued', 'running'] },
-          );
-          return;
-        }
-        // Cooperative cancellation (pre-call): a cancel can land during the
-        // revision start event's await above; re-check immediately before the paid
-        // reviewer call so it is not issued for a no-longer-running session.
-        const beforeReviewLive = await loadSession(db, id);
-        if (runnerStopRequested(beforeReviewLive)) {
-          logMaestro('warn', 'session_interrupted', { session_id: id, status: beforeReviewLive?.status });
-          return;
-        }
-        const result = await callProvider(env, reviewer, prompt, input.models ?? {});
-        const cost = calculateObservedCost(result, prompt, rates);
-        observedCost += cost;
-        // Cooperative cancellation (post-call): if cancelled while the reviewer
-        // call was in flight, do not write revision artifacts/events for the
-        // now-cancelled session.
-        const afterReviewLive = await loadSession(db, id);
-        if (runnerStopRequested(afterReviewLive)) {
-          logMaestro('warn', 'session_interrupted', { session_id: id, status: afterReviewLive?.status });
-          return;
-        }
-        // M3: an empty reviewer response is a provider failure, not a silent
-        // NOT_READY vote. Fail fast instead of recording a meaningless turn.
-        if (!result.text.trim()) {
-          throw new Error(`O provedor ${AGENT_LABELS[reviewer]} retornou uma revisao vazia (texto em branco).`);
-        }
-        const status = extractStatus(result.text);
-        const revisionReport =
-          extractTagged(result.text, 'maestro_revision_report') ||
-          JSON.stringify({
-            reviewer,
-            current_author: currentAuthor,
-            status,
-            custody: 'unstructured_report_missing',
-          });
-        const revisedText = extractTagged(result.text, 'maestro_final_text');
-        const changedByReviewer = Boolean(revisedText && isSubstantiveEditorialChange(currentText, revisedText));
-        const candidateText = revisedText && changedByReviewer ? revisedText : currentText;
-        const revisionGuardError = validateRevisionGuard(currentText, candidateText, status, revisionReport);
-        if (revisionGuardError) {
+          const prompt =
+            buildRevisionPrompt({
+              input,
+              runId: id,
+              turn: events.length + 1,
+              currentText,
+              currentAuthor,
+              reviewer,
+              history: events,
+            }) + (correctiveRetryCount > 0 ? correctiveRetrySection(correctiveRetryCount) : '');
+          const rates = input.rates?.[reviewer] ?? {};
+          const projected = estimateCost(prompt, MAX_OUTPUT_TOKENS, rates);
+          if (!Number.isFinite(projected) || observedCost + projected > Number(input.max_cost_usd)) {
+            await pushEvent({
+              at: nowIso(),
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              message: `Cost guard blocked provider call before ${AGENT_LABELS[reviewer]}.`,
+              cost_usd: projected,
+            });
+            await persistSession(
+              db,
+              id,
+              { status: 'blocked_cost', observed_cost_usd: observedCost },
+              { ifStatusIn: ['queued', 'running'] },
+            );
+            return;
+          }
+          // Cooperative cancellation (pre-call): a cancel can land during the
+          // revision start event's await above; re-check immediately before the paid
+          // reviewer call so it is not issued for a no-longer-running session.
+          const beforeReviewLive = await loadSession(db, id);
+          if (runnerStopRequested(beforeReviewLive)) {
+            logMaestro('warn', 'session_interrupted', { session_id: id, status: beforeReviewLive?.status });
+            return;
+          }
+          const result = await callProvider(env, reviewer, prompt, input.models ?? {});
+          const cost = calculateObservedCost(result, prompt, rates);
+          observedCost += cost;
+          // Cooperative cancellation (post-call): if cancelled while the reviewer
+          // call was in flight, do not write revision artifacts/events for the
+          // now-cancelled session.
+          const afterReviewLive = await loadSession(db, id);
+          if (runnerStopRequested(afterReviewLive)) {
+            logMaestro('warn', 'session_interrupted', { session_id: id, status: afterReviewLive?.status });
+            return;
+          }
+          // M3: an empty reviewer response is a provider failure, not a silent
+          // NOT_READY vote. Fail fast instead of recording a meaningless turn.
+          if (!result.text.trim()) {
+            throw new Error(`O provedor ${AGENT_LABELS[reviewer]} retornou uma revisao vazia (texto em branco).`);
+          }
+          const status = extractStatus(result.text);
+          const report = extractTagged(result.text, 'maestro_revision_report');
+          const revisedText = extractTagged(result.text, 'maestro_final_text');
+          let effectiveStatus: 'READY' | 'NOT_READY' = status;
+          let readyRejectedReason: string | null = null;
+          let contractError = validateSerialTurnOutput(result.text, status, report, revisedText);
+          if (!contractError && revisedText === null) {
+            // Desktop parity (unrevised-turn audit): a READY vote on a custody
+            // text that still fails the release gate is rewritten to NOT_READY
+            // without retry (ReadyRejected); NOT_READY without a corrective text
+            // is itself a contract violation and goes to corrective retry.
+            const custodyReleaseError = validateFinalReleaseCandidate(currentText);
+            if (status === 'READY' && custodyReleaseError) {
+              effectiveStatus = 'NOT_READY';
+              readyRejectedReason = custodyReleaseError;
+            } else if (status === 'NOT_READY') {
+              contractError =
+                custodyReleaseError ??
+                'NOT_READY unchanged is not a valid serial-review outcome: the reviewer must either return READY unchanged when no blocker remains, or return a revised complete text that resolves the concrete blocker.';
+            }
+          }
+          if (contractError) {
+            const retryKey = `${cycle}:${order.indexOf(reviewer)}:${reviewer}:${currentText}`;
+            const retryCount = (correctiveRetryCounts.get(retryKey) ?? 0) + 1;
+            correctiveRetryCounts.set(retryKey, retryCount);
+            artifactTurn += 1;
+            await createArtifact(db, {
+              sessionId: id,
+              cycle,
+              turn: artifactTurn,
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              title: input.title,
+              contentMd: currentText,
+              revisionReport: JSON.stringify({
+                guard: 'serial_turn_contract',
+                reclassified: 'CONTRACT_VIOLATION',
+                reason: contractError,
+                attempt: retryCount,
+                attempted_report: (report ?? '').slice(0, 2000),
+              }),
+              linkAudit: [],
+              costUsd: cost,
+              model: result.model,
+              previousArtifactId,
+            });
+            await pushEvent({
+              at: nowIso(),
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              message: `Reclassificado para CONTRACT_VIOLATION: ${sanitizeText(contractError, 300)}`,
+              cost_usd: cost,
+              model: result.model,
+            });
+            await persistSession(db, id, { observed_cost_usd: observedCost });
+            if (retryCount <= MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN) {
+              correctiveRetryCount = retryCount;
+              continue;
+            }
+            await pushEvent({
+              at: nowIso(),
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              message: 'Corrective retries exhausted; reviewer turn skipped without a vote.',
+            });
+            break;
+          }
+          const changedByReviewer = Boolean(revisedText && isSubstantiveEditorialChange(currentText, revisedText));
+          if (
+            revisedText !== null &&
+            changedByReviewer &&
+            qualityGuardBlocksRevision(currentAuthor, reviewer, currentText, revisedText, true)
+          ) {
+            // Desktop parity (anti-impoverishment quality ratchet): the shrunk
+            // revision from a lower-tier reviewer is rejected and discarded; the
+            // custody text and author stay unchanged and the session continues.
+            artifactTurn += 1;
+            await createArtifact(db, {
+              sessionId: id,
+              cycle,
+              turn: artifactTurn,
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              title: input.title,
+              contentMd: currentText,
+              revisionReport: JSON.stringify({
+                guard: 'anti_impoverishment_quality_ratchet',
+                reason: 'Lower-tier reviewer shrank stronger custody text beyond the allowed ratio; revision rejected.',
+                attempted_report: (report ?? '').slice(0, 2000),
+              }),
+              linkAudit: [],
+              costUsd: cost,
+              model: result.model,
+              previousArtifactId,
+            });
+            await pushEvent({
+              at: nowIso(),
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              message: 'Quality guard rejected lower-tier shrink revision; custody unchanged.',
+              cost_usd: cost,
+              model: result.model,
+            });
+            await persistSession(db, id, { observed_cost_usd: observedCost });
+            break;
+          }
+          const candidateText = revisedText && changedByReviewer ? revisedText : currentText;
+          // M4: re-audit only when the custody text actually changed. Unchanged
+          // text already passed the previous audit, so re-fetching its links only
+          // risks a transient failure killing an otherwise-valid session.
+          const linkAudit = changedByReviewer ? await auditLinks(candidateText) : currentLinkAudit;
+          if (changedByReviewer) currentLinkAudit = linkAudit;
+          const brokenLinks = linkAudit.filter((link) => !link.ok);
           artifactTurn += 1;
-          await createArtifact(db, {
+          const artifact = await createArtifact(db, {
             sessionId: id,
             cycle,
             turn: artifactTurn,
             agent: reviewer,
             role: 'revision',
-            status: 'blocked',
+            status: brokenLinks.length ? 'blocked' : effectiveStatus.toLowerCase(),
             title: input.title,
-            contentMd: currentText,
-            revisionReport: JSON.stringify({
-              guard: 'approved_content_lock',
-              reason: revisionGuardError,
-              attempted_report: revisionReport.slice(0, 2000),
-            }),
-            linkAudit: [],
+            contentMd: candidateText,
+            revisionReport: report ?? '',
+            linkAudit,
             costUsd: cost,
             model: result.model,
             previousArtifactId,
           });
+          previousArtifactId = artifact.id;
+          if (brokenLinks.length) {
+            await pushEvent({
+              at: nowIso(),
+              agent: reviewer,
+              role: 'revision',
+              status: 'blocked',
+              message: `Automatic link audit blocked ${brokenLinks.length} broken link(s).`,
+              cost_usd: cost,
+              model: result.model,
+              link_audit: linkAudit,
+            });
+            await persistSession(
+              db,
+              id,
+              {
+                status: 'blocked_link_audit',
+                current_author: currentAuthor,
+                current_text: currentText,
+                observed_cost_usd: observedCost,
+                error: `Link audit blocked revision: ${brokenLinks
+                  .map((link) => `${link.url} (${link.status ?? link.error ?? 'invalid'})`)
+                  .join('; ')}`,
+              },
+              { ifStatusIn: ['queued', 'running'] },
+            );
+            return;
+          }
+          if (revisedText && changedByReviewer) {
+            currentText = revisedText;
+            currentAuthor = reviewer;
+            changedThisCycle = true;
+          }
+          if (effectiveStatus === 'READY') readyVotes += 1;
           await pushEvent({
             at: nowIso(),
             agent: reviewer,
             role: 'revision',
-            status: 'blocked',
-            message: revisionGuardError,
-            cost_usd: cost,
-            model: result.model,
-          });
-          await persistSession(
-            db,
-            id,
-            {
-              status: 'blocked_revision_contract',
-              current_author: currentAuthor,
-              current_text: currentText,
-              observed_cost_usd: observedCost,
-              error: revisionGuardError,
-            },
-            { ifStatusIn: ['queued', 'running'] },
-          );
-          return;
-        }
-        // M4: re-audit only when the custody text actually changed. Unchanged
-        // text already passed the previous audit, so re-fetching its links only
-        // risks a transient failure killing an otherwise-valid session.
-        const linkAudit = changedByReviewer ? await auditLinks(candidateText) : currentLinkAudit;
-        if (changedByReviewer) currentLinkAudit = linkAudit;
-        const brokenLinks = linkAudit.filter((link) => !link.ok);
-        artifactTurn += 1;
-        const artifact = await createArtifact(db, {
-          sessionId: id,
-          cycle,
-          turn: artifactTurn,
-          agent: reviewer,
-          role: 'revision',
-          status: brokenLinks.length ? 'blocked' : status.toLowerCase(),
-          title: input.title,
-          contentMd: candidateText,
-          revisionReport,
-          linkAudit,
-          costUsd: cost,
-          model: result.model,
-          previousArtifactId,
-        });
-        previousArtifactId = artifact.id;
-        if (brokenLinks.length) {
-          await pushEvent({
-            at: nowIso(),
-            agent: reviewer,
-            role: 'revision',
-            status: 'blocked',
-            message: `Automatic link audit blocked ${brokenLinks.length} broken link(s).`,
+            status: effectiveStatus === 'READY' ? 'ready' : 'not_ready',
+            message: readyRejectedReason
+              ? `READY rejected by release gate: ${sanitizeText(readyRejectedReason, 300)}`
+              : changedByReviewer
+                ? 'Reviewer revised custody text.'
+                : 'Reviewer left custody unchanged.',
             cost_usd: cost,
             model: result.model,
             link_audit: linkAudit,
           });
-          await persistSession(
-            db,
-            id,
-            {
-              status: 'blocked_link_audit',
-              current_author: currentAuthor,
-              current_text: currentText,
-              observed_cost_usd: observedCost,
-              error: `Link audit blocked revision: ${brokenLinks
-                .map((link) => `${link.url} (${link.status ?? link.error ?? 'invalid'})`)
-                .join('; ')}`,
-            },
-            { ifStatusIn: ['queued', 'running'] },
-          );
-          return;
+          // Do NOT re-assert status:'running' here. The session is already
+          // 'running'; rewriting it would clobber a concurrent operator cancel
+          // (blocked_cancelled) that landed during this turn, defeating the
+          // cooperative-cancel check at the top of the next iteration.
+          await persistSession(db, id, {
+            current_author: currentAuthor,
+            current_text: currentText,
+            observed_cost_usd: observedCost,
+          });
+          break;
         }
-        if (revisedText && changedByReviewer) {
-          currentText = revisedText;
-          currentAuthor = reviewer;
-          changedThisCycle = true;
-        }
-        if (status === 'READY') readyVotes += 1;
-        await pushEvent({
-          at: nowIso(),
-          agent: reviewer,
-          role: 'revision',
-          status: status === 'READY' ? 'ready' : 'not_ready',
-          message: changedByReviewer ? 'Reviewer revised custody text.' : 'Reviewer left custody unchanged.',
-          cost_usd: cost,
-          model: result.model,
-          link_audit: linkAudit,
-        });
-        // Do NOT re-assert status:'running' here. The session is already
-        // 'running'; rewriting it would clobber a concurrent operator cancel
-        // (blocked_cancelled) that landed during this turn, defeating the
-        // cooperative-cancel check at the top of the next iteration.
-        await persistSession(db, id, {
-          current_author: currentAuthor,
-          current_text: currentText,
-          observed_cost_usd: observedCost,
-        });
       }
       converged = eligibleVotes > 0 && readyVotes === eligibleVotes && !changedThisCycle;
     }

--- a/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-b1.md
+++ b/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-b1.md
@@ -1,0 +1,92 @@
+# Maestro AI Parity Plan B1 — Contrato de Turno, Retry Corretivo e Tier Guard
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Portar para o módulo Maestro AI web a validação estrutural de saída de turno (`validate_serial_turn_output`), o ciclo de retry corretivo por CONTRACT_VIOLATION e o anti-empobrecimento por tier do maestro-app, substituindo `validateRevisionGuard`.
+
+**Architecture:** Funções puras novas em `sessions.ts` (porta byte-exata dos helpers Rust) + integração no loop `runSession` mantendo o modelo de ciclos atual (convergência cumulativa é Plano B3; content lock é B2; auditoria HTTP na finalização é Plano D — aqui o gate de release usa só o bloqueador bibliográfico, subconjunto fiel).
+
+**Tech Stack:** Cloudflare Worker (TypeScript), Vitest. Fonte canônica: `maestro-app/src-tauri/src/session_orchestration.rs` (linhas citadas por task).
+
+## Global Constraints
+
+- `MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN = 3` (session_orchestration.rs:78).
+- Threshold de escalada de outage: 3 rounds consecutivos (`ALL_ERROR_ESCALATION_THRESHOLD`, :370).
+- Comparações de campo `eq_ignore_ascii_case` = comparação case-insensitive ASCII (portar como comparação de asciiLowercase de ambos os lados, nunca `toLowerCase()` Unicode).
+- Sem statuses novos no B1 (decisão de implementação): exaustão de retry corretivo pula o turno sem voto; a contabilidade de round do desktop (`PAUSED_ROUND_INCOMPLETE`, escalada de outage) chega com o B3/C junto dos estados retomáveis.
+- Semântica desktop decisiva: READY + `<maestro_final_text>` substantivo é turno de revisão NORMAL (avança a versão, sessions_orchestration.rs:1717-1721); READY-unchanged com bloqueador bibliográfico no texto corrente vira NOT_READY sem retry (ReadyRejected, :1418-1445, :1998-2007); NOT_READY-unchanged sem texto corretivo é CONTRACT_VIOLATION com retry (:2009-2029).
+- TDD red-first; gates completos; cross-review ALL READY; bump minor + CHANGELOG.
+
+---
+
+### Task 1: micro-parser de campos do relatório (porta byte-exata)
+
+**Files:**
+- Modify: `admin-motor/src/handlers/routes/maestro-ai/sessions.ts` (novas funções puras após `isSubstantiveEditorialChange`)
+- Test: `admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts`
+
+**Interfaces (Produces):**
+- `reportDeclaresCustodyValue(report: string, value: string): boolean` (Rust :2291-2300 — JSON estrito primeiro via try JSON.parse objeto + campo `custody` string `trim().eq_ignore_ascii_case`; senão scan escalar)
+- `reportDeclaresNonemptyChanges(report: string): boolean` (:2302-2304 → array field `changes`)
+- Helpers privados: `charAtOffset` (:2384-2389), `advancePastUnclosedQuoteLine` (:2391-2395), `isFieldKeyStart` (:2397-2413), `isStructureStart` (:2415-2424), `parseQuotedToken` (:2426-2445, com escape `\\`), `isBareFieldBoundary` (:2447-2460), `isFieldNameCharacter` (:2462-2464 — alnum ASCII ou `_`), `arrayFieldHasContent` (:2466-2476 — `:` então `[` então não-`]`), `scalarFieldMatchesValue` (:2478-2495 — valor entre aspas duplas/simples/crase via parseQuotedToken OU token bare de `[A-Za-z0-9_-]`), `isScalarValueCharacter` (:2497-2499), `reportDeclaresScalarFieldValue` (:2349-2382), `reportDeclaresNonemptyArrayField` (:2310-2347).
+- Nota de porta: offsets Rust são bytes UTF-8; em TS usar offsets UTF-16 — equivalente porque todos os delimitadores testados são ASCII e `charAtOffset` avança por code point (usar `codePointAt`/`String.fromCodePoint` com avanço de `String.fromCodePoint(cp).length`).
+
+**Steps:** teste vermelho (matriz: JSON estrito `{"custody":"revised"}`, scalar `custody: revised`, quoted key `"custody": 'Revised'`, boundary falso `xcustody:`, campo em linha própria, campo após `{`, changes `[]` vazio vs `["x"]`, aspas não fechadas) → implementar → verde.
+
+### Task 2: bloqueadores bibliográficos + echo + tags balanceadas
+
+**Interfaces (Produces):**
+- `asciiLowercase(text: string): string` (espelho de `asciiUppercase`, só A-Z)
+- `containsPromptOrProtocolEcho(stdout: string): boolean` (:2501-2514 — asciiLowercase(stdout) contém qualquer um dos 7 markers verbatim)
+- `requireBalancedTag(stdout: string, tag: string): string | null` (:2265-2277 — retorna mensagem de erro `missing {tag} block` / `incomplete {tag} block` ou null; 0/0 = missing; open===close = ok)
+- `requireBalancedOptionalTag(stdout: string, tag: string): string | null` (:2279-2289 — 0/0 ok; open!==close = `incomplete {tag} block`)
+- `asciiFoldedAlnum(ch: string): string | null` (:2209-2220 — a-z/0-9 identidade; áàãâä→a; éèêë→e; íìîï→i; óòõôö→o; úùûü→u; ç→c; resto null)
+- `compactAsciiSignature(value: string): string` (:2139-2145 — `value.toLowerCase()` Unicode AQUI é o próprio Rust `to_lowercase()` — manter toLowerCase(), depois filter asciiFoldedAlnum)
+- `asciiFoldedTokens(value: string): string[]` (:2193-2207)
+- `isBibliographicLacunaMarker(raw: string, compact: string): boolean` (:2147-2169 — compact ∈ {sd,nd,sl,sn,slsn,sineloco,sinenomine,sinedata} ou contém sinedata/sineloco/sinenomine; ou pares de tokens (s,d)/(n,d)/(s,l)/(s,n); ou marcador de data incerta)
+- `containsUncertainDateMarker(raw: string, tokens: string[]): boolean` (:2171-2191 — exige dígito ASCII; `?` ou `--`; ou janela de 4 tokens `entre <digits> e <digits>`)
+- `containsFinalReleaseBlocker(text: string): boolean` (:2112-2137 — compact do texto todo contém `evidenciapendente`/`edicaoconsultadanaoidentificada`; ou varredura de trechos `[...]` com isBibliographicLacunaMarker/markers)
+- `validateFinalReleaseCandidate(text: string): string | null` (:1990-1996 — mensagem exata `final candidate failed bibliographic integrity gate: unresolved evidence marker or bibliographic lacuna found`)
+
+**Steps:** teste vermelho (`[EVIDENCIA_PENDENTE]`, `[s.d.]`, `[S. l.]`, `[entre 1990 e 1995]`, `[1990?]`, `[sine data]`, negativo `[2001]`, `[Fonte: IBGE 2020]`; echo com `## Required Output Contract` case-insensitive; tags duplicadas balanceadas ok, incompletas erro) → implementar → verde.
+
+### Task 3: validateSerialTurnOutput
+
+**Interfaces (Produces):** `validateSerialTurnOutput(rawText: string, status: string, report: string | null, finalText: string | null): string | null` retornando a PRIMEIRA mensagem de erro na ordem exata do Rust (:1926-1978):
+1. status ∉ {READY, NOT_READY} → `invalid serial status: {status}`
+2. echo → `output appears to reproduce prompt/protocol scaffolding`
+3. requireBalancedTag(raw, 'maestro_revision_report')
+4. requireBalancedOptionalTag(raw, 'maestro_final_text')
+5. report ausente → `missing complete maestro_revision_report block`; vazio → `empty maestro_revision_report block`
+6. custody revised E unchanged → `ambiguous custody declaration in maestro_revision_report`
+7. finalText presente: vazio → `empty maestro_final_text block`; sem custody revised → `maestro_final_text requires custody revised in the report`; validateFinalReleaseCandidate(finalText)
+8. finalText ausente + custody revised → `revised custody requires a complete maestro_final_text block`
+9. finalText ausente + sem custody unchanged → `{status} without maestro_final_text must explicitly declare custody unchanged`
+10. finalText ausente + custody unchanged + changes não-vazio → `correctable changes require custody revised and a complete maestro_final_text block`
+
+### Task 4: integração no runSession — retry corretivo + tier guard + ReadyRejected
+
+**Modifica o corpo do turno de revisão em `runSession`:**
+- Constantes: `MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN = 3`; retry key = `` `${cycle}:${turnIndex}:${reviewer}:${currentText}` `` (Map<string, number>; Rust :2103-2110).
+- Wrapper `while` no turno: em CONTRACT_VIOLATION (validateSerialTurnOutput erro), gravar artefato blocked com nota `Reclassificado para CONTRACT_VIOLATION: {reason}` (Rust :2534-2538), incrementar retry; se count ≤ 3 → repetir o MESMO reviewer com o prompt acrescido da seção exata (Rust :1061-1067):
+
+```text
+## Mandatory Corrective Retry
+
+This is corrective retry {n}/{max} for this same reviewer turn.
+Your previous answer failed the required output contract or identified a blocker without revising the article.
+You MUST resolve every correctable blocker in this turn by producing `custody: "revised"` and a complete `<maestro_final_text>`.
+Unresolved evidence markers or bibliographic lacunae in the current text are correctable defects: if supplied evidence does not verify them, remove or rewrite the unsupported claim/reference in the article and explain the quarantine in the report. Do not preserve `[EVIDENCIA_PENDENTE]`, bracketed lacunae, or unverifiable reference placeholders in `<maestro_final_text>`.
+Only request operator evidence for a decision that cannot be made by deleting, narrowing, or quarantining the unsupported claim without harming the article.
+```
+
+- Exaustão (count > 3): pular o turno sem voto (continue no for de reviewers); a convergência do ciclo falha e a sessão segue até `blocked_max_cycles` se não convergir — a contabilidade integral de round/outage do desktop chega com B3/C.
+- Turno unrevised (sem finalText): (a) READY + `containsFinalReleaseBlocker(currentText)` → ReadyRejected: status vira NOT_READY (sem retry, sem voto ready; artefato reclassificado com a reason do gate); (b) NOT_READY → CONTRACT_VIOLATION retry com reason exata `NOT_READY unchanged is not a valid serial-review outcome: the reviewer must either return READY unchanged when no blocker remains, or return a revised complete text that resolves the concrete blocker.` (Rust :2019) — ou, se o texto corrente tem bloqueador bibliográfico, a reason do gate (Rust :2015-2017).
+- Tier guard substitui o trecho de shrink do validateRevisionGuard: portar `editorialQualityTier` (:2565-2572) e `qualityGuardBlocksRevision` (:2574-2593 — substantive && tier(reviewer) < tier(autor) && before ≥ 400 chars && after*100 < before*85); quando bloquear → rejeitar a revisão (texto/custódia inalterados), gravar evento/artefato blocked SEM reclassificação, `continue` (Rust :1677-1711).
+- `validateRevisionGuard` é removido (substituído por Tasks 3+4); READY+revisado passa a ser aceito como turno normal.
+
+### Task 5: gates + ship
+
+- Suíte completa + typecheck + eslint + biome + prettier public + markdownlint.
+- Bump `APP_VERSION` minor + CHANGELOG.
+- Cross-review ALL READY; branch `feat/maestro-ai-parity-plan-b1` → PR → automerge → GHA verde.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.04.00';
+const APP_VERSION = 'APP v02.05.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary
Plan B1 of the A–F parity roadmap (`docs/superpowers/plans/`): the maestro-app desktop is the canonical behavior source; this PR ports its serial-turn enforcement to the web module.

- **`validate_serial_turn_output` ported byte-exactly**: prompt/protocol echo markers, balanced tags, required report, custody `revised`/`unchanged` cross-field consistency, bibliographic integrity gate (`[EVIDENCIA_PENDENTE]`, `[s.d.]`, `[S. l.]`, `[entre N e M]`, uncertain dates) — ten checks in the canonical order with the exact strings, backed by the ported report-field micro-parser (strict-JSON first, then quoted/bare scalar and array scan).
- **Corrective retry**: CONTRACT_VIOLATION → up to 3 retries of the same reviewer with the desktop's verbatim "Mandatory Corrective Retry" prompt section; exhaustion skips the turn without a vote instead of killing the session.
- **Outcome bans inverted to canonical semantics**: READY + substantive revision is a normal custody-advancing turn; NOT_READY-unchanged is a violation with retry; READY over custody still failing the bibliographic gate is rewritten to NOT_READY (ReadyRejected).
- **Tier quality guard** replaces the old anti-impoverishment rule: fires only when a lower-tier reviewer (claude/codex=3, gemini=2, deepseek/grok/perplexity=1) shrinks ≥400-char text by >15%, and **rejects the revision while the session continues**.
- `validateRevisionGuard` removed (function, hook, tests).

Documented interim decisions (in the plan doc): no new session statuses in B1 (desktop round accounting arrives with B3/C); bibliographic-only release gate (capacity/HTTP stages arrive with Plan D); cycle-based convergence until B3.

## Testing
- 7 new unit tests + 3 new integration tests, red-first; full admin-motor suite **139/139**; typecheck baseline clean; eslint/biome/prettier/markdownlint green.
- Cross-review session cd8e64e6: 5 rounds; codex's round-4 empty-block parity claim was **refuted with the canonical extractor source** (editorial_io.rs:325 collapses complete-but-empty bodies to None on the desktop too) plus a zero-change lock test; **round 5 unanimous READY** (caller + codex, gemini, deepseek, grok, perplexity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)