### PR TITLE
feat(maestro-ai): sovereign approved-content lock — parity Plan B2 (v02.06.00)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.06.00] - 2026-07-05
+
+### Alterado
+
+- **Maestro AI — trava soberana de conteúdo aprovado (Plano B2 da equiparação com o maestro-app)**: novo módulo `content-lock` (port byte-exato de `editorial_content_lock.rs`). Uma revisão só pode alterar, remover, reordenar ou acrescentar blocos de texto (segmentados por linha em branco, IDs `B0001…`) que o relatório declare na seção `changed_blocks`, cada um com `protocol_basis` não-vazio; crescimento do número de blocos exige `change_type` split/addition e reordenação exige `change_type` reorder por bloco movido. Violações seguem o mesmo caminho de CONTRACT_VIOLATION com retry corretivo do Plano B1 (a trava roda antes do guard de tier, na ordem canônica). Igualdade de blocos por texto normalizado (whitespace canônico) — equivalente ao hash do desktop, documentado no plano.
+
 ## [v02.05.00] - 2026-07-05
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/content-lock.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/content-lock.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { segmentEditorialBlocks, validateRevisionContentLock } from './content-lock.ts';
+
+// Oracle fixtures mirror maestro-app editorial_content_lock.rs (canonical).
+const BEFORE = '# Titulo\n\nParagrafo aprovado e denso.\n\nReferencia pendente citada.';
+
+describe('Maestro AI approved-content lock (Plan B2)', () => {
+  it('segments blocks on blank lines with B%04d ids', () => {
+    const blocks = segmentEditorialBlocks(BEFORE);
+    expect(blocks.map((block) => block.id)).toEqual(['B0001', 'B0002', 'B0003']);
+    expect(segmentEditorialBlocks('  \n\n  ')).toEqual([]);
+    // CRLF and stray CR normalize before segmentation.
+    expect(segmentEditorialBlocks('a\r\n\r\nb').map((block) => block.id)).toEqual(['B0001', 'B0002']);
+  });
+
+  it('accepts an unchanged revision without a changed_blocks section', () => {
+    expect(validateRevisionContentLock(BEFORE, BEFORE, 'custody: "revised"')).toBeNull();
+    // Whitespace-only differences are cosmetic under the canonical normalization.
+    expect(
+      validateRevisionContentLock(BEFORE, BEFORE.replace('aprovado e denso.', 'aprovado  e\ndenso.'), 'x'),
+    ).toBeNull();
+    // Dropping a block counts as changing it: the canonical rule requires the
+    // drop to be declared, so an undeclared drop is a lock violation.
+    const dropped = '# Titulo\n\nParagrafo aprovado e denso.';
+    const error = validateRevisionContentLock(BEFORE, dropped, 'x');
+    expect(error).toContain('no changed_blocks section with block IDs');
+    expect(error).toContain('B0003');
+  });
+
+  it('rejects a changed received block with no changed_blocks section', () => {
+    const after = '# Titulo\n\nParagrafo encurtado.\n\nReferencia pendente citada.';
+    const error = validateRevisionContentLock(BEFORE, after, 'custody: "revised" without section');
+    expect(error).toContain('no changed_blocks section with block IDs');
+    expect(error).toContain('B0002');
+  });
+
+  it('rejects a changed block missing from the declarations (canonical oracle test)', () => {
+    const before = '# Titulo\n\nParagrafo aprovado e denso.\n\nReferencia pendente [EVIDENCIA_PENDENTE].';
+    const after = '# Titulo\n\nParagrafo encurtado.\n\nReferencia removida.';
+    const report = `{
+      "changed_blocks": [
+        {"block_id": "B0003", "protocol_basis": "bibliographic integrity"}
+      ],
+      "custody": "revised"
+    }`;
+    const error = validateRevisionContentLock(before, after, report);
+    expect(error).toContain('without matching changed_blocks declaration');
+    expect(error).toContain('B0002');
+  });
+
+  it('accepts a declared change with non-empty protocol_basis and rejects an empty one', () => {
+    const after = '# Titulo\n\nParagrafo corrigido com base protocolar.\n\nReferencia pendente citada.';
+    const good =
+      '"changed_blocks": [{"block_id": "B0002", "protocol_basis": "factual precision rule"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, after, good)).toBeNull();
+    const empty = '"changed_blocks": [{"block_id": "B0002", "protocol_basis": ""}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, after, empty)).toContain('must include protocol_basis');
+  });
+
+  it('requires change_type split/addition for block-count growth', () => {
+    const grown = `${BEFORE}\n\nBloco novo acrescentado.`;
+    const noGrowth =
+      '"changed_blocks": [{"block_id": "B0003", "protocol_basis": "expansion rule"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, grown, noGrowth)).toContain(
+      'added new blocks without declaring change_type split/addition',
+    );
+    const withGrowth =
+      '"changed_blocks": [{"block_id": "B0003", "protocol_basis": "expansion rule", "change_type": "addition"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, grown, withGrowth)).toBeNull();
+  });
+
+  it('requires change_type reorder on every moved block', () => {
+    const reordered = '# Titulo\n\nReferencia pendente citada.\n\nParagrafo aprovado e denso.';
+    expect(validateRevisionContentLock(BEFORE, reordered, 'no section here')).toContain('reordered received blocks');
+    const undeclared =
+      '"changed_blocks": [{"block_id": "B0002", "protocol_basis": "order rule"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, reordered, undeclared)).toContain(
+      'must each declare change_type reorder',
+    );
+    const declared =
+      '"changed_blocks": [{"block_id": "B0002", "protocol_basis": "order rule", "change_type": "reorder"}, {"block_id": "B0003", "protocol_basis": "order rule", "change_type": "reorder"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, reordered, declared)).toBeNull();
+  });
+
+  it('rejects a Unicode-suffixed block_id exactly like the Rust word boundary', () => {
+    // The Rust regex word boundary is Unicode: "B0002é" does NOT match the
+    // block_id pattern on the desktop (é is a word character), so the entry is
+    // ignored and the change stays undeclared. A JS ASCII boundary would
+    // wrongly match and accept the declaration.
+    const after = '# Titulo\n\nParagrafo corrigido com base protocolar.\n\nReferencia pendente citada.';
+    const report =
+      '"changed_blocks": [{"block_id": "B0002é", "protocol_basis": "precision rule"}]\n"custody": "revised"';
+    const error = validateRevisionContentLock(BEFORE, after, report);
+    expect(error).toContain('without matching changed_blocks declaration');
+    expect(error).toContain('B0002');
+  });
+  it('mirrors the Rust regex whitespace and digit classes in field extraction', () => {
+    const after = '# Titulo\n\nParagrafo corrigido com base protocolar.\n\nReferencia pendente citada.';
+    // U+0085 (NEL) is Rust \s but not JS \s: the assignment gap must accept it.
+    const nelReport =
+      '"changed_blocks": [{"block_id":\u0085"B0002", "protocol_basis": "precision rule"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, after, nelReport)).toBeNull();
+    // U+FEFF is JS \s but NOT Rust \s: the declaration must be ignored.
+    const feffReport =
+      '"changed_blocks": [{"block_id":\uFEFF"B0002", "protocol_basis": "precision rule"}]\n"custody": "revised"';
+    const feffError = validateRevisionContentLock(BEFORE, after, feffReport);
+    expect(feffError).toContain('without matching changed_blocks declaration');
+    // Rust \d is Unicode Nd: a declaration keyed by Arabic-Indic digits is
+    // still parsed on the desktop, so its change_type addition allows growth.
+    const grown = `${BEFORE}\n\nBloco novo acrescentado.`;
+    const arabicReport =
+      '"changed_blocks": [{"block_id": "B\u0660\u0661\u0662\u0663", "protocol_basis": "x", "change_type": "addition"}]\n"custody": "revised"';
+    expect(validateRevisionContentLock(BEFORE, grown, arabicReport)).toBeNull();
+  });
+  it('reads bare (non-JSON) changed_blocks lines via the block_id fallback', () => {
+    const after = '# Titulo\n\nParagrafo corrigido com base protocolar.\n\nReferencia pendente citada.';
+    const report = 'changed_blocks:\n- block_id: B0002, protocol_basis: precision clause\ncustody: revised';
+    expect(validateRevisionContentLock(BEFORE, after, report)).toBeNull();
+  });
+});

--- a/admin-motor/src/handlers/routes/maestro-ai/content-lock.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/content-lock.ts
@@ -1,0 +1,464 @@
+// Approved-content lock — byte-exact port of maestro-app (canonical)
+// src-tauri/src/editorial_content_lock.rs. Blocks are segmented on blank
+// lines, identified as B0001.., and compared via whitespace-normalized text;
+// a revised custody may only change/reorder/grow blocks that the
+// maestro_revision_report declares in a changed_blocks section with
+// protocol_basis (and change_type split/addition/reorder where applicable).
+//
+// Implementation note (documented deviation): the desktop keys block equality
+// by sha256(normalized_text); this port keys by the normalized text itself —
+// the equality relation is identical and no hash is exposed by validation.
+// The prompt-side manifest column (sha256_12) belongs to Plan F.
+
+type EditorialContentBlock = {
+  id: string;
+  normalizedKey: string;
+};
+
+type ChangedBlockDeclaration = {
+  hasProtocolBasis: boolean;
+  allowsBlockCountGrowth: boolean;
+  allowsReorder: boolean;
+};
+
+// Rust char::is_whitespace = Unicode White_Space (same class as the Plan A
+// helpers in sessions.ts; duplicated locally to keep this module standalone
+// like its desktop counterpart).
+const WS_CLASS = '[\\t\\n\\u000B\\f\\r \\u0085\\u00A0\\u1680\\u2000-\\u200A\\u2028\\u2029\\u202F\\u205F\\u3000]';
+const WS_RUN = new RegExp(`${WS_CLASS}+`, 'g');
+const WS_EDGES = new RegExp(`^${WS_CLASS}+|${WS_CLASS}+$`, 'g');
+const WS_START = new RegExp(`^${WS_CLASS}+`);
+// Rust splits the bare protocol_basis token on char::is_whitespace or , } ].
+const BARE_TOKEN_BOUNDARY = new RegExp(`${WS_CLASS}|[,}\\]]`);
+// Field-extraction regexes mirror the Rust regex crate classes exactly:
+// \s there is Unicode White_Space (NEL in, FEFF out) -> WS_CLASS here;
+// \d there is Unicode \p{Nd}; the trailing boundary is the Unicode word
+// class ([\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}]) as a negative
+// lookahead, since JS \b/\s/\d are ASCII or ES-specific classes.
+const BLOCK_ID_FIELD = new RegExp(
+  `["']?block_id["']?${WS_CLASS}*[:=]${WS_CLASS}*["']?(B\\p{Nd}{4})(?![\\p{Alphabetic}\\p{M}\\p{Nd}\\p{Pc}\\p{Join_Control}])`,
+  'isu',
+);
+const PROTOCOL_BASIS_KEY = new RegExp(`["']?protocol_basis["']?${WS_CLASS}*[:=]${WS_CLASS}*`, 'isu');
+
+function rustTrim(text: string): string {
+  return text.replace(WS_EDGES, '');
+}
+
+function rustTrimStart(text: string): string {
+  return text.replace(WS_START, '');
+}
+
+function asciiLowercase(text: string): string {
+  return text.replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+function normalizeBlockText(text: string): string {
+  return text.split(WS_RUN).filter(Boolean).join(' ');
+}
+
+export function segmentEditorialBlocks(text: string): EditorialContentBlock[] {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n\n')
+    .map((rawBlock) => rustTrim(rawBlock))
+    .filter((block) => block !== '')
+    .map((block, index) => ({
+      id: `B${String(index + 1).padStart(4, '0')}`,
+      normalizedKey: normalizeBlockText(block),
+    }));
+}
+
+export function validateRevisionContentLock(before: string, after: string, report: string): string | null {
+  const beforeBlocks = segmentEditorialBlocks(before);
+  const afterBlocks = segmentEditorialBlocks(after);
+  const changedIds = changedReceivedBlockIds(beforeBlocks, afterBlocks);
+  const reorderedIds = reorderedReceivedBlockIds(beforeBlocks, afterBlocks);
+  const reordered = reorderedIds.length > 0;
+  const changedSection = extractChangedBlocksSection(report);
+  if (changedSection === null) {
+    if (changedIds.length === 0 && afterBlocks.length <= beforeBlocks.length && !reordered) {
+      return null;
+    }
+    if (reordered) {
+      return `approved-content lock violation: revised custody reordered received blocks ${reorderedIds.join(', ')} but maestro_revision_report has no changed_blocks section with change_type reorder`;
+    }
+    return `approved-content lock violation: revised custody changed received blocks ${changedIds.join(', ')} but maestro_revision_report has no changed_blocks section with block IDs`;
+  }
+  const declarations = extractChangedBlockDeclarations(changedSection);
+
+  const undeclared = changedIds.filter((id) => !declarations.has(id));
+  if (undeclared.length > 0) {
+    return `approved-content lock violation: changed received blocks ${undeclared.join(', ')} without matching changed_blocks declaration`;
+  }
+
+  const idsRequiringProtocolBasis = [...changedIds];
+  for (const id of reorderedIds) {
+    if (!idsRequiringProtocolBasis.includes(id)) idsRequiringProtocolBasis.push(id);
+  }
+
+  const missingProtocolBasis = idsRequiringProtocolBasis.filter((id) => {
+    const declaration = declarations.get(id);
+    return declaration ? !declaration.hasProtocolBasis : false;
+  });
+  if (missingProtocolBasis.length > 0) {
+    return `approved-content lock violation: changed_blocks entries for ${missingProtocolBasis.join(', ')} must include protocol_basis`;
+  }
+
+  if (
+    afterBlocks.length > beforeBlocks.length &&
+    ![...declarations.values()].some((declaration) => declaration.allowsBlockCountGrowth)
+  ) {
+    return 'approved-content lock violation: revised custody added new blocks without declaring change_type split/addition in changed_blocks';
+  }
+
+  if (
+    reordered &&
+    !reorderedIds.every((id) => {
+      const declaration = declarations.get(id);
+      return declaration ? declaration.allowsReorder : false;
+    })
+  ) {
+    const missingReorder = reorderedIds.filter((id) => {
+      const declaration = declarations.get(id);
+      return declaration ? !declaration.allowsReorder : true;
+    });
+    return `approved-content lock violation: reordered received blocks ${missingReorder.join(', ')} must each declare change_type reorder in changed_blocks`;
+  }
+
+  return null;
+}
+
+function changedReceivedBlockIds(
+  beforeBlocks: EditorialContentBlock[],
+  afterBlocks: EditorialContentBlock[],
+): string[] {
+  const afterKeyCounts = new Map<string, number>();
+  for (const after of afterBlocks) {
+    afterKeyCounts.set(after.normalizedKey, (afterKeyCounts.get(after.normalizedKey) ?? 0) + 1);
+  }
+  const changed: string[] = [];
+  for (const before of beforeBlocks) {
+    const count = afterKeyCounts.get(before.normalizedKey) ?? 0;
+    if (count === 0) {
+      changed.push(before.id);
+    } else {
+      afterKeyCounts.set(before.normalizedKey, count - 1);
+    }
+  }
+  return changed;
+}
+
+function reorderedReceivedBlockIds(
+  beforeBlocks: EditorialContentBlock[],
+  afterBlocks: EditorialContentBlock[],
+): string[] {
+  const commonCounts = commonNormalizedKeyCounts(beforeBlocks, afterBlocks);
+  let total = 0;
+  for (const count of commonCounts.values()) total += count;
+  if (total <= 1) return [];
+
+  const beforeSequence = commonBlockIdSequence(beforeBlocks, beforeBlocks, commonCounts);
+  const afterSequence = commonBlockIdSequence(beforeBlocks, afterBlocks, commonCounts);
+  if (beforeSequence.join(' ') === afterSequence.join(' ')) return [];
+
+  const beforePositions = new Map(beforeSequence.map((id, index) => [id, index]));
+  const afterPositions = new Map(afterSequence.map((id, index) => [id, index]));
+  return beforeSequence.filter((id) => beforePositions.get(id) !== afterPositions.get(id));
+}
+
+function commonNormalizedKeyCounts(
+  beforeBlocks: EditorialContentBlock[],
+  afterBlocks: EditorialContentBlock[],
+): Map<string, number> {
+  const beforeCounts = new Map<string, number>();
+  const afterCounts = new Map<string, number>();
+  for (const block of beforeBlocks) {
+    beforeCounts.set(block.normalizedKey, (beforeCounts.get(block.normalizedKey) ?? 0) + 1);
+  }
+  for (const block of afterBlocks) {
+    afterCounts.set(block.normalizedKey, (afterCounts.get(block.normalizedKey) ?? 0) + 1);
+  }
+  const commonCounts = new Map<string, number>();
+  for (const [key, beforeCount] of beforeCounts) {
+    const afterCount = afterCounts.get(key);
+    if (afterCount !== undefined) {
+      commonCounts.set(key, Math.min(beforeCount, afterCount));
+    }
+  }
+  return commonCounts;
+}
+
+function commonBlockIdSequence(
+  beforeBlocks: EditorialContentBlock[],
+  orderedBlocks: EditorialContentBlock[],
+  commonCounts: Map<string, number>,
+): string[] {
+  const idsByKey = new Map<string, string[]>();
+  const remainingForIds = new Map(commonCounts);
+  for (const block of beforeBlocks) {
+    const count = remainingForIds.get(block.normalizedKey);
+    if (count !== undefined && count > 0) {
+      const ids = idsByKey.get(block.normalizedKey);
+      if (ids) {
+        ids.push(block.id);
+      } else {
+        idsByKey.set(block.normalizedKey, [block.id]);
+      }
+      remainingForIds.set(block.normalizedKey, count - 1);
+    }
+  }
+
+  const remaining = new Map(commonCounts);
+  const sequence: string[] = [];
+  for (const block of orderedBlocks) {
+    const count = remaining.get(block.normalizedKey);
+    if (count !== undefined && count > 0) {
+      const ids = idsByKey.get(block.normalizedKey);
+      const id = ids?.shift();
+      if (id !== undefined) sequence.push(id);
+      remaining.set(block.normalizedKey, count - 1);
+    }
+  }
+  return sequence;
+}
+
+function extractChangedBlocksSection(report: string): string | null {
+  const lower = asciiLowercase(report);
+  const start = findFirstReportFieldKey(lower, ['changed_blocks', 'changes']);
+  if (start === null) return null;
+  const relativeEnd = findFirstReportFieldKey(lower.slice(start + 1), [
+    'operator_evidence_required',
+    'out_of_scope',
+    'quality_preservation',
+    'unchanged_approved_blocks',
+    'custody',
+  ]);
+  const end = relativeEnd === null ? report.length : start + 1 + relativeEnd;
+  return report.slice(start, end);
+}
+
+// Rust u8::is_ascii_whitespace: space, tab, LF, CR and form feed.
+function isAsciiWhitespaceChar(character: string): boolean {
+  return character === ' ' || character === '\t' || character === '\n' || character === '\r' || character === '\f';
+}
+
+function findFirstReportFieldKey(haystack: string, keys: string[]): number | null {
+  let index = 0;
+  let inQuote: string | null = null;
+  let escaped = false;
+  while (index < haystack.length) {
+    const character = haystack.charAt(index);
+    if (inQuote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === inQuote) {
+        inQuote = null;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      const fieldStart = index;
+      const endQuote = haystack.indexOf(character, index + 1);
+      if (endQuote !== -1) {
+        const candidate = haystack.slice(index + 1, endQuote);
+        const after = endQuote + 1;
+        if (
+          keys.includes(candidate) &&
+          fieldKeyIsDelimitedBefore(haystack, fieldStart) &&
+          fieldKeyHasAssignmentAfter(haystack, after)
+        ) {
+          return fieldStart;
+        }
+      }
+      inQuote = character;
+      index += 1;
+      continue;
+    }
+    if (fieldKeyIsDelimitedBefore(haystack, index)) {
+      for (const key of keys) {
+        if (haystack.startsWith(key, index)) {
+          const after = index + key.length;
+          if (fieldKeyHasAssignmentAfter(haystack, after)) {
+            return index;
+          }
+        }
+      }
+    }
+    index += 1;
+  }
+  return null;
+}
+
+function fieldKeyIsDelimitedBefore(haystack: string, index: number): boolean {
+  if (index === 0) return true;
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    const character = haystack.charAt(cursor);
+    if (isAsciiWhitespaceChar(character)) continue;
+    return character === '{' || character === '[' || character === ',' || character === '\n' || character === '\r';
+  }
+  return true;
+}
+
+function fieldKeyHasAssignmentAfter(haystack: string, index: number): boolean {
+  for (let cursor = index; cursor < haystack.length; cursor += 1) {
+    const character = haystack.charAt(cursor);
+    if (isAsciiWhitespaceChar(character)) continue;
+    return character === ':' || character === '=';
+  }
+  return false;
+}
+
+function extractChangedBlockDeclarations(section: string): Map<string, ChangedBlockDeclaration> {
+  const declarations = new Map<string, ChangedBlockDeclaration>();
+  for (const fragment of changedBlockEntryFragments(section)) {
+    const blockId = extractBlockIdField(fragment);
+    if (blockId === null) continue;
+    const declaration: ChangedBlockDeclaration = {
+      hasProtocolBasis: fragmentHasNonemptyProtocolBasis(fragment),
+      allowsBlockCountGrowth: fragmentDeclaresBlockCountGrowth(fragment),
+      allowsReorder: fragmentDeclaresReorder(fragment),
+    };
+    const existing = declarations.get(blockId);
+    if (existing) {
+      existing.hasProtocolBasis ||= declaration.hasProtocolBasis;
+      existing.allowsBlockCountGrowth ||= declaration.allowsBlockCountGrowth;
+      existing.allowsReorder ||= declaration.allowsReorder;
+    } else {
+      declarations.set(blockId, declaration);
+    }
+  }
+  return declarations;
+}
+
+function changedBlockEntryFragments(section: string): string[] {
+  const fragments: string[] = [];
+  let depth = 0;
+  let start: number | null = null;
+  for (let index = 0; index < section.length; index += 1) {
+    const character = section.charAt(index);
+    if (character === '{') {
+      if (depth === 0) start = index;
+      depth += 1;
+    } else if (character === '}' && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && start !== null) {
+        fragments.push(section.slice(start, index + 1));
+        start = null;
+      }
+    }
+  }
+  if (fragments.length === 0) {
+    for (const line of section.split('\n')) {
+      if (asciiLowercase(line).includes('block_id')) fragments.push(line);
+    }
+  }
+  return fragments;
+}
+
+function extractBlockIdField(fragment: string): string | null {
+  const match = BLOCK_ID_FIELD.exec(fragment);
+  return match?.[1] ?? null;
+}
+
+function fragmentHasNonemptyProtocolBasis(fragment: string): boolean {
+  const match = PROTOCOL_BASIS_KEY.exec(fragment);
+  if (!match) return false;
+  return protocolBasisValueIsNonempty(fragment.slice(match.index + match[0].length));
+}
+
+function protocolBasisValueIsNonempty(value: string): boolean {
+  const trimmed = rustTrimStart(value);
+  if (trimmed === '') return false;
+  if (trimmed.startsWith('"')) return quotedValueIsNonempty(trimmed.slice(1), '"');
+  if (trimmed.startsWith("'")) return quotedValueIsNonempty(trimmed.slice(1), "'");
+  if (trimmed.startsWith('[')) return bracketedValueIsNonempty(trimmed.slice(1), '[', ']');
+  if (trimmed.startsWith('{')) return bracketedValueIsNonempty(trimmed.slice(1), '{', '}');
+  const bareValue = rustTrim(trimmed.split(BARE_TOKEN_BOUNDARY)[0] ?? '');
+  return bareValue !== '' && asciiLowercase(bareValue) !== 'null' && bareValue !== '[]' && bareValue !== '{}';
+}
+
+function quotedValueIsNonempty(rest: string, quote: string): boolean {
+  let escaped = false;
+  let value = '';
+  for (const character of rest) {
+    if (escaped) {
+      value += character;
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === quote) {
+      return rustTrim(value) !== '';
+    }
+    value += character;
+  }
+  return false;
+}
+
+function bracketedValueIsNonempty(rest: string, open: string, close: string): boolean {
+  let depth = 1;
+  let body = '';
+  let inQuote: string | null = null;
+  let escaped = false;
+  for (const character of rest) {
+    if (inQuote !== null) {
+      body += character;
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === inQuote) {
+        inQuote = null;
+      }
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      inQuote = character;
+      body += character;
+      continue;
+    }
+    if (character === open) {
+      depth += 1;
+      body += character;
+      continue;
+    }
+    if (character === close) {
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) {
+        return rustTrim(body) !== '';
+      }
+      body += character;
+      continue;
+    }
+    body += character;
+  }
+  return false;
+}
+
+function fragmentDeclaresBlockCountGrowth(fragment: string): boolean {
+  const lower = asciiLowercase(fragment);
+  return (
+    lower.includes('change_type') &&
+    (lower.includes('split') ||
+      lower.includes('addition') ||
+      lower.includes('added') ||
+      lower.includes('new_block') ||
+      lower.includes('new block'))
+  );
+}
+
+function fragmentDeclaresReorder(fragment: string): boolean {
+  const lower = asciiLowercase(fragment);
+  return (
+    lower.includes('change_type') &&
+    (lower.includes('reorder') || lower.includes('reordered') || lower.includes('move') || lower.includes('moved'))
+  );
+}

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -956,10 +956,53 @@ describe('runSession orchestrator', () => {
     expect(db.__sessions.get('run-1')?.status).toBe('converged');
   });
 
+  it('sends an undeclared block change to corrective retry via the approved-content lock', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    let codexCalls = 0;
+    const codexBodies: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (hostOf(url) === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'Rascunho valido e completo.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (hostOf(url) === 'api.openai.com') {
+        codexCalls += 1;
+        codexBodies.push(String(init?.body ?? ''));
+        const text =
+          codexCalls === 1
+            ? 'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "revised"\nchanges: ["rewrote the paragraph"]</maestro_revision_report>\n<maestro_final_text>Texto reescrito sem declarar blocos.</maestro_final_text>'
+            : 'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>';
+        return new Response(JSON.stringify({ output_text: text, usage: { input_tokens: 10, output_tokens: 20 } }), {
+          status: 200,
+        });
+      }
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    // The undeclared block change is a content-lock CONTRACT_VIOLATION: the
+    // same reviewer is retried and the original custody text survives.
+    expect(codexCalls).toBe(2);
+    expect(codexBodies[1]).toContain('Mandatory Corrective Retry');
+    expect(db.__sessions.get('run-1')?.status).toBe('converged');
+    expect(db.__sessions.get('run-1')?.final_text).toBe('Rascunho valido e completo.');
+  });
+
   it('accepts READY with a substantive revision as a normal turn (desktop bans inversion)', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
     const revised = 'Texto revisado, mais preciso e completo, sem marcadores pendentes.';
-    const codexText = `MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "revised"\nchanges: ["improved precision"]\nprotocol basis: precision rule</maestro_revision_report>\n<maestro_final_text>${revised}</maestro_final_text>`;
+    // changed_blocks leads the report: the canonical section finder recognizes
+    // the key at report start or after {, [ or , (a preceding quoted value
+    // line would hide it, matching the desktop parser).
+    const codexText = `MAESTRO_STATUS: READY\n<maestro_revision_report>changed_blocks: [{"block_id": "B0001", "protocol_basis": "precision rule"}]\ncustody: "revised"</maestro_revision_report>\n<maestro_final_text>${revised}</maestro_final_text>`;
     vi.stubGlobal('fetch', providerFetch({ claudeText: 'Rascunho original razoavel e completo.', codexText }));
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
@@ -978,6 +1021,7 @@ describe('runSession orchestrator', () => {
     const db = createInMemoryDb({
       sessions: [runnableSession({ active_agents_json: JSON.stringify(['claude', 'deepseek']) })],
     });
+    let deepseekCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (hostOf(url) === 'api.anthropic.com') {
@@ -990,7 +1034,8 @@ describe('runSession orchestrator', () => {
         );
       }
       if (hostOf(url) === 'api.deepseek.com') {
-        const text = `MAESTRO_STATUS: NOT_READY\n<maestro_revision_report>custody: "revised"\nchanges: ["trimmed"]</maestro_revision_report>\n<maestro_final_text>${shrunk}</maestro_final_text>`;
+        deepseekCalls += 1;
+        const text = `MAESTRO_STATUS: NOT_READY\n<maestro_revision_report>changed_blocks: [{"block_id": "B0001", "protocol_basis": "concision rule"}]\ncustody: "revised"</maestro_revision_report>\n<maestro_final_text>${shrunk}</maestro_final_text>`;
         return new Response(
           JSON.stringify({
             choices: [{ message: { content: text } }],
@@ -1008,6 +1053,8 @@ describe('runSession orchestrator', () => {
     const row = db.__sessions.get('run-1');
     expect(row?.current_text).toBe(original.trim());
     expect(row?.status).toBe('blocked_max_cycles');
+    // Exactly one call: the tier guard rejects without a corrective retry.
+    expect(deepseekCalls).toBe(1);
   });
 
   it('marks the session as error when a reviewer returns empty text', async () => {

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import { toHeaders } from '../../../../../functions/api/_lib/mainsite-admin';
+import { validateRevisionContentLock } from './content-lock.ts';
 
 type D1Database = {
   prepare(query: string): {
@@ -2271,6 +2272,13 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
                 custodyReleaseError ??
                 'NOT_READY unchanged is not a valid serial-review outcome: the reviewer must either return READY unchanged when no blocker remains, or return a revised complete text that resolves the concrete blocker.';
             }
+          }
+          if (!contractError && revisedText !== null) {
+            // Desktop parity (validate_serial_revised_content_lock): a revised
+            // custody may only change/reorder/grow blocks declared in the
+            // report's changed_blocks section; violations take the same
+            // CONTRACT_VIOLATION corrective-retry path.
+            contractError = validateRevisionContentLock(currentText, revisedText, report ?? '');
           }
           if (contractError) {
             const retryKey = `${cycle}:${order.indexOf(reviewer)}:${reviewer}:${currentText}`;

--- a/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-b2.md
+++ b/docs/superpowers/plans/2026-07-05-maestro-ai-parity-plan-b2.md
@@ -1,0 +1,26 @@
+# Maestro AI Parity Plan B2 — Approved-Content Lock (executado)
+
+> Registro do ship; fonte canônica: `maestro-app/src-tauri/src/editorial_content_lock.rs` (959 linhas; lógica 1-607, testes oracle 608+).
+
+**Goal:** Portar a trava soberana de conteúdo aprovado: uma custódia revisada só pode alterar/reordenar/crescer blocos declarados na seção `changed_blocks` do relatório, com `protocol_basis` não-vazio e `change_type` split/addition (crescimento) ou reorder (reordenação).
+
+## Entregue
+
+- Novo módulo `admin-motor/src/handlers/routes/maestro-ai/content-lock.ts` — port byte-exato e standalone (espelha a modularidade do desktop):
+  - `segmentEditorialBlocks`: CRLF→LF, split em `\n\n`, trim canônico (classe White_Space do Rust), IDs `B0001…`.
+  - `validateRevisionContentLock(before, after, report)`: mesma ordem e strings exatas dos 5 erros do desktop (sem seção com mudança/reordenação; bloco alterado sem declaração; `protocol_basis` ausente; crescimento sem split/addition; reordenação sem reorder por bloco).
+  - Detecção de mudança/reordenação por multiconjunto de chaves normalizadas (`changed_received_block_ids`, `reordered_received_block_ids` com sequência comum por hash e posições).
+  - Localizador de seção (`extract_changed_blocks_section` + `find_first_report_field_key`): chave `changed_blocks`/`changes` reconhecida no início, ou após `{`/`[`/`,` (pulando whitespace ASCII), com chaves entre aspas suportadas; fim da seção na próxima chave de {operator_evidence_required, out_of_scope, quality_preservation, unchanged_approved_blocks, custody}.
+  - Declarações por fragmento `{...}` (profundidade de chaves) com fallback por linhas contendo `block_id`; valores quoted/bracketed/bare com as mesmas regras de não-vazio; keywords de `change_type` idênticas.
+  - **Regexes de extração com classes canônicas (achados do cross-review, red-first)**: o `\b`/`\s`/`\d` do regex crate do Rust são Unicode (White_Space com NEL e sem FEFF; `\p{Nd}`; word class `[\p{Alphabetic}\p{M}\p{Nd}\p{Pc}\p{Join_Control}]`), enquanto os do JS são ASCII/ES — `BLOCK_ID_FIELD` e `PROTOCOL_BASIS_KEY` são construídas de `WS_CLASS` + `\p{Nd}` + lookahead negativo da word class, com testes de paridade para `B0002é`, NEL, FEFF e dígitos árabes.
+- Wiring em `runSession`: após `validateSerialTurnOutput` passar e havendo `<maestro_final_text>`, `validateRevisionContentLock` roda ANTES do tier guard (ordem canônica: sessões 1591 < 1677); violação segue o mesmo caminho CONTRACT_VIOLATION → retry corretivo ×3 → skip.
+
+## Desvio de implementação documentado
+
+- O desktop chaveia igualdade de bloco por `sha256(texto_normalizado)`; o port usa o próprio texto normalizado como chave — relação de igualdade idêntica, nenhum hash é exposto pela validação (crypto.subtle é assíncrono em Workers). A coluna `sha256_12` do manifest de prompt pertence ao Plano F.
+
+## Testes
+
+- `content-lock.test.ts` (8 testes, oracle do desktop incl. o teste canônico B0002-sem-declaração): segmentação, revisão inalterada/cosmética, drop não-declarado é violação, mudança sem seção, declaração sem `protocol_basis`, crescimento sem/com `change_type addition`, reordenação sem/com `reorder` por bloco, fallback bare (não-JSON).
+- Integração em `sessions.test.ts`: mudança de bloco não-declarada → CONTRACT_VIOLATION com retry corretivo e custódia preservada; fixtures dos testes de bans-inversion e tier-guard atualizados para a forma canônica de relatório (`changed_blocks` liderando — o localizador não reconhece a chave precedida por linha de valor quoted, igual ao desktop) e asserção de chamada única no tier guard.
+- Suíte completa 148/148.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.05.00';
+const APP_VERSION = 'APP v02.06.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary
Plan B2 of the A–F parity roadmap: ports the desktop's sovereign approved-content lock (`editorial_content_lock.rs`) to a new standalone `content-lock.ts` module, wired into the revision turn **between** the serial-turn contract and the tier quality guard (canonical order).

- Blocks segmented on blank lines (`B0001…`), compared by canonical whitespace-normalized text (equality relation identical to the desktop's sha256 keying — documented deviation, no hash exposed by validation).
- A revised custody may only change/drop/reorder/grow blocks declared in the report's `changed_blocks` section, each with non-empty `protocol_basis`; block-count growth requires `change_type` split/addition and reorder requires `change_type` reorder per moved block — with the desktop's exact five error strings and precedence.
- Violations take the Plan B1 CONTRACT_VIOLATION corrective-retry path.
- Field-extraction regexes are built from the canonical Unicode classes (White_Space with NEL-in/FEFF-out, `\p{Nd}`, Unicode word-class negative lookahead) after cross-review caught the JS ASCII `\b`/`\s`/`\d` divergences — locked by red-first parity tests (`B0002é`, NEL, FEFF, Arabic-Indic digits).

## Testing
- 10 unit tests in `content-lock.test.ts` (including the canonical desktop oracle test and the Unicode regex parity matrix) + 1 new integration test (undeclared block change → corrective retry, custody preserved) — all red-first; full suite **150/150**.
- Typecheck baseline clean; eslint/biome/prettier/markdownlint green.
- Cross-review session 8b160ebb: 3 rounds; codex's two real regex-parity findings fixed red-first; **round 3 unanimous READY** (caller + codex, gemini, deepseek, grok, perplexity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)