### PR TITLE
fix(maestro-ai): teach the revision prompt the block contract the lock enforces (v02.06.01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.06.01] - 2026-07-05
+
+### Corrigido
+
+- **Maestro AI — prompt de revisão passa a ensinar o contrato de blocos que o B2 impõe** (achado P1 do chatgpt-codex-connector no PR #298): o `buildRevisionPrompt` agora inclui a seção **Current Text Block Manifest** com a tabela canônica de blocos travados (`block_id`, `kind`, `chars`, `sha256_12` real via `crypto.subtle`, excerto), o esquema completo do relatório (`changed_blocks` com `block_id`/`change_type`/`protocol_basis`, `unchanged_approved_blocks`, `operator_evidence_required`) e o **Evidence and Bibliographic Integrity Gate** com as regras de outcome (NOT_READY+unchanged é violação; READY unchanged omite texto). Sem isso, revisões legítimas de agentes seguindo o prompt antigo cairiam em CONTRACT_VIOLATION→retry×3→skip por não declararem blocos que nunca lhes foram apresentados.
+
 ## [v02.06.00] - 2026-07-05
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/content-lock.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/content-lock.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { segmentEditorialBlocks, validateRevisionContentLock } from './content-lock.ts';
+import { formatBlockManifestForPrompt, segmentEditorialBlocks, validateRevisionContentLock } from './content-lock.ts';
 
 // Oracle fixtures mirror maestro-app editorial_content_lock.rs (canonical).
 const BEFORE = '# Titulo\n\nParagrafo aprovado e denso.\n\nReferencia pendente citada.';
@@ -117,5 +117,19 @@ describe('Maestro AI approved-content lock (Plan B2)', () => {
     const after = '# Titulo\n\nParagrafo corrigido com base protocolar.\n\nReferencia pendente citada.';
     const report = 'changed_blocks:\n- block_id: B0002, protocol_basis: precision clause\ncustody: revised';
     expect(validateRevisionContentLock(BEFORE, after, report)).toBeNull();
+  });
+
+  it('formats the block manifest exactly like the desktop prompt table', async () => {
+    const manifest = await formatBlockManifestForPrompt(BEFORE);
+    const lines = manifest.split('\n');
+    expect(lines[0]).toBe('| block_id | kind | chars | sha256_12 | locked_by_default | excerpt |');
+    expect(lines[1]).toBe('|---|---:|---:|---|---|---|');
+    expect(lines[2]).toContain('| B0001 | heading |');
+    expect(lines[3]).toContain('| B0002 | paragraph |');
+    expect(lines[2]).toContain('| yes |');
+    // sha256_12 column: 12 lowercase hex chars of the normalized block hash.
+    const sha12 = lines[2]?.split('|')[4]?.trim() ?? '';
+    expect(sha12).toMatch(/^[0-9a-f]{12}$/);
+    expect(await formatBlockManifestForPrompt('   ')).toBe('No editorial content blocks were detected.');
   });
 });

--- a/admin-motor/src/handlers/routes/maestro-ai/content-lock.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/content-lock.ts
@@ -13,6 +13,9 @@
 type EditorialContentBlock = {
   id: string;
   normalizedKey: string;
+  text: string;
+  kind: string;
+  chars: number;
 };
 
 type ChangedBlockDeclaration = {
@@ -67,7 +70,62 @@ export function segmentEditorialBlocks(text: string): EditorialContentBlock[] {
     .map((block, index) => ({
       id: `B${String(index + 1).padStart(4, '0')}`,
       normalizedKey: normalizeBlockText(block),
+      text: block,
+      kind: classifyBlockKind(block),
+      chars: Array.from(block).length,
     }));
+}
+
+// Desktop parity (classify_block_kind): heading/quote by leading marker, list
+// when every line starts with a bullet or ASCII digit, table when two or more
+// lines contain a pipe, else paragraph.
+function classifyBlockKind(text: string): string {
+  const trimmed = rustTrimStart(text);
+  if (trimmed.startsWith('#')) return 'heading';
+  if (trimmed.startsWith('>')) return 'quote';
+  const lines = trimmed.split('\n');
+  if (
+    lines.every((line) => {
+      const lineStart = rustTrimStart(line);
+      return lineStart.startsWith('- ') || lineStart.startsWith('* ') || /^[0-9]/.test(lineStart.charAt(0));
+    })
+  ) {
+    return 'list';
+  }
+  if (lines.filter((line) => line.includes('|')).length >= 2) return 'table';
+  return 'paragraph';
+}
+
+function markdownTableExcerpt(text: string): string {
+  const compact = normalizeBlockText(text).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  const characters = Array.from(compact);
+  let excerpt = characters.slice(0, 96).join('');
+  if (characters.length > 96) excerpt += '...';
+  return excerpt;
+}
+
+async function sha256Hex(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+// Desktop parity (format_block_manifest_for_prompt): the prompt-facing table
+// of locked blocks. The sha256_12 column here IS the desktop hash — computed
+// asynchronously via crypto.subtle over the normalized block text.
+export async function formatBlockManifestForPrompt(text: string): Promise<string> {
+  const blocks = segmentEditorialBlocks(text);
+  if (blocks.length === 0) return 'No editorial content blocks were detected.';
+  const lines = [
+    '| block_id | kind | chars | sha256_12 | locked_by_default | excerpt |',
+    '|---|---:|---:|---|---|---|',
+  ];
+  for (const block of blocks) {
+    const hash = await sha256Hex(block.normalizedKey);
+    lines.push(
+      `| ${block.id} | ${block.kind} | ${block.chars} | ${hash.slice(0, 12)} | yes | ${markdownTableExcerpt(block.text)} |`,
+    );
+  }
+  return lines.join('\n');
 }
 
 export function validateRevisionContentLock(before: string, after: string, report: string): string | null {

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -588,6 +588,42 @@ describe('Maestro AI desktop-parity parsing (Plan A)', () => {
   });
 });
 
+describe('Maestro AI revision prompt teaches the block contract', () => {
+  it('exposes the block manifest and changed_blocks schema in the revision prompt', async () => {
+    const prompt = await maestroAiTestHooks.buildRevisionPrompt({
+      input: {
+        title: 'Sessao',
+        prompt: 'Escreva.',
+        protocol_text: protocolText,
+        initial_agent: 'claude',
+        active_agents: ['claude', 'codex'],
+        initial_content: '',
+        max_cost_usd: 10,
+        max_runtime_minutes: null,
+        rates,
+        models: {},
+        max_cycles: 2,
+      } as Parameters<(typeof maestroAiTestHooks)['buildRevisionPrompt']>[0]['input'],
+      runId: 'run-1',
+      turn: 1,
+      currentText: '# Titulo\n\nCorpo do artigo em custodia.',
+      currentAuthor: 'claude',
+      reviewer: 'codex',
+      history: [],
+    });
+    expect(prompt).toContain('## Current Text Block Manifest');
+    expect(prompt).toContain('| block_id | kind | chars | sha256_12 | locked_by_default | excerpt |');
+    expect(prompt).toContain('| B0001 | heading |');
+    expect(prompt).toContain('changed_blocks: list every changed received block using block_id');
+    expect(prompt).toContain('unchanged_approved_blocks');
+    expect(prompt).toContain('change_type: "reorder"');
+    expect(prompt).toContain('## Evidence and Bibliographic Integrity Gate');
+    expect(prompt).toContain('Missing evidence by itself is not a sufficient reason to pass the blocker forward.');
+    expect(prompt).toContain('A text is not final-deliverable while it still depends on unresolved evidence markers');
+    expect(prompt).toContain('MAESTRO_STATUS: NOT_READY with custody: "unchanged" is a contract violation');
+  });
+});
+
 describe('Maestro AI serial turn contract (Plan B1)', () => {
   it('reportDeclaresCustodyValue mirrors JSON-first then scalar-scan semantics', () => {
     const { reportDeclaresCustodyValue } = maestroAiTestHooks;

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import { toHeaders } from '../../../../../functions/api/_lib/mainsite-admin';
-import { validateRevisionContentLock } from './content-lock.ts';
+import { formatBlockManifestForPrompt, validateRevisionContentLock } from './content-lock.ts';
 
 type D1Database = {
   prepare(query: string): {
@@ -1594,7 +1594,7 @@ ${input.protocol_text}
 `;
 }
 
-function buildRevisionPrompt(args: {
+async function buildRevisionPrompt(args: {
   input: MaestroResolvedSessionInput;
   runId: string;
   turn: number;
@@ -1602,7 +1602,8 @@ function buildRevisionPrompt(args: {
   currentAuthor: ProviderKey;
   reviewer: ProviderKey;
   history: SessionEvent[];
-}): string {
+}): Promise<string> {
+  const blockManifest = await formatBlockManifestForPrompt(args.currentText);
   return `# Maestro Editorial AI - Web/API Serial Review-Rewrite Turn
 
 Run: \`${args.runId}\`
@@ -1642,14 +1643,49 @@ Codex and Claude are the strongest long-form writers in this system. Gemini is s
 Preserve the strongest existing formulation unless a concrete editorial-protocol defect requires a narrow change.
 Do not reduce breadth, depth, articulation, nuance, reflexivity, or argumentative amplitude.
 
+## Evidence and Bibliographic Integrity Gate
+
+- Do not invent links, editions, publishers, years, URLs, page ranges, or source details.
+- If evidence is missing, do not pass [EVIDENCIA_PENDENTE], bracketed lacunae, or unsupported reference placeholders forward inside <maestro_final_text>.
+- Unverified claims or references are correctable defects when they can be removed, narrowed, generalized, or quarantined without damaging the article.
+- Do not convert evidence-pending markers into publicable references, bracketed lacunae, or bibliographic placeholders such as [s. d.], [S. l.: s. n.], or [Edição consultada não identificada].
+- If the current text depends on an unverified reference, source, link, or bibliographic detail, revise the article in this same turn by deleting, narrowing, generalizing, or quarantining that dependency unless the missing evidence or operator decision is truly indispensable.
+- Missing evidence by itself is not a sufficient reason to pass the blocker forward. First remove, narrow, generalize, or quarantine the unsupported claim/reference; request operator evidence only for a blocker that cannot be resolved by any of those editorial actions.
+- A text is not final-deliverable while it still depends on unresolved evidence markers or bibliographic lacunae.
+- A blocker that can be corrected with the current text, prior reports, supplied evidence, or the editorial protocol MUST be corrected in this same turn. Do not merely point it out or pass it to the next reviewer.
+- Do not return MAESTRO_STATUS: NOT_READY with custody set to "unchanged". That is an invalid pass-through objection.
+- If no concrete blocker remains, return MAESTRO_STATUS: READY, set custody to "unchanged", keep changes empty, and omit <maestro_final_text>.
+- If any concrete blocker remains, correct it in this same turn, return MAESTRO_STATUS: READY or MAESTRO_STATUS: NOT_READY according to the revised article's safety, set custody to "revised", and include the complete corrected article inside <maestro_final_text>.
+- Use operator_evidence_required only to document external evidence still desirable after you have already removed, narrowed, generalized, or quarantined the unsupported dependency in the revised article.
+
 ## Required Output Contract
 
 The answer MUST contain exactly these parts:
 
 1. First line: MAESTRO_STATUS: READY or MAESTRO_STATUS: NOT_READY.
-2. <maestro_revision_report> containing en_US JSON-like audit data with reviewer, current_author, status, changes, out_of_scope, quality_preservation, and custody.
+2. <maestro_revision_report> containing en_US JSON-like audit data:
+   - reviewer
+   - current_author
+   - status
+   - changed_blocks: list every changed received block using block_id, change_type, reason, protocol_basis, and required: true|false. Use change_type: "split" or "addition" whenever the revised article creates extra blocks, and change_type: "reorder" whenever approved blocks move.
+   - unchanged_approved_blocks: list approved block IDs that you intentionally preserved.
+   - changes: list of changed passages, received line/passage reference, reason, protocol citation, and whether the change was required.
+   - operator_evidence_required: list of blockers that cannot be corrected from supplied materials and require external evidence or operator decision.
+   - out_of_scope: concerns intentionally not changed.
+   - quality_preservation: explicit statement that approved strong formulations were preserved; if not, justify each reduction.
+   - custody: exactly "revised" when you changed the article, or exactly "unchanged" only when you approve the current article without changing custody.
 3. Include <maestro_final_text> containing only the complete operator-facing article in pt_BR only when custody is "revised".
-4. If custody is "unchanged", omit <maestro_final_text> entirely. Do not repeat the current article.
+4. If custody is "unchanged", status MUST be READY, changes MUST be empty, <maestro_final_text> MUST be omitted, and all remaining concerns must be non-blocking out_of_scope notes.
+5. MAESTRO_STATUS: NOT_READY with custody: "unchanged" is a contract violation: either fix the blocker and transfer revised custody, or approve the current version as READY unchanged.
+
+Anything outside those tags may be discarded by the app.
+An incomplete tag, missing closing tag, reproduced protocol text, or truncated JSON/report is a contract violation and will not count as READY.
+
+## Current Text Block Manifest
+
+Every received block is locked by default. If <maestro_final_text> changes, deletes, compresses, splits, moves, or replaces a received block, the corresponding received block_id MUST appear in changed_blocks with a concrete protocol_basis. Silent changes to approved blocks are contract violations. Extra blocks require change_type: "split" or "addition"; moved approved blocks require change_type: "reorder".
+
+${blockManifest}
 
 ## Operator Request
 
@@ -1888,6 +1924,7 @@ function publicApiHealthResult(
 
 export const maestroAiTestHooks = {
   buildProviderHttpRequest,
+  buildRevisionPrompt,
   publicApiHealthResult,
   extractStatus,
   extractTagged,
@@ -2200,7 +2237,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
                 : `Serial revision turn started in cycle ${cycle}.`,
           });
           const prompt =
-            buildRevisionPrompt({
+            (await buildRevisionPrompt({
               input,
               runId: id,
               turn: events.length + 1,
@@ -2208,7 +2245,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
               currentAuthor,
               reviewer,
               history: events,
-            }) + (correctiveRetryCount > 0 ? correctiveRetrySection(correctiveRetryCount) : '');
+            })) + (correctiveRetryCount > 0 ? correctiveRetrySection(correctiveRetryCount) : '');
           const rates = input.rates?.[reviewer] ?? {};
           const projected = estimateCost(prompt, MAX_OUTPUT_TOKENS, rates);
           if (!Number.isFinite(projected) || observedCost + projected > Number(input.max_cost_usd)) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.06.00';
+const APP_VERSION = 'APP v02.06.01';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary
Addresses the **P1 inline finding by chatgpt-codex-connector on PR #298**: the approved-content lock (v02.06.00) enforces `changed_blocks` declarations with block IDs and `protocol_basis`, but the revision prompt never taught that schema nor showed the `B0001…` IDs — ordinary prompt-compliant revisions would be reclassified CONTRACT_VIOLATION, retried 3× and skipped.

- `formatBlockManifestForPrompt` ported to `content-lock.ts`: the canonical locked-blocks table (`block_id | kind | chars | sha256_12 | locked_by_default | excerpt`) with the **real** sha256 (via `crypto.subtle`) of the normalized block text — byte-identical values to the desktop manifest; kind classifier and 96-char excerpt ported.
- `buildRevisionPrompt` (now async) gains the **complete** canonical Evidence and Bibliographic Integrity Gate, the full Required Output Contract report schema (`changed_blocks`, `unchanged_approved_blocks`, `operator_evidence_required`, custody rules 4–5, discard warnings) and the Current Text Block Manifest section.
- **P2 finding on PR #297 dispositioned as canonical parity** (no code change): the desktop gates its unrevised-turn corrective retry on `final_text.is_none()` (session_orchestration.rs:2003/2014) and accepts NOT_READY echoed-final-text turns without retry (1738–1760); the web does exactly the same.

## Testing
- Red-first tests: manifest table format vs the desktop columns + empty sentinel; prompt exposes manifest/schema/gate (10 containment assertions). Full suite **152/152**; all gates green.
- Cross-review session 8870435f: 7 rounds (codex extracted full gate fidelity — the three platform-neutral evidence bullets were restored verbatim); **round 7 unanimous READY**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)