### PR TITLE
feat(maestro-ai): resumable lifecycle and operational resilience (parity Plan C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.08.00] - 2026-07-06
+
+### Adicionado
+
+- **Maestro AI — lifecycle retomável e resiliência operacional (Plano C da equiparação com o maestro-app)**: sessões deixam de morrer em falhas transitórias e limites. (1) **Retry canônico de provider** (`provider_retry.rs`): máximo de 2 tentativas; erro de rede re-tenta uma vez após 1500 ms; **somente HTTP 429 re-tenta** aguardando `Retry-After` (delta em segundos ou data HTTP; default 30 s; teto 120 s); demais statuses seguem para classificação normal. Esperas canceláveis com check cooperativo fatiado (5 s). (2) **Falha operacional de turno não mata a sessão**: o turno é pulado com evento, preservando as aprovações estáveis (só violações as limpam); **3 falhas consecutivas** (incluindo exaustões de retry corretivo, paridade canônica) escalam para `paused_reviewer_outage`; falha no fechamento da rodada pausa como `paused_round_incomplete`. (3) **Draft com fallback serial**: o lead rascunha primeiro; erro/rascunho vazio passa ao próximo agente ativo; todos falhando pausa como `paused_draft_unavailable`. (4) **Tempo canônico**: âncora em `created_at` no run inicial e em `now` na retomada; exaustão = restante < 2 s, checada antes do draft e de cada turno; timeout por chamada acoplado ao deadline (`min(120 s, restante)`). (5) **Custo por execução** (cost_scope canônico): o cap passa a valer por execução do runner via baseline — retomadas não herdam o gasto anterior no guard. (6) **Retomada real**: novo endpoint `POST /api/maestro-ai/sessions/:id/resume` + botão **Retomar** na interface; somente `converged` é terminal — a família `paused_*` (renomeada de `blocked_cost`/`blocked_time`/`blocked_cycle_limit`/`blocked_round_incomplete`/`blocked_self_review`/`blocked_final_audit` para `paused_cost_limit`/`paused_time_limit`/`paused_cycle_limit`/`paused_round_incomplete`/`paused_self_review`/`paused_final_audit`), `blocked_cancelled`, `blocked_max_cycles`, `blocked_link_audit` e `error` são retomáveis. A retomada recupera só texto/autor da custódia (aprovações e contabilidade de rodada recomeçam vazias, paridade com a recuperação limitada do desktop), pula a fase de draft e re-audita os links. (7) **Cancel abortivo**: chamadas HTTP de provider correm com `AbortController` + poller cooperativo (5 s) que aborta a chamada em voo quando o operador cancela. Desvios web documentados no plano (`docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-c.md`).
+
 ## [v02.07.00] - 2026-07-06
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   handleMaestroAiArtifactsGet,
   handleMaestroAiSessionCancelPost,
   handleMaestroAiSessionContentPut,
+  handleMaestroAiSessionResumePost,
   handleMaestroAiSessionsGet,
   handleMaestroAiSessionsPost,
   handleMaestroAiSettingsGet,
@@ -209,32 +210,40 @@ function createInMemoryDb(seed: { settings?: Partial<Row>; sessions?: Row[]; art
     store.set(String(values[0]), row);
   };
 
-  const applyUpdate = (table: 'maestro_ai_sessions' | 'maestro_ai_settings', query: string, values: unknown[]) => {
+  // Mirrors D1's meta.changes: returns the number of rows the UPDATE modified,
+  // so a losing CAS write reports 0 changes like the real database.
+  const applyUpdate = (
+    table: 'maestro_ai_sessions' | 'maestro_ai_settings',
+    query: string,
+    values: unknown[],
+  ): number => {
     const setMatch = /SET\s+([\s\S]+?)\s+WHERE/i.exec(query);
-    if (!setMatch) return;
+    if (!setMatch) return 0;
     const assignments = (setMatch[1] ?? '').split(',').map((part) => part.trim());
     const setCols = assignments.map((a) => (a.split('=')[0] ?? '').trim());
     if (table === 'maestro_ai_settings') {
       setCols.forEach((col, i) => {
         settings[col] = values[i];
       });
-      return;
+      return 1;
     }
     const id = String(values[setCols.length]);
     const row = sessions.get(id);
-    if (!row) return;
+    if (!row) return 0;
     // Honor an optional "AND status IN (?, ?)" CAS guard.
     if (/status\s+IN/i.test(query)) {
       const guardStatuses = values.slice(setCols.length + 1).map(String);
-      if (guardStatuses.length && !guardStatuses.includes(String(row.status))) return;
+      if (guardStatuses.length && !guardStatuses.includes(String(row.status))) return 0;
     }
     setCols.forEach((col, i) => {
       row[col] = values[i];
     });
+    return 1;
   };
 
   const makeStatement = (query: string, values: unknown[]) => ({
     run: async () => {
+      let changes = 1;
       if (/INSERT INTO maestro_ai_sessions/i.test(query)) applyInsert(sessionColumns, sessions, values);
       else if (/INSERT INTO maestro_ai_artifacts/i.test(query)) applyInsert(artifactColumns, artifacts, values);
       else if (/INSERT INTO maestro_ai_settings/i.test(query)) {
@@ -264,9 +273,9 @@ function createInMemoryDb(seed: { settings?: Partial<Row>; sessions?: Row[]; art
           models_json: values[7],
           updated_at: values[8],
         });
-      } else if (/UPDATE maestro_ai_sessions/i.test(query)) applyUpdate('maestro_ai_sessions', query, values);
-      else if (/UPDATE maestro_ai_settings/i.test(query)) applyUpdate('maestro_ai_settings', query, values);
-      return { success: true };
+      } else if (/UPDATE maestro_ai_sessions/i.test(query)) changes = applyUpdate('maestro_ai_sessions', query, values);
+      else if (/UPDATE maestro_ai_settings/i.test(query)) changes = applyUpdate('maestro_ai_settings', query, values);
+      return { success: true, meta: { changes } };
     },
     first: async <T>() => {
       if (/FROM maestro_ai_settings/i.test(query)) return settings as T;
@@ -624,6 +633,128 @@ describe('Maestro AI revision prompt teaches the block contract', () => {
   });
 });
 
+describe('Maestro AI provider retry and time budget (Plan C)', () => {
+  it('parseRetryAfterHeader handles delta-seconds, HTTP-date and absence', () => {
+    const { parseRetryAfterHeader } = maestroAiTestHooks;
+    expect(parseRetryAfterHeader(new Headers({ 'retry-after': '7' }))).toBe(7);
+    expect(parseRetryAfterHeader(new Headers({ 'retry-after': ' 12 ' }))).toBe(12);
+    const future = new Date(Date.now() + 45_000).toUTCString();
+    const parsed = parseRetryAfterHeader(new Headers({ 'retry-after': future }));
+    expect(parsed).toBeGreaterThanOrEqual(43);
+    expect(parsed).toBeLessThanOrEqual(46);
+    const past = new Date(Date.now() - 60_000).toUTCString();
+    expect(parseRetryAfterHeader(new Headers({ 'retry-after': past }))).toBe(0);
+    expect(parseRetryAfterHeader(new Headers())).toBeNull();
+    expect(parseRetryAfterHeader(new Headers({ 'retry-after': 'garbage' }))).toBeNull();
+  });
+
+  it('remainingSessionMs and sessionTimeExhausted mirror the canonical 2s cutoff', () => {
+    const { remainingSessionMs, sessionTimeExhausted } = maestroAiTestHooks;
+    expect(remainingSessionMs(Date.now(), null)).toBeNull();
+    expect(sessionTimeExhausted(Date.now(), null)).toBe(false);
+    const fresh = remainingSessionMs(Date.now(), 10);
+    expect(fresh).toBeGreaterThan(9 * 60_000);
+    expect(sessionTimeExhausted(Date.now(), 10)).toBe(false);
+    // Anchor 10 minutes in the past with a 10-minute budget: exhausted.
+    expect(remainingSessionMs(Date.now() - 10 * 60_000, 10)).toBe(0);
+    expect(sessionTimeExhausted(Date.now() - 10 * 60_000, 10)).toBe(true);
+    // 1.5s remaining is below the canonical < 2s cutoff.
+    expect(sessionTimeExhausted(Date.now() - 10 * 60_000 + 1_500, 10)).toBe(true);
+    expect(sessionTimeExhausted(Date.now() - 10 * 60_000 + 30_000, 10)).toBe(false);
+  });
+
+  it('fetchProviderWithRetry retries 429 with Retry-After and network errors once', async () => {
+    const { fetchProviderWithRetry } = maestroAiTestHooks;
+    const never = async () => false;
+    // 429 then 200: waits Retry-After (0s here) and returns the second response.
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) return new Response('slow down', { status: 429, headers: { 'retry-after': '0' } });
+        return new Response('ok', { status: 200 });
+      }),
+    );
+    const ok = await fetchProviderWithRetry('https://api.test/x', {}, 5_000, never);
+    expect(ok).not.toBe('cancelled');
+    expect((ok as Response).status).toBe(200);
+    expect(calls).toBe(2);
+    // Second 429 is returned as-is (max 2 attempts).
+    calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        return new Response('slow', { status: 429, headers: { 'retry-after': '0' } });
+      }),
+    );
+    const still429 = await fetchProviderWithRetry('https://api.test/x', {}, 5_000, never);
+    expect((still429 as Response).status).toBe(429);
+    expect(calls).toBe(2);
+    // 500 never retries.
+    calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        return new Response('boom', { status: 500 });
+      }),
+    );
+    const err500 = await fetchProviderWithRetry('https://api.test/x', {}, 5_000, never);
+    expect((err500 as Response).status).toBe(500);
+    expect(calls).toBe(1);
+    // Network error retries exactly once, then throws.
+    calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        throw new Error('ECONNRESET');
+      }),
+    );
+    await expect(fetchProviderWithRetry('https://api.test/x', {}, 5_000, never)).rejects.toThrow('ECONNRESET');
+    expect(calls).toBe(2);
+    // Cancellation during the 429 wait returns the sentinel.
+    calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        calls += 1;
+        return new Response('slow', { status: 429, headers: { 'retry-after': '1' } });
+      }),
+    );
+    const cancelled = await fetchProviderWithRetry('https://api.test/x', {}, 5_000, async () => true);
+    expect(cancelled).toBe('cancelled');
+    expect(calls).toBe(1);
+    vi.unstubAllGlobals();
+  }, 30_000);
+
+  it('aborts an in-flight provider call when the session is cancelled (abortive cancel poller)', async () => {
+    const { fetchProviderWithRetry } = maestroAiTestHooks;
+    // A hung provider call that only settles when its AbortSignal fires.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+          }),
+      ),
+    );
+    let cancelled = false;
+    setTimeout(() => {
+      cancelled = true;
+    }, 1_000);
+    const startedAt = Date.now();
+    // 60s call timeout: without the abort poller this would hang for a minute.
+    const result = await fetchProviderWithRetry('https://api.test/x', {}, 60_000, async () => cancelled);
+    expect(result).toBe('cancelled');
+    // One poller tick (5s) after the 1s cancel flag: well under the call timeout.
+    expect(Date.now() - startedAt).toBeLessThan(20_000);
+    vi.unstubAllGlobals();
+  }, 30_000);
+});
 describe('Maestro AI stable-approval convergence and reviewer selection (Plan B3)', () => {
   it('hasAllIndependentApprovals requires every non-author agent in the stable set', () => {
     const { hasAllIndependentApprovals } = maestroAiTestHooks;
@@ -980,16 +1111,54 @@ describe('runSession orchestrator', () => {
     MAESTRO_OPENAI_API_KEY: 'k-codex',
   };
 
-  it('marks the session as error when the initial draft text is empty and never calls reviewers', async () => {
+  it('falls back to the next active agent when the initial draft text is empty (canonical draft fallback)', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
-    const fetchMock = providerFetch({ claudeText: '   ' });
+    // Claude (lead) returns a blank draft; codex must take over as draft author.
+    const fetchMock = providerFetch({
+      claudeText:
+        'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found</maestro_revision_report>',
+      codexText: 'Texto de rascunho de fallback robusto e completo.',
+    });
+    // Override: anthropic returns empty ONLY for the draft (first anthropic call).
+    let anthropicCalls = 0;
+    const withEmptyFirstDraft = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (hostOf(String(input)) === 'api.anthropic.com') {
+        anthropicCalls += 1;
+        if (anthropicCalls === 1) {
+          return new Response(
+            JSON.stringify({ content: [{ type: 'text', text: '   ' }], usage: { input_tokens: 1, output_tokens: 1 } }),
+            { status: 200 },
+          );
+        }
+      }
+      return fetchMock(input, init);
+    });
+    vi.stubGlobal('fetch', withEmptyFirstDraft);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    // codex drafted; claude (sole other reviewer) approved unchanged → converged.
+    const row = db.__sessions.get('run-1');
+    expect(row?.status).toBe('converged');
+    expect(row?.current_author).toBe('codex');
+    expect(row?.final_text).toBe('Texto de rascunho de fallback robusto e completo.');
+    const events = JSON.parse(String(row?.events_json)) as Array<{ message?: string }>;
+    expect(events.some((event) => /Draft attempt failed/.test(String(event.message)))).toBe(true);
+  });
+
+  it('pauses as paused_draft_unavailable when every active agent fails to draft', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const fetchMock = providerFetch({ claudeText: '   ', codexText: '   ' });
     vi.stubGlobal('fetch', fetchMock);
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
-    expect(db.__sessions.get('run-1')?.status).toBe('error');
-    expect(String(db.__sessions.get('run-1')?.error)).toMatch(/vazi|empty/i);
-    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.openai.com')).toBe(false);
+    const row = db.__sessions.get('run-1');
+    expect(row?.status).toBe('paused_draft_unavailable');
+    expect(String(row?.error)).toMatch(/failed to produce an initial draft/i);
+    // Both agents were tried for the draft.
+    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.anthropic.com')).toBe(true);
+    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.openai.com')).toBe(true);
   });
 
   it('converges when the sole reviewer returns READY without changing custody', async () => {
@@ -1115,14 +1284,14 @@ describe('runSession orchestrator', () => {
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
-    // The pass-through reviewer exhausts its corrective retries (4 calls),
-    // then every redraw re-selects it for one immediately-exhausted call
-    // (same canonical retry key), never counting as a valid round agent —
-    // so the closing redactor is NEVER scheduled and the serial turn cap
-    // ends the session. 4 + 7x1 = 11 calls across the 8 capped turns.
-    expect(codexCalls).toBe(11);
+    // The pass-through reviewer exhausts its corrective retries (4 calls) and
+    // each redraw re-selects it for one immediately-exhausted call (same
+    // canonical retry key), never counting as a valid round agent — so the
+    // closing redactor is NEVER scheduled. Since Plan C each exhausted turn is
+    // an operational failure: the 3rd consecutive one escalates. 4 + 1 + 1 = 6.
+    expect(codexCalls).toBe(6);
     expect(claudeReviewCalls).toBe(1); // draft only — the lead never reviews
-    expect(db.__sessions.get('run-1')?.status).toBe('blocked_cycle_limit');
+    expect(db.__sessions.get('run-1')?.status).toBe('paused_reviewer_outage');
   });
 
   it('accepts READY with a substantive revision as a normal turn (desktop bans inversion)', async () => {
@@ -1142,7 +1311,7 @@ describe('runSession orchestrator', () => {
     // circuit is incomplete (desktop PAUSED_ROUND_INCOMPLETE analog).
     expect(row?.current_text).toBe(revised);
     expect(row?.current_author).toBe('codex');
-    expect(row?.status).toBe('blocked_round_incomplete');
+    expect(row?.status).toBe('paused_round_incomplete');
   });
 
   it('rejects a lower-tier shrink revision and keeps custody unchanged (quality ratchet)', async () => {
@@ -1183,21 +1352,29 @@ describe('runSession orchestrator', () => {
     const row = db.__sessions.get('run-1');
     expect(row?.current_text).toBe(original.trim());
     // The guard keeps rejecting the only pending reviewer until the serial
-    // turn cap fires (desktop PAUSED_EDITORIAL_CYCLE_LIMIT analog).
-    expect(row?.status).toBe('blocked_cycle_limit');
+    // turn cap fires (desktop PAUSED_EDITORIAL_CYCLE_LIMIT analog). Ratchet
+    // rejections are clean provider responses, so no outage escalation fires.
+    expect(row?.status).toBe('paused_cycle_limit');
     // Every turn re-selects deepseek (the gated lead is never eligible), and
     // each rejection consumes one serial turn up to the cap of 8.
     expect(deepseekCalls).toBe(8);
   });
 
-  it('marks the session as error when a reviewer returns empty text', async () => {
+  it('escalates to paused_reviewer_outage after 3 consecutive empty reviewer turns (operational failures)', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
-    vi.stubGlobal('fetch', providerFetch({ claudeText: 'Rascunho valido e completo.', codexText: '   ' }));
+    const fetchMock = providerFetch({ claudeText: 'Rascunho valido e completo.', codexText: '   ' });
+    vi.stubGlobal('fetch', fetchMock);
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
-    expect(db.__sessions.get('run-1')?.status).toBe('error');
-    expect(String(db.__sessions.get('run-1')?.error)).toMatch(/vazi|empty/i);
+    const row = db.__sessions.get('run-1');
+    // Canonical 3-strike: each empty reviewer response is an operational turn
+    // failure that skips the turn; the third consecutive one pauses the session.
+    expect(row?.status).toBe('paused_reviewer_outage');
+    expect(String(row?.error)).toMatch(/consecutive reviewer turns failed/i);
+    expect(fetchMock.mock.calls.filter(([u]) => hostOf(u) === 'api.openai.com').length).toBe(3);
+    // The custody text survives the pause for a later resume.
+    expect(row?.current_text).toBe('Rascunho valido e completo.');
   });
 
   it('blocks the session when a link is persistently 5xx (broken after retry)', async () => {
@@ -1548,6 +1725,184 @@ describe('session cancellation and sweeper', () => {
     expect(db.__sessions.get('queued-stale')?.status).toBe('error');
     expect(db.__sessions.get('fresh')?.status).toBe('running');
     expect(db.__sessions.get('done')?.status).toBe('converged');
+  });
+
+  describe('session resume (Plan C)', () => {
+    const pausedRow = (overrides: Partial<Row> = {}): Row =>
+      activeRow({
+        id: 'r-1',
+        status: 'paused_cost_limit',
+        current_author: 'claude',
+        current_text: 'Rascunho valido e completo.',
+        // Lifetime spend already exceeds the cap: only the per-execution cost
+        // baseline lets the resumed run proceed.
+        observed_cost_usd: 19.9,
+        max_cost_usd: 20,
+        error: 'Cost guard blocked provider call.',
+        ...overrides,
+      });
+
+    const resumeContext = (sessionId: string, db: ReturnType<typeof createInMemoryDb>) => {
+      const captured: Promise<unknown>[] = [];
+      return {
+        context: {
+          env: {
+            BIGDATA_DB: db,
+            MAESTRO_ANTHROPIC_API_KEY: 'k-claude',
+            MAESTRO_OPENAI_API_KEY: 'k-codex',
+          },
+          request: new Request(`https://admin.local/api/maestro-ai/sessions/${sessionId}/resume`, { method: 'POST' }),
+          waitUntil: (promise: Promise<unknown>) => {
+            captured.push(promise);
+          },
+        },
+        captured,
+      };
+    };
+
+    const reviewerFetch = () =>
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (hostOf(String(input)) === 'api.openai.com') {
+          return new Response(
+            JSON.stringify({
+              output_text:
+                'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+              usage: { input_tokens: 10, output_tokens: 20 },
+            }),
+            { status: 200 },
+          );
+        }
+        if (hostOf(String(input)) === 'api.anthropic.com') {
+          throw new Error('draft must be skipped on resume');
+        }
+        return new Response('', { status: 200 });
+      });
+
+    it('resumes a paused_cost_limit session, skips the draft and converges under a fresh cost baseline', async () => {
+      const db = createInMemoryDb({ sessions: [pausedRow()] });
+      const fetchMock = reviewerFetch();
+      vi.stubGlobal('fetch', fetchMock);
+      const { context, captured } = resumeContext('r-1', db);
+      const response = await handleMaestroAiSessionResumePost(context, 'r-1');
+      expect(response.status).toBe(202);
+      await Promise.all(captured);
+      vi.unstubAllGlobals();
+
+      const row = db.__sessions.get('r-1');
+      // Draft skipped (anthropic never called), custody recovered, error
+      // cleared, and the per-execution baseline let the reviewer run despite
+      // lifetime spend at 19.9/20.
+      expect(row?.status).toBe('converged');
+      expect(row?.final_text).toBe('Rascunho valido e completo.');
+      expect(row?.error).toBeNull();
+      expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.anthropic.com')).toBe(false);
+    });
+
+    it('anchors the time budget at resume time, not created_at', async () => {
+      // created_at is 2 hours in the past with a 1-minute budget: a fresh-run
+      // anchor would exhaust immediately; the resume anchor must be `now`.
+      const db = createInMemoryDb({
+        sessions: [
+          pausedRow({
+            status: 'paused_time_limit',
+            max_runtime_minutes: 1,
+            created_at: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+            error: 'Time guard blocked provider call.',
+          }),
+        ],
+      });
+      const fetchMock = reviewerFetch();
+      vi.stubGlobal('fetch', fetchMock);
+      const { context, captured } = resumeContext('r-1', db);
+      const response = await handleMaestroAiSessionResumePost(context, 'r-1');
+      expect(response.status).toBe(202);
+      await Promise.all(captured);
+      vi.unstubAllGlobals();
+
+      expect(db.__sessions.get('r-1')?.status).toBe('converged');
+    });
+
+    it('rejects a concurrent double-resume: the CAS loser gets 409 and never dispatches a second runner', async () => {
+      const db = createInMemoryDb({ sessions: [pausedRow()] });
+      // Race shape: handler B loaded the row while it was still paused, but
+      // handler A's CAS write landed first (row is already queued and A's
+      // runner dispatched). Serve B's first session SELECT from the stale
+      // paused snapshot; the stored row is already queued.
+      const staleRow = { ...(db.__sessions.get('r-1') as Row) };
+      const winnerRow = db.__sessions.get('r-1') as Row;
+      winnerRow.status = 'queued';
+      let staleServed = false;
+      const racedDb = {
+        ...db,
+        prepare(query: string) {
+          const statement = db.prepare(query);
+          if (!staleServed && /SELECT \* FROM maestro_ai_sessions/i.test(query)) {
+            staleServed = true;
+            return {
+              ...statement,
+              bind: (...values: unknown[]) => ({
+                ...statement.bind(...values),
+                first: async () => staleRow,
+              }),
+            };
+          }
+          return statement;
+        },
+      };
+      const fetchMock = reviewerFetch();
+      vi.stubGlobal('fetch', fetchMock);
+      const { context, captured } = resumeContext('r-1', racedDb as unknown as ReturnType<typeof createInMemoryDb>);
+      const response = await handleMaestroAiSessionResumePost(context, 'r-1');
+      vi.unstubAllGlobals();
+
+      // The CAS write matched 0 rows (status is queued, not paused): the loser
+      // must return 409 and must NOT dispatch a second runSession.
+      expect(response.status).toBe(409);
+      expect(captured.length).toBe(0);
+      expect(db.__sessions.get('r-1')?.status).toBe('queued');
+    });
+
+    it('returns 409 for a converged session and for a still-active session', async () => {
+      const db = createInMemoryDb({
+        sessions: [
+          pausedRow({ id: 'done', status: 'converged', final_text: 'Final.' }),
+          pausedRow({ id: 'live', status: 'running' }),
+        ],
+      });
+      const done = await handleMaestroAiSessionResumePost(resumeContext('done', db).context, 'done');
+      expect(done.status).toBe(409);
+      const live = await handleMaestroAiSessionResumePost(resumeContext('live', db).context, 'live');
+      expect(live.status).toBe(409);
+      expect(db.__sessions.get('done')?.status).toBe('converged');
+      expect(db.__sessions.get('live')?.status).toBe('running');
+    });
+
+    it('pauses a fresh run as paused_time_limit before any provider call when created_at already exhausts the budget', async () => {
+      const db = createInMemoryDb({
+        sessions: [
+          pausedRow({
+            status: 'queued',
+            current_text: '',
+            current_author: null,
+            observed_cost_usd: 0,
+            max_runtime_minutes: 1,
+            created_at: new Date(Date.now() - 2 * 3_600_000).toISOString(),
+            error: null,
+          }),
+        ],
+      });
+      const fetchMock = reviewerFetch();
+      vi.stubGlobal('fetch', fetchMock);
+      await maestroAiTestHooks.runSession(
+        db,
+        { BIGDATA_DB: db, MAESTRO_ANTHROPIC_API_KEY: 'k-claude', MAESTRO_OPENAI_API_KEY: 'k-codex' },
+        'r-1',
+      );
+      vi.unstubAllGlobals();
+
+      expect(db.__sessions.get('r-1')?.status).toBe('paused_time_limit');
+      expect(fetchMock.mock.calls.length).toBe(0);
+    });
   });
 });
 

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -833,9 +833,19 @@ function calculateObservedCost(result: ProviderCallResult, fallbackPrompt: strin
   return (inputTokens / 1_000_000) * inputRate + (outputTokens / 1_000_000) * outputRate + requestRate / 1000;
 }
 
-function runtimeLimitExceeded(startedAtMs: number, maxRuntimeMinutes?: number | null): boolean {
-  if (!Number.isFinite(Number(maxRuntimeMinutes)) || Number(maxRuntimeMinutes) <= 0) return false;
-  return Date.now() - startedAtMs > Number(maxRuntimeMinutes) * 60_000;
+// Canonical session time budget (editorial_inputs.rs:205-215 / session_orchestration.rs):
+// null = no limit; exhaustion is `remaining < 2s`, checked before the draft and
+// before every turn. The anchor is created_at on a fresh run and `now` on resume.
+const SESSION_TIME_EXHAUSTION_CUTOFF_MS = 2_000;
+
+function remainingSessionMs(anchorMs: number, maxRuntimeMinutes?: number | null): number | null {
+  if (!Number.isFinite(Number(maxRuntimeMinutes)) || Number(maxRuntimeMinutes) <= 0) return null;
+  return Math.max(0, anchorMs + Number(maxRuntimeMinutes) * 60_000 - Date.now());
+}
+
+function sessionTimeExhausted(anchorMs: number, maxRuntimeMinutes?: number | null): boolean {
+  const remaining = remainingSessionMs(anchorMs, maxRuntimeMinutes);
+  return remaining !== null && remaining < SESSION_TIME_EXHAUSTION_CUTOFF_MS;
 }
 
 // Rust char::is_whitespace / str::trim / split_whitespace use the Unicode
@@ -901,6 +911,9 @@ function isSubstantiveEditorialChange(before: string, after: string): boolean {
 // quoted/bare scalar scan with line/brace key-position rules).
 
 const MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN = 3;
+// Canonical escalation threshold: 3 consecutive operational turn failures pause
+// the session as paused_reviewer_outage (consecutive_reviewer_outage_rounds).
+const REVIEWER_OUTAGE_ESCALATION_THRESHOLD = 3;
 
 const RUST_WS_START = new RegExp(`^${RUST_WS_CLASS}+`);
 
@@ -1775,18 +1788,102 @@ async function fetchWithTimeout(
   input: RequestInfo | URL,
   init: RequestInit,
   timeoutMs = PROVIDER_TIMEOUT_MS,
+  externalSignal?: AbortSignal,
 ): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const onExternalAbort = () => controller.abort();
+  externalSignal?.addEventListener('abort', onExternalAbort);
+  if (externalSignal?.aborted) controller.abort();
   try {
     return await fetch(input, { ...init, signal: controller.signal });
   } catch (error) {
+    if (externalSignal?.aborted) {
+      throw new ProviderCancelledError('Provider request aborted by session cancellation.', { cause: error });
+    }
     if (controller.signal.aborted) {
       throw new Error(`Provider request excedeu o tempo limite de ${Math.round(timeoutMs / 1000)}s.`, { cause: error });
     }
     throw error;
   } finally {
     clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
+  }
+}
+
+// Canonical provider retry policy (provider_retry.rs): max 2 attempts; a network
+// error retries once after a 1500ms backoff; ONLY HTTP 429 retries, waiting
+// Retry-After (delta-seconds or HTTP-date, default 30s, cap 120s). Any other
+// status is returned as-is for normal classification. Waits are cancel-aware:
+// sliced sleeps (5s) polling the cooperative cancel check (web analogue of the
+// desktop CancellationToken).
+const PROVIDER_RETRY_MAX_ATTEMPTS = 2;
+const PROVIDER_RETRY_NETWORK_BACKOFF_MS = 1_500;
+const PROVIDER_RETRY_429_DEFAULT_SECS = 30;
+const PROVIDER_RETRY_429_CAP_SECS = 120;
+const CANCEL_POLL_SLICE_MS = 5_000;
+
+/** Web analogue of the desktop STOPPED_BY_USER interruption: the runner catches
+ *  this and returns silently without clobbering the canceller's terminal write. */
+class ProviderCancelledError extends Error {}
+
+function parseRetryAfterHeader(headers: Headers): number | null {
+  const value = headers.get('retry-after');
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  const dateMs = Date.parse(trimmed);
+  if (!Number.isNaN(dateMs)) return Math.max(0, Math.round((dateMs - Date.now()) / 1000));
+  return null;
+}
+
+/** Sleep for ms, polling isCancelled every slice. Returns true if cancelled mid-wait. */
+async function cancelAwareSleep(ms: number, isCancelled: () => Promise<boolean>): Promise<boolean> {
+  let waited = 0;
+  while (waited < ms) {
+    if (await isCancelled()) return true;
+    const step = Math.min(CANCEL_POLL_SLICE_MS, ms - waited);
+    await new Promise((resolve) => setTimeout(resolve, step));
+    waited += step;
+  }
+  return await isCancelled();
+}
+
+async function fetchProviderWithRetry(
+  input: RequestInfo | URL,
+  init: RequestInit,
+  timeoutMs: number,
+  isCancelled: () => Promise<boolean>,
+): Promise<Response | 'cancelled'> {
+  for (let attempt = 1; ; attempt += 1) {
+    let response: Response;
+    // Abortive cancel (web analogue of the desktop CancellationToken): while the
+    // provider call is in flight, a poller watches the cooperative cancel check
+    // and aborts the request instead of letting it run to completion/timeout.
+    const cancelAbort = new AbortController();
+    const poller = setInterval(() => {
+      void isCancelled()
+        .then((cancelled) => {
+          if (cancelled) cancelAbort.abort();
+        })
+        .catch(() => {});
+    }, CANCEL_POLL_SLICE_MS);
+    try {
+      response = await fetchWithTimeout(input, init, timeoutMs, cancelAbort.signal);
+    } catch (error) {
+      if (error instanceof ProviderCancelledError) return 'cancelled';
+      if (attempt >= PROVIDER_RETRY_MAX_ATTEMPTS) throw error;
+      if (await cancelAwareSleep(PROVIDER_RETRY_NETWORK_BACKOFF_MS, isCancelled)) return 'cancelled';
+      continue;
+    } finally {
+      clearInterval(poller);
+    }
+    if (response.status !== 429 || attempt >= PROVIDER_RETRY_MAX_ATTEMPTS) return response;
+    const retryAfterSecs = Math.min(
+      parseRetryAfterHeader(response.headers) ?? PROVIDER_RETRY_429_DEFAULT_SECS,
+      PROVIDER_RETRY_429_CAP_SECS,
+    );
+    if (await cancelAwareSleep(retryAfterSecs * 1_000, isCancelled)) return 'cancelled';
   }
 }
 
@@ -1806,6 +1903,13 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
   }
 }
 
+interface ProviderCallOptions {
+  /** Per-call timeout, canonically min(120s, remaining session time). */
+  timeoutMs?: number;
+  /** Cooperative cancel check; enables retry waits + in-flight abort polling. */
+  isCancelled?: () => Promise<boolean>;
+}
+
 async function callProvider(
   env: MaestroAiEnv,
   agent: ProviderKey,
@@ -1813,6 +1917,7 @@ async function callProvider(
   models: Partial<Record<ProviderKey, string>>,
   maxOutputTokens = MAX_OUTPUT_TOKENS,
   systemOverride?: string,
+  options?: ProviderCallOptions,
 ): Promise<ProviderCallResult> {
   const apiKey = secretForAgent(env, agent);
   if (!apiKey) throw new Error(`${AGENT_LABELS[agent]} API key is not configured in admin-motor secrets.`);
@@ -1821,7 +1926,11 @@ async function callProvider(
     systemOverride ??
     `You are ${AGENT_LABELS[agent]} inside Maestro Editorial AI. Internal coordination must be in en_US. Operator-facing deliverables must be in pt_BR. Follow the current Maestro role contract exactly.`;
 
+  const timeoutMs = options?.timeoutMs ?? PROVIDER_TIMEOUT_MS;
   if (agent === 'gemini') {
+    // Documented web deviation: the Gemini SDK exposes no Response/AbortSignal,
+    // so this path keeps the deadline-coupled timeout but has no 429 retry or
+    // in-flight abort (the cooperative cancel checks around the call cover it).
     const ai = new GoogleGenAI({ apiKey });
     const response = await withTimeout(
       ai.models.generateContent({
@@ -1829,7 +1938,7 @@ async function callProvider(
         contents: `${system}\n\n${prompt}`,
         config: { temperature: 0.2, topP: 0.9, maxOutputTokens },
       }),
-      PROVIDER_TIMEOUT_MS,
+      timeoutMs,
       `${AGENT_LABELS[agent]} request`,
     );
     return {
@@ -1841,7 +1950,12 @@ async function callProvider(
   }
 
   const request = buildProviderHttpRequest(agent, apiKey, model, system, prompt, maxOutputTokens);
-  const response = await fetchWithTimeout(request.endpoint, request.init);
+  const response = options?.isCancelled
+    ? await fetchProviderWithRetry(request.endpoint, request.init, timeoutMs, options.isCancelled)
+    : await fetchWithTimeout(request.endpoint, request.init, timeoutMs);
+  if (response === 'cancelled') {
+    throw new ProviderCancelledError('Provider call cancelled by cooperative session cancellation.');
+  }
   const parsed = await parseProviderResponse(response);
 
   if (agent === 'claude') {
@@ -1975,6 +2089,25 @@ function publicApiHealthResult(
   };
 }
 
+// Plan C (canonical resume): only convergence is terminal — everything else can
+// be resumed. The runner re-validates every limit with a fresh per-execution
+// scope (cost baseline, `now` time anchor) and recovers only custody
+// text/author; approvals and round accounting restart empty.
+const RESUMABLE_STATUSES = new Set([
+  'paused_cost_limit',
+  'paused_time_limit',
+  'paused_cycle_limit',
+  'paused_round_incomplete',
+  'paused_final_audit',
+  'paused_self_review',
+  'paused_reviewer_outage',
+  'paused_draft_unavailable',
+  'blocked_cancelled',
+  'blocked_max_cycles',
+  'blocked_link_audit',
+  'error',
+]);
+
 export const maestroAiTestHooks = {
   buildProviderHttpRequest,
   buildRevisionPrompt,
@@ -1996,9 +2129,14 @@ export const maestroAiTestHooks = {
   extractUrls,
   checkOneLink,
   fetchWithTimeout,
+  parseRetryAfterHeader,
+  remainingSessionMs,
+  sessionTimeExhausted,
+  fetchProviderWithRetry,
   persistSession,
   runSession,
   sweepStaleSessions,
+  RESUMABLE_STATUSES,
 };
 
 async function parseProviderResponse(response: Response): Promise<ProviderResponsePayload> {
@@ -2044,13 +2182,17 @@ const PERSIST_COLUMNS: ReadonlyArray<keyof SessionPatch> = [
  * nullable column be set explicitly to null (the old `?? row.x` merge could
  * never persist null for final_text). Column names come from a fixed allowlist;
  * values are always bound.
+ *
+ * Returns whether the UPDATE modified a row (D1 meta.changes): a CAS-guarded
+ * write that lost the race reports false so callers can refuse follow-up
+ * actions (e.g. the resume handler must not dispatch a second runner).
  */
 async function persistSession(
   db: D1Database,
   id: string,
   patch: SessionPatch,
   opts: { ifStatusIn?: readonly string[] } = {},
-): Promise<void> {
+): Promise<boolean> {
   const assignments: string[] = [];
   const values: unknown[] = [];
   for (const column of PERSIST_COLUMNS) {
@@ -2059,7 +2201,7 @@ async function persistSession(
       values.push(patch[column]);
     }
   }
-  if (assignments.length === 0) return;
+  if (assignments.length === 0) return false;
   assignments.push('updated_at = ?');
   values.push(nowIso());
   let where = 'id = ?';
@@ -2071,10 +2213,13 @@ async function persistSession(
     where += ` AND status IN (${opts.ifStatusIn.map(() => '?').join(', ')})`;
     values.push(...opts.ifStatusIn);
   }
-  await db
+  const result = (await db
     .prepare(`UPDATE maestro_ai_sessions SET ${assignments.join(', ')} WHERE ${where}`)
     .bind(...values)
-    .run();
+    .run()) as { meta?: { changes?: number } } | undefined;
+  // D1 reports modified rows in meta.changes; a store that omits it (older
+  // mocks) is treated as applied to preserve unconditional-write semantics.
+  return (result?.meta?.changes ?? 1) > 0;
 }
 
 /** True when the runner must stop: the row is gone or no longer in a runnable
@@ -2123,7 +2268,24 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
   let artifactTurn = 0;
   let previousArtifactId: string | null = null;
   const correctiveRetryCounts = new Map<string, number>();
-  const startedAtMs = Date.now();
+  // ── Plan C: resumable lifecycle ──
+  // Resume detection (canonical limited recovery: custody text + author). A
+  // resumed run skips the draft phase and re-enters the review circuit.
+  const isResume = Boolean(row.current_text?.trim() && row.current_author);
+  // Canonical time anchor: created_at on a fresh run, `now` on resume.
+  const createdAtMs = Date.parse(row.created_at);
+  const timeAnchorMs = isResume || !Number.isFinite(createdAtMs) ? Date.now() : createdAtMs;
+  // Canonical cost_scope: the cost cap applies per runner execution, so a
+  // resumed run guards against (observed - baseline), not lifetime spend.
+  const costBaseline = observedCost;
+  // Canonical consecutive operational-outage counter (3-strike escalation).
+  let consecutiveOutages = 0;
+  const isCancelled = async () => runnerStopRequested(await loadSession(db, id));
+  const callTimeoutMs = () => {
+    const remaining = remainingSessionMs(timeAnchorMs, input.max_runtime_minutes);
+    return remaining === null ? PROVIDER_TIMEOUT_MS : Math.max(1, Math.min(PROVIDER_TIMEOUT_MS, remaining));
+  };
+  const callOptions = (): ProviderCallOptions => ({ timeoutMs: callTimeoutMs(), isCancelled });
 
   try {
     logMaestro('info', 'session_started', { session_id: id, initial_agent: initialAgent, active_agents: activeAgents });
@@ -2135,107 +2297,236 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
       logMaestro('warn', 'session_interrupted', { session_id: id, status: preDraftLive?.status });
       return;
     }
-    const draftPrompt = buildDraftPrompt(input, id);
-    const draftRates = input.rates?.[initialAgent] ?? {};
-    const projectedDraftCost = estimateCost(draftPrompt, MAX_OUTPUT_TOKENS, draftRates);
-    if (!Number.isFinite(projectedDraftCost) || observedCost + projectedDraftCost > Number(input.max_cost_usd)) {
-      throw new Error(`Cost guard blocked initial draft before provider call (${AGENT_LABELS[initialAgent]}).`);
-    }
-    await pushEvent({
-      at: nowIso(),
-      agent: initialAgent,
-      role: 'draft',
-      status: 'running',
-      message: 'Draft call started.',
-    });
-    // Re-check immediately before the paid call: a cancel can land during the
-    // `await pushEvent` above, and the provider request must not run (cost) for a
-    // session that is no longer queued/running. This load is the last statement
-    // before callProvider, so no await can interpose a stale read.
-    const beforeCallLive = await loadSession(db, id);
-    if (runnerStopRequested(beforeCallLive)) {
-      logMaestro('warn', 'session_interrupted', { session_id: id, status: beforeCallLive?.status });
-      return;
-    }
-    const draft = await callProvider(env, initialAgent, draftPrompt, input.models ?? {});
-    const draftCost = calculateObservedCost(draft, draftPrompt, draftRates);
-    observedCost += draftCost;
-    // Cooperative cancellation (post-draft): if the session was cancelled while
-    // the initial provider call was in flight, do not write the draft
-    // artifact/events for the now-cancelled session.
-    const postDraftLive = await loadSession(db, id);
-    if (runnerStopRequested(postDraftLive)) {
-      logMaestro('warn', 'session_interrupted', { session_id: id, status: postDraftLive?.status });
-      return;
-    }
-    let currentText = draft.text;
-    // M3: an empty provider response (e.g. a thinking-only completion) must not
-    // silently start a paid review chain over a blank text. Fail fast.
-    if (!currentText.trim()) {
-      throw new Error(`O provedor ${AGENT_LABELS[initialAgent]} retornou um rascunho vazio (texto em branco).`);
-    }
-    let currentLinkAudit = await auditLinks(currentText);
-    // M4: only a genuinely broken link (4xx other than 429) blocks the session.
-    // Transient failures (timeout / network / 429 / 5xx) must not terminate a
-    // paid session — they are logged but the run proceeds.
-    const brokenDraftLinks = currentLinkAudit.filter((result) => !result.ok);
-    artifactTurn += 1;
-    const draftArtifact = await createArtifact(db, {
-      sessionId: id,
-      cycle: 0,
-      turn: artifactTurn,
-      agent: initialAgent,
-      role: 'draft',
-      status: brokenDraftLinks.length ? 'blocked' : 'ready',
-      title: input.title,
-      contentMd: currentText,
-      revisionReport: JSON.stringify({
-        reviewer: initialAgent,
-        role: 'initial_drafter',
+    let currentText = '';
+    let currentLinkAudit: Awaited<ReturnType<typeof auditLinks>> = [];
+    if (isResume) {
+      // Canonical resume (limited recovery): custody text/author are restored,
+      // the draft phase is skipped, and the review circuit restarts with empty
+      // approval/round accounting.
+      currentText = String(row.current_text);
+      currentAuthor = sanitizeAgent(row.current_author ?? '', initialAgent);
+      currentLinkAudit = await auditLinks(currentText);
+      const brokenResumeLinks = currentLinkAudit.filter((result) => !result.ok);
+      await pushEvent({
+        at: nowIso(),
+        agent: currentAuthor,
+        role: 'draft',
+        status: brokenResumeLinks.length ? 'blocked' : 'running',
+        message: 'Session resumed: draft phase skipped, custody text recovered.',
+        link_audit: currentLinkAudit,
+      });
+      if (brokenResumeLinks.length) {
+        await persistSession(
+          db,
+          id,
+          {
+            status: 'blocked_link_audit',
+            current_author: currentAuthor,
+            current_text: currentText,
+            observed_cost_usd: observedCost,
+            error: `Link audit blocked resumed custody text: ${brokenResumeLinks
+              .map((result) => `${result.url} (${result.status ?? result.error ?? 'invalid'})`)
+              .join('; ')}`,
+          },
+          { ifStatusIn: ['queued', 'running'] },
+        );
+        return;
+      }
+      await persistSession(db, id, { status: 'running' }, { ifStatusIn: ['queued', 'running'] });
+    } else {
+      // Canonical draft fallback: the lead drafts first; an operational failure
+      // or empty draft falls through to the next active agent; cost/time
+      // exhaustion pauses; all agents failing pauses as draft-unavailable.
+      const draftPrompt = buildDraftPrompt(input, id);
+      const draftAgents = [initialAgent, ...activeAgents.filter((agent) => agent !== initialAgent)];
+      let draftAuthor: ProviderKey | null = null;
+      let draft: ProviderCallResult | null = null;
+      let draftCost = 0;
+      for (const draftAgent of draftAgents) {
+        if (sessionTimeExhausted(timeAnchorMs, input.max_runtime_minutes)) {
+          await pushEvent({
+            at: nowIso(),
+            agent: draftAgent,
+            role: 'draft',
+            status: 'blocked',
+            message: `Time guard blocked draft call before ${AGENT_LABELS[draftAgent]}.`,
+          });
+          await persistSession(
+            db,
+            id,
+            { status: 'paused_time_limit', observed_cost_usd: observedCost },
+            { ifStatusIn: ['queued', 'running'] },
+          );
+          return;
+        }
+        const draftRates = input.rates?.[draftAgent] ?? {};
+        const projectedDraftCost = estimateCost(draftPrompt, MAX_OUTPUT_TOKENS, draftRates);
+        if (
+          !Number.isFinite(projectedDraftCost) ||
+          observedCost - costBaseline + projectedDraftCost > Number(input.max_cost_usd)
+        ) {
+          await pushEvent({
+            at: nowIso(),
+            agent: draftAgent,
+            role: 'draft',
+            status: 'blocked',
+            message: `Cost guard blocked draft call before ${AGENT_LABELS[draftAgent]}.`,
+            cost_usd: projectedDraftCost,
+          });
+          await persistSession(
+            db,
+            id,
+            { status: 'paused_cost_limit', observed_cost_usd: observedCost },
+            { ifStatusIn: ['queued', 'running'] },
+          );
+          return;
+        }
+        await pushEvent({
+          at: nowIso(),
+          agent: draftAgent,
+          role: 'draft',
+          status: 'running',
+          message: draftAgent === initialAgent ? 'Draft call started.' : 'Draft fallback call started.',
+        });
+        // Re-check immediately before the paid call: a cancel can land during the
+        // `await pushEvent` above, and the provider request must not run (cost) for a
+        // session that is no longer queued/running. This load is the last statement
+        // before callProvider, so no await can interpose a stale read.
+        const beforeCallLive = await loadSession(db, id);
+        if (runnerStopRequested(beforeCallLive)) {
+          logMaestro('warn', 'session_interrupted', { session_id: id, status: beforeCallLive?.status });
+          return;
+        }
+        try {
+          const attempt = await callProvider(
+            env,
+            draftAgent,
+            draftPrompt,
+            input.models ?? {},
+            MAX_OUTPUT_TOKENS,
+            undefined,
+            callOptions(),
+          );
+          draftCost = calculateObservedCost(attempt, draftPrompt, draftRates);
+          observedCost += draftCost;
+          // M3: an empty provider response (e.g. a thinking-only completion) is a
+          // draft failure, not a silent blank custody — fall through to the next agent.
+          if (!attempt.text.trim()) {
+            throw new Error(`O provedor ${AGENT_LABELS[draftAgent]} retornou um rascunho vazio (texto em branco).`);
+          }
+          draft = attempt;
+          draftAuthor = draftAgent;
+        } catch (error) {
+          if (error instanceof ProviderCancelledError) {
+            logMaestro('warn', 'session_interrupted', { session_id: id, reason: 'cancelled_during_draft' });
+            return;
+          }
+          await pushEvent({
+            at: nowIso(),
+            agent: draftAgent,
+            role: 'draft',
+            status: 'blocked',
+            message: `Draft attempt failed with ${AGENT_LABELS[draftAgent]}: ${sanitizeText(
+              error instanceof Error ? error.message : String(error),
+              300,
+            )}. Trying next active agent.`,
+          });
+          await persistSession(db, id, { observed_cost_usd: observedCost });
+          continue;
+        }
+        break;
+      }
+      if (!draft || !draftAuthor) {
+        await persistSession(
+          db,
+          id,
+          {
+            status: 'paused_draft_unavailable',
+            observed_cost_usd: observedCost,
+            error: 'All active agents failed to produce an initial draft.',
+          },
+          { ifStatusIn: ['queued', 'running'] },
+        );
+        return;
+      }
+      // Cooperative cancellation (post-draft): if the session was cancelled while
+      // the initial provider call was in flight, do not write the draft
+      // artifact/events for the now-cancelled session.
+      const postDraftLive = await loadSession(db, id);
+      if (runnerStopRequested(postDraftLive)) {
+        logMaestro('warn', 'session_interrupted', { session_id: id, status: postDraftLive?.status });
+        return;
+      }
+      currentText = draft.text;
+      currentAuthor = draftAuthor;
+      currentLinkAudit = await auditLinks(currentText);
+      // M4: only a genuinely broken link (4xx other than 429) blocks the session.
+      // Transient failures (timeout / network / 429 / 5xx) must not terminate a
+      // paid session — they are logged but the run proceeds.
+      const brokenDraftLinks = currentLinkAudit.filter((result) => !result.ok);
+      artifactTurn += 1;
+      const draftArtifact = await createArtifact(db, {
+        sessionId: id,
+        cycle: 0,
+        turn: artifactTurn,
+        agent: draftAuthor,
+        role: 'draft',
         status: brokenDraftLinks.length ? 'blocked' : 'ready',
-        custody: 'created',
-      }),
-      linkAudit: currentLinkAudit,
-      costUsd: draftCost,
-      model: draft.model,
-      previousArtifactId,
-    });
-    previousArtifactId = draftArtifact.id;
-    await pushEvent({
-      at: nowIso(),
-      agent: initialAgent,
-      role: 'draft',
-      status: brokenDraftLinks.length ? 'blocked' : 'ready',
-      message: brokenDraftLinks.length
-        ? `Initial draft produced with ${brokenDraftLinks.length} broken link(s).`
-        : 'Initial draft produced.',
-      cost_usd: draftCost,
-      model: draft.model,
-      link_audit: currentLinkAudit,
-    });
-    if (brokenDraftLinks.length) {
+        title: input.title,
+        contentMd: currentText,
+        revisionReport: JSON.stringify({
+          reviewer: draftAuthor,
+          role: 'initial_drafter',
+          status: brokenDraftLinks.length ? 'blocked' : 'ready',
+          custody: 'created',
+        }),
+        linkAudit: currentLinkAudit,
+        costUsd: draftCost,
+        model: draft.model,
+        previousArtifactId,
+      });
+      previousArtifactId = draftArtifact.id;
+      await pushEvent({
+        at: nowIso(),
+        agent: draftAuthor,
+        role: 'draft',
+        status: brokenDraftLinks.length ? 'blocked' : 'ready',
+        message: brokenDraftLinks.length
+          ? `Initial draft produced with ${brokenDraftLinks.length} broken link(s).`
+          : 'Initial draft produced.',
+        cost_usd: draftCost,
+        model: draft.model,
+        link_audit: currentLinkAudit,
+      });
+      if (brokenDraftLinks.length) {
+        await persistSession(
+          db,
+          id,
+          {
+            status: 'blocked_link_audit',
+            current_author: currentAuthor,
+            current_text: currentText,
+            observed_cost_usd: observedCost,
+            error: `Link audit blocked draft: ${brokenDraftLinks
+              .map((result) => `${result.url} (${result.status ?? result.error ?? 'invalid'})`)
+              .join('; ')}`,
+          },
+          { ifStatusIn: ['queued', 'running'] },
+        );
+        return;
+      }
       await persistSession(
         db,
         id,
         {
-          status: 'blocked_link_audit',
+          status: 'running',
           current_author: currentAuthor,
           current_text: currentText,
           observed_cost_usd: observedCost,
-          error: `Link audit blocked draft: ${brokenDraftLinks
-            .map((result) => `${result.url} (${result.status ?? result.error ?? 'invalid'})`)
-            .join('; ')}`,
         },
         { ifStatusIn: ['queued', 'running'] },
       );
-      return;
     }
-    await persistSession(
-      db,
-      id,
-      { status: 'running', current_author: currentAuthor, current_text: currentText, observed_cost_usd: observedCost },
-      { ifStatusIn: ['queued', 'running'] },
-    );
 
     const order = [
       ...activeAgents.slice(activeAgents.indexOf(initialAgent) + 1),
@@ -2247,8 +2538,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
     // changes, contract/lock violations and quality-guard blocks clear it.
     // The session finalizes the moment every non-author agent of the rotation
     // is in the set (mid-round capable), and a global serial-turn cap bounds
-    // deliberation. Resumable pause states arrive with Plan C; until then the
-    // pause analogs below are terminal web statuses.
+    // deliberation. Since Plan C the paused_* statuses are resumable.
     let converged = false;
     const maxCycles = Math.max(1, Math.min(5, Number(input.max_cycles || 2)));
     const roundTurnCount = order.length;
@@ -2258,6 +2548,54 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
     let serialTurns = 0;
     const validRoundAgents = new Set<string>();
     const stableApprovals = new Set<string>();
+    // ── Plan C: operational turn failures (canonical 3-strike escalation) ──
+    // A provider/network/timeout failure or an exhausted corrective-retry turn
+    // does NOT kill the session: it skips the turn (stableApprovals PRESERVED —
+    // only violations clear it), and three consecutive operational failures
+    // escalate to paused_reviewer_outage. A clean turn resets the counter. A
+    // failure on the round's closing turn pauses as paused_round_incomplete.
+    const handleOperationalFailure = async (reviewer: ProviderKey, message: string): Promise<'stop' | 'skip'> => {
+      consecutiveOutages += 1;
+      await pushEvent({
+        at: nowIso(),
+        agent: reviewer,
+        role: 'revision',
+        status: 'blocked',
+        message: `Operational turn failure (${consecutiveOutages}/${REVIEWER_OUTAGE_ESCALATION_THRESHOLD}): ${sanitizeText(message, 300)}`,
+      });
+      if (consecutiveOutages >= REVIEWER_OUTAGE_ESCALATION_THRESHOLD) {
+        await persistSession(
+          db,
+          id,
+          {
+            status: 'paused_reviewer_outage',
+            current_author: currentAuthor,
+            current_text: currentText,
+            observed_cost_usd: observedCost,
+            error: `${REVIEWER_OUTAGE_ESCALATION_THRESHOLD} consecutive reviewer turns failed operationally; session paused for operator action.`,
+          },
+          { ifStatusIn: ['queued', 'running'] },
+        );
+        return 'stop';
+      }
+      roundTurnIndex += 1;
+      if (roundTurnIndex >= roundTurnCount) {
+        await persistSession(
+          db,
+          id,
+          {
+            status: 'paused_round_incomplete',
+            current_author: currentAuthor,
+            current_text: currentText,
+            observed_cost_usd: observedCost,
+            error: 'Operational failure at the end of the round; review circuit incomplete.',
+          },
+          { ifStatusIn: ['queued', 'running'] },
+        );
+        return 'stop';
+      }
+      return 'skip';
+    };
     for (;;) {
       // Cooperative cancellation: an operator cancel (or sweeper) flips the
       // stored status to a terminal state; detect it between turns and stop
@@ -2287,7 +2625,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
           db,
           id,
           {
-            status: 'blocked_cycle_limit',
+            status: 'paused_cycle_limit',
             current_author: currentAuthor,
             current_text: currentText,
             observed_cost_usd: observedCost,
@@ -2334,7 +2672,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
           db,
           id,
           {
-            status: 'blocked_self_review',
+            status: 'paused_self_review',
             current_author: currentAuthor,
             current_text: currentText,
             observed_cost_usd: observedCost,
@@ -2344,7 +2682,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
         );
         return;
       }
-      if (runtimeLimitExceeded(startedAtMs, input.max_runtime_minutes)) {
+      if (sessionTimeExhausted(timeAnchorMs, input.max_runtime_minutes)) {
         await pushEvent({
           at: nowIso(),
           agent: reviewer,
@@ -2355,7 +2693,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
         await persistSession(
           db,
           id,
-          { status: 'blocked_time', observed_cost_usd: observedCost },
+          { status: 'paused_time_limit', observed_cost_usd: observedCost },
           { ifStatusIn: ['queued', 'running'] },
         );
         return;
@@ -2366,7 +2704,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
         // reviewer up to MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN times, with a
         // Mandatory Corrective Retry section appended to the prompt; exhaustion
         // skips the turn, and an exhausted turn at the end of the round pauses
-        // the circuit as blocked_round_incomplete.
+        // the circuit as paused_round_incomplete.
         for (;;) {
           await pushEvent({
             at: nowIso(),
@@ -2390,7 +2728,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             })) + (correctiveRetryCount > 0 ? correctiveRetrySection(correctiveRetryCount) : '');
           const rates = input.rates?.[reviewer] ?? {};
           const projected = estimateCost(prompt, MAX_OUTPUT_TOKENS, rates);
-          if (!Number.isFinite(projected) || observedCost + projected > Number(input.max_cost_usd)) {
+          if (!Number.isFinite(projected) || observedCost - costBaseline + projected > Number(input.max_cost_usd)) {
             await pushEvent({
               at: nowIso(),
               agent: reviewer,
@@ -2402,7 +2740,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             await persistSession(
               db,
               id,
-              { status: 'blocked_cost', observed_cost_usd: observedCost },
+              { status: 'paused_cost_limit', observed_cost_usd: observedCost },
               { ifStatusIn: ['queued', 'running'] },
             );
             return;
@@ -2415,7 +2753,31 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             logMaestro('warn', 'session_interrupted', { session_id: id, status: beforeReviewLive?.status });
             return;
           }
-          const result = await callProvider(env, reviewer, prompt, input.models ?? {});
+          let result: ProviderCallResult;
+          try {
+            result = await callProvider(
+              env,
+              reviewer,
+              prompt,
+              input.models ?? {},
+              MAX_OUTPUT_TOKENS,
+              undefined,
+              callOptions(),
+            );
+          } catch (error) {
+            if (error instanceof ProviderCancelledError) {
+              logMaestro('warn', 'session_interrupted', { session_id: id, reason: 'cancelled_during_review' });
+              return;
+            }
+            // Canonical operational turn failure: skip the turn instead of
+            // killing the session; three consecutive failures escalate.
+            const action = await handleOperationalFailure(
+              reviewer,
+              error instanceof Error ? error.message : String(error),
+            );
+            if (action === 'stop') return;
+            break;
+          }
           const cost = calculateObservedCost(result, prompt, rates);
           observedCost += cost;
           // Cooperative cancellation (post-call): if cancelled while the reviewer
@@ -2427,9 +2789,15 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             return;
           }
           // M3: an empty reviewer response is a provider failure, not a silent
-          // NOT_READY vote. Fail fast instead of recording a meaningless turn.
+          // NOT_READY vote — an operational turn failure, not a session error.
           if (!result.text.trim()) {
-            throw new Error(`O provedor ${AGENT_LABELS[reviewer]} retornou uma revisao vazia (texto em branco).`);
+            await persistSession(db, id, { observed_cost_usd: observedCost });
+            const action = await handleOperationalFailure(
+              reviewer,
+              `O provedor ${AGENT_LABELS[reviewer]} retornou uma revisao vazia (texto em branco).`,
+            );
+            if (action === 'stop') return;
+            break;
           }
           const status = extractStatus(result.text);
           const report = extractTagged(result.text, 'maestro_revision_report');
@@ -2502,31 +2870,14 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
               correctiveRetryCount = retryCount;
               continue;
             }
-            await pushEvent({
-              at: nowIso(),
-              agent: reviewer,
-              role: 'revision',
-              status: 'blocked',
-              message: 'Corrective retries exhausted; reviewer turn skipped without a vote.',
-            });
-            roundTurnIndex += 1;
-            if (roundTurnIndex >= roundTurnCount) {
-              // Desktop parity: a round whose circuit cannot complete pauses
-              // instead of silently wrapping (PAUSED_ROUND_INCOMPLETE analog).
-              await persistSession(
-                db,
-                id,
-                {
-                  status: 'blocked_round_incomplete',
-                  current_author: currentAuthor,
-                  current_text: currentText,
-                  observed_cost_usd: observedCost,
-                  error: 'Corrective retries exhausted at the end of the round; review circuit incomplete.',
-                },
-                { ifStatusIn: ['queued', 'running'] },
-              );
-              return;
-            }
+            // Desktop parity: an exhausted corrective-retry turn is an
+            // operational failure — it feeds the same 3-strike escalation and
+            // pauses the circuit when it lands on the round's closing turn.
+            const action = await handleOperationalFailure(
+              reviewer,
+              'Corrective retries exhausted; reviewer turn skipped without a vote.',
+            );
+            if (action === 'stop') return;
             break;
           }
           const changedByReviewer = Boolean(revisedText && isSubstantiveEditorialChange(currentText, revisedText));
@@ -2569,7 +2920,9 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             });
             await persistSession(db, id, { observed_cost_usd: observedCost });
             // Desktop parity: the rejected revision clears the stable set and
-            // the turn does NOT count as a valid round agent.
+            // the turn does NOT count as a valid round agent. The provider
+            // itself responded, so the operational-outage streak resets.
+            consecutiveOutages = 0;
             stableApprovals.clear();
             roundTurnIndex += 1;
             if (roundTurnIndex >= roundTurnCount) {
@@ -2632,7 +2985,9 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             return;
           }
           // Desktop parity: ReadyRejected turns do not count as valid round
-          // agents; every other accepted turn feeds the closure gating.
+          // agents; every other accepted turn feeds the closure gating. Any
+          // accepted turn is a clean provider response: outage streak resets.
+          consecutiveOutages = 0;
           if (readyRejectedReason === null) validRoundAgents.add(reviewer);
           if (revisedText && changedByReviewer) {
             // Substantive revision: custody transfers and the new version must
@@ -2694,7 +3049,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
           db,
           id,
           {
-            status: 'blocked_final_audit',
+            status: 'paused_final_audit',
             current_author: currentAuthor,
             current_text: currentText,
             observed_cost_usd: observedCost,
@@ -3151,6 +3506,43 @@ export async function handleMaestroAiSessionCancelPost(context: RequestContext, 
     return json({ ok: true, session: next ? publicSession(next) : null });
   } catch (error) {
     return json({ ok: false, error: error instanceof Error ? error.message : 'Erro ao cancelar Maestro AI.' }, 500);
+  }
+}
+
+export async function handleMaestroAiSessionResumePost(context: RequestContext, sessionId: string): Promise<Response> {
+  try {
+    const db = requireDb(context.env);
+    await ensureSchema(db);
+    const row = await loadSession(db, sessionId);
+    if (!row) return json({ ok: false, error: 'Sessao Maestro AI nao encontrada.' }, 404);
+    if (ACTIVE_SESSION_STATUSES.has(row.status)) {
+      return json({ ok: false, error: 'Sessao ainda ativa; nada a retomar.' }, 409);
+    }
+    if (!RESUMABLE_STATUSES.has(row.status) || row.final_text != null) {
+      return json({ ok: false, error: 'Sessao concluida; nada a retomar.' }, 409);
+    }
+    const events = parseJson<SessionEvent[]>(row.events_json, []);
+    events.push({ at: nowIso(), status: 'running', message: 'Sessao retomada pelo operador.' });
+    const applied = await persistSession(
+      db,
+      sessionId,
+      { status: 'queued', events_json: JSON.stringify(events), error: null },
+      { ifStatusIn: [row.status] },
+    );
+    if (!applied) {
+      // CAS lost: a concurrent resume/cancel changed the row after our read.
+      // The winner (if any) already dispatched a runner — do NOT dispatch another.
+      return json({ ok: false, error: 'Sessao mudou de estado durante a retomada; tente novamente.' }, 409);
+    }
+    const resumed = await loadSession(db, sessionId);
+    if (resumed?.status !== 'queued') {
+      return json({ ok: false, error: 'Sessao mudou de estado durante a retomada; tente novamente.' }, 409);
+    }
+    const runPromise = runSession(db, context.env, sessionId);
+    context.waitUntil?.(runPromise);
+    return json({ ok: true, session: publicSession(resumed) }, 202);
+  } catch (error) {
+    return json({ ok: false, error: error instanceof Error ? error.message : 'Erro ao retomar Maestro AI.' }, 500);
   }
 }
 

--- a/admin-motor/src/index.ts
+++ b/admin-motor/src/index.ts
@@ -64,6 +64,7 @@ import {
   handleMaestroAiArtifactsGet,
   handleMaestroAiSessionCancelPost,
   handleMaestroAiSessionContentPut,
+  handleMaestroAiSessionResumePost,
   handleMaestroAiSessionsGet,
   handleMaestroAiSessionsPost,
   handleMaestroAiSettingsGet,
@@ -548,6 +549,7 @@ app.get('/api/maestro-ai/sessions/:id/artifacts/:artifactId', (c) =>
 );
 app.put('/api/maestro-ai/sessions/:id/content', (c) => handleMaestroAiSessionContentPut(rc(c), c.req.param('id')));
 app.post('/api/maestro-ai/sessions/:id/cancel', (c) => handleMaestroAiSessionCancelPost(rc(c), c.req.param('id')));
+app.post('/api/maestro-ai/sessions/:id/resume', (c) => handleMaestroAiSessionResumePost(rc(c), c.req.param('id')));
 
 // ── mainsite comments admin ──
 app.get('/api/mainsite/comments/admin/all', (c) => handleCommentsAdminAll(re(c)));

--- a/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-c.md
+++ b/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-c.md
@@ -1,0 +1,45 @@
+# Maestro AI Parity Plan C — Lifecycle Retomável e Resiliência (executado)
+
+> Blueprint de execução; fonte canônica: `provider_retry.rs` (integral), `session_orchestration.rs` (draft loop 436-591, turno operacional 1215-1310, escalada 1233-1276), `session_resume.rs:43-70`, `editorial_inputs.rs:205-215`, `session_commands.rs:210-347`, `session_artifacts.rs:47-159`, `session_persistence.rs:99-143`.
+
+**Goal:** Sessões web deixam de morrer em falhas transitórias e limites: retry canônico de provider, falhas operacionais pulam o turno com escalada 3-strike, draft com fallback serial, custo/tempo pausam retomável, e a família `paused_*` ganha retomada real via novo endpoint.
+
+## Semântica canônica adotada (com adaptações web documentadas)
+
+1. **Retry de provider** (provider_retry.rs): máx 2 tentativas; rede → 1 retry com backoff 1500 ms; **somente HTTP 429 re-tenta** com espera = Retry-After (int segundos OU data RFC2822 → delta ≥ 0; default 30 s; cap 120 s); demais statuses seguem para classificação normal. Esperas canceláveis — web: sleep fatiado (5 s) checando cancel cooperativo no D1; `Cancelled` → runner retorna silencioso (análogo STOPPED_BY_USER).
+2. **Falha operacional de turno** (1215-1310): erro de provider/rede/timeout NÃO mata a sessão — evento, `consecutiveOutages += 1`, `roundTurnIndex += 1`, wrap → `paused_round_incomplete`, `continue`; **stableApprovals é PRESERVADO** (só violações limpam); turno limpo zera o contador; `>= 3` → `paused_reviewer_outage` (threshold canônico). Incrementos também nas exaustões de retry corretivo (paridade 1353/1487/1625).
+3. **Draft fallback** (436-591): ordem = initialAgent + demais ativos; por agente: check de tempo → guard de custo → chamada; `erro/vazio` → próximo agente (evento `session.draft.retry` análogo); custo → `paused_cost_limit`; tempo → `paused_time_limit`; todos falham → `paused_draft_unavailable`.
+4. **Tempo** (session_resume.rs/editorial_inputs.rs): anchor = `created_at` no run inicial, `now` na retomada; exaustão = `remaining < 2 s`, checada antes do draft e de cada turno; timeout por chamada = `min(120 s, remaining)` (acoplamento deadline→abort da chamada).
+5. **Custo por execução** (cost_scope canônico): o cap vale por execução do runner — web: `costBaseline = observed` no início do run; guards comparam `(observed − baseline) + projetado > cap`. Estouro → `paused_cost_limit` (era `blocked_cost` terminal).
+6. **Retomada** (session_artifacts.rs:47-159 + session_commands.rs): terminal = somente convergência (texto final gravado); TUDO mais é retomável. Recuperação limitada (paridade): texto/autor; **stableApprovals/validRoundAgents/outages NÃO são recuperados** (recomeçam vazios) e a contabilidade de rounds reinicia (round-position não é persistido no schema web — coerente com o escopo por execução do turn cap). Web: `POST /api/maestro-ai/sessions/:id/resume` — status ∈ RESUMABLE_STATUSES e `final_text` nulo → status `queued`, error limpo, evento `resumed`, re-dispatch `waitUntil(runSession)`. Runner detecta retomada por `current_text` não-vazio + `current_author` presente (fresh com `initial_content` tem `current_author` nulo) → pula a fase de draft, re-audita os links da custódia e ancora o tempo em `now`.
+7. **Cancel abortivo**: chamadas de provider passam a correr com `AbortController`, abortadas por um poller cooperativo (5 s) que detecta status terminal/cancelado no D1 — análogo web do CancellationToken.
+
+## Mapa de statuses (contract surface completa)
+
+- Renomeados para retomáveis: `blocked_cost`→`paused_cost_limit`, `blocked_time`→`paused_time_limit`, `blocked_cycle_limit`→`paused_cycle_limit`, `blocked_round_incomplete`→`paused_round_incomplete`, `blocked_final_audit`→`paused_final_audit`, `blocked_self_review`→`paused_self_review`.
+- Novos: `paused_reviewer_outage`, `paused_draft_unavailable`.
+- Retomáveis também: `blocked_cancelled` (STOPPED_BY_USER canônico é retomável), `blocked_max_cycles` (bound interino do operador), `blocked_link_audit` (retomar re-audita; timing muda no D), `error` (varrida do sweeper/falha catastrófica — retomável por decisão web: a retomada re-valida tudo).
+- Terminal: `converged` apenas.
+- Superfície varrida: statusLabel + botão Retomar no frontend; sweeper inalterado (só queued/running); cancel handler inalterado; RESUMABLE_STATUSES exportado para teste.
+
+## Desvios web documentados
+
+- Resume não recebe config nova (a UI não tem formulário de retomada): usa a config salva na row — o princípio canônico "request é fonte de verdade" fica para quando a UI de retomada existir (Plano F/UI).
+- Retry 429: espera fatiada com check cooperativo (não há CancellationToken em Workers).
+- Draft fallback não distingue `STOPPED_BY_USER` no meio do loop (o cancel cooperativo intercepta entre agentes).
+- Gemini (SDK sem Response/AbortSignal): mantém timeout acoplado ao deadline, mas sem retry 429 e sem abort in-flight (os checks cooperativos em volta da chamada cobrem o cancel).
+- O redator de fechamento da rotação permanece o `initial_agent` configurado mesmo quando o draft veio de um agente de fallback (paridade com a ordem de specs do desktop).
+- A exaustão de retry corretivo alimenta a escalada de outage (paridade): a dinâmica do teste de closure gating do B3 mudou de 11 chamadas/turn-cap para 6 chamadas/`paused_reviewer_outage`.
+
+## Tasks (TDD, red-first cada uma)
+
+1. Puros: `parseRetryAfterHeader` (int/RFC2822/None) + `sessionTimeExhausted`/`remainingSessionMs` (<2 s; None = sem limite) + testes matriz.
+2. `fetchProviderWithRetry` (429/network/backoff/cap/cancel-aware) + testes com fetch mock (429 com Retry-After int e data; rede 1 retry; 500 sem retry; cancel durante espera).
+3. Custo baseline por execução + `paused_cost_limit` (draft e turno) + teste (resume não herda gasto anterior no guard).
+4. Tempo: anchor fresh/resume + checks + timeout acoplado + `paused_time_limit` + testes.
+5. Turno operacional: try/catch por turno, outage counter/reset, escalada `paused_reviewer_outage`, wrap `paused_round_incomplete`, stableApprovals preservado + testes (falha 1x → recupera; 3x consecutivas → pausa; aprovações sobrevivem à falha).
+6. Draft fallback serial + `paused_draft_unavailable` + testes (initial falha → segundo assume; todos falham → pausa; teste antigo de draft vazio atualizado).
+7. Resume endpoint + RESUMABLE_STATUSES + skip-draft na retomada + rota no index.ts + testes (retomada de paused_cost_limit conclui; converged retorna 409; retomada não recupera aprovações).
+8. Cancel abortivo (AbortController + poller) + teste (cancel durante chamada aborta em <10 s simulado com timers fake? — usar mock de fetch pendente + cancel no D1).
+9. Frontend: labels + botão Retomar (status retomável) chamando o endpoint.
+10. Gates + bump v02.08.00 + CHANGELOG + cross-review (draft auto-contido) + ship.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.07.00';
+const APP_VERSION = 'APP v02.08.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',

--- a/src/modules/maestro-ai/MaestroAiModule.tsx
+++ b/src/modules/maestro-ai/MaestroAiModule.tsx
@@ -205,18 +205,36 @@ const statusLabel: Record<string, string> = {
   queued: 'Na fila',
   running: 'Em execução',
   converged: 'Concluída',
-  blocked_cost: 'Bloqueada por custo',
-  blocked_time: 'Bloqueada por tempo',
+  paused_cost_limit: 'Pausada por custo',
+  paused_time_limit: 'Pausada por tempo',
   blocked_max_cycles: 'Sem unanimidade',
-  blocked_cycle_limit: 'Limite de turnos atingido',
-  blocked_round_incomplete: 'Rodada incompleta',
-  blocked_self_review: 'Auto-revisão bloqueada',
-  blocked_final_audit: 'Bloqueada na auditoria final',
+  paused_cycle_limit: 'Limite de turnos atingido',
+  paused_round_incomplete: 'Rodada incompleta',
+  paused_self_review: 'Auto-revisão bloqueada',
+  paused_final_audit: 'Pausada na auditoria final',
+  paused_reviewer_outage: 'Pausada por falha de revisor',
+  paused_draft_unavailable: 'Pausada sem rascunho inicial',
   blocked_revision_contract: 'Bloqueada por contrato',
   blocked_link_audit: 'Bloqueada por link inválido',
   blocked_cancelled: 'Cancelada',
   error: 'Erro',
 };
+
+// Mirror of the backend RESUMABLE_STATUSES: only converged is terminal.
+const RESUMABLE_STATUSES = new Set([
+  'paused_cost_limit',
+  'paused_time_limit',
+  'paused_cycle_limit',
+  'paused_round_incomplete',
+  'paused_final_audit',
+  'paused_self_review',
+  'paused_reviewer_outage',
+  'paused_draft_unavailable',
+  'blocked_cancelled',
+  'blocked_max_cycles',
+  'blocked_link_audit',
+  'error',
+]);
 
 function agentLabel(agent?: AgentKey | string | null): string {
   return AGENTS.find((item) => item.key === agent)?.label ?? String(agent || 'Maestro AI');
@@ -224,6 +242,10 @@ function agentLabel(agent?: AgentKey | string | null): string {
 
 function isRunning(status?: string): boolean {
   return status === 'queued' || status === 'running';
+}
+
+function isResumable(session?: { status?: string; final_text?: string | null } | null): boolean {
+  return Boolean(session?.status && RESUMABLE_STATUSES.has(session.status) && session.final_text == null);
 }
 
 function eventDate(value: string): string {
@@ -311,6 +333,7 @@ export function MaestroAiModule() {
   const [testingApis, setTestingApis] = useState(false);
   const [starting, setStarting] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [resuming, setResuming] = useState(false);
   const [creatingPost, setCreatingPost] = useState(false);
   const [postEditorOpen, setPostEditorOpen] = useState(false);
   const [loadingArtifacts, setLoadingArtifacts] = useState(false);
@@ -626,6 +649,21 @@ export function MaestroAiModule() {
     }
   };
 
+  const resumeSession = async (sessionId: string) => {
+    setResuming(true);
+    try {
+      await readJson<{ ok: true; session: MaestroSession }>(
+        await fetch(`/api/maestro-ai/sessions/${encodeURIComponent(sessionId)}/resume`, { method: 'POST' }),
+      );
+      await loadSessions(true);
+      showNotification('Sessão retomada.', 'success');
+    } catch (error) {
+      showNotification(error instanceof Error ? error.message : 'Erro ao retomar sessão.', 'error');
+    } finally {
+      setResuming(false);
+    }
+  };
+
   const createMainSitePost = async (
     postTitle: string,
     author: string,
@@ -692,6 +730,16 @@ export function MaestroAiModule() {
               disabled={cancelling}
             >
               {cancelling ? <Loader2 size={14} className="spin" /> : <Ban size={14} />} Cancelar
+            </button>
+          )}
+          {selectedSession && isResumable(selectedSession) && (
+            <button
+              type="button"
+              className="ghost-button"
+              onClick={() => void resumeSession(selectedSession.id)}
+              disabled={resuming}
+            >
+              {resuming ? <Loader2 size={14} className="spin" /> : <Play size={14} />} Retomar
             </button>
           )}
           <button type="button" className="ghost-button" onClick={() => void loadSessions()} disabled={loading}>


### PR DESCRIPTION
## Summary

Plan C of the maestro-app parity program: the web Maestro AI module gains the desktop's resilience layer — sessions stop dying on transient failures and limits, and every non-converged state becomes resumable.

- **Canonical provider retry** (`provider_retry.rs` port): max 2 attempts; network retries once after 1500 ms; only HTTP 429 retries honoring `Retry-After` (delta-seconds or HTTP-date, default 30 s, cap 120 s); cancel-aware sliced waits.
- **Abortive cancel**: in-flight HTTP provider calls are aborted by a 5 s cooperative poller (`AbortController`); the runner catches the cancellation sentinel and returns silently (CAS-guarded writes already prevent clobbering the canceller's terminal status).
- **Operational turn failures**: skipped turn + event, `stableApprovals` preserved, canonical 3-strike escalation to `paused_reviewer_outage` (corrective-retry exhaustion feeds the counter), end-of-round failure pauses as `paused_round_incomplete`.
- **Serial draft fallback**: lead first, error/empty falls through to the next active agent, all failing pauses as `paused_draft_unavailable`.
- **Canonical time budget**: anchor `created_at` (fresh) / `now` (resume); exhaustion = remaining < 2 s before the draft and every turn; per-call timeout `min(120s, remaining)`.
- **Per-execution cost scope**: guards use `(observed - baseline) + projected` so resumes do not inherit prior spend.
- **Real resume**: `POST /api/maestro-ai/sessions/:id/resume` + `RESUMABLE_STATUSES` (only `converged` is terminal), `paused_*` status family rename, skip-draft resume with link re-audit and empty approval restart, frontend **Retomar** button + labels.
- **Race fix from cross-review**: `persistSession` now returns whether the CAS UPDATE applied (D1 `meta.changes`); the resume handler returns 409 before dispatch when the CAS loses, closing a concurrent double-resume double-dispatch race (deterministic regression test included).

Documented web deviations: `docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-c.md`.

## Test plan

- 166/166 vitest (`vitest.admin-motor.config.ts`): +11 new tests (Retry-After/exhaustion/retry/abort-poller unit matrix, 5 resume integration tests incl. the double-resume race, draft fallback, outage escalation); 3 existing integration tests updated to the canonical dynamics.
- Gates: eslint clean, biome clean (2 pre-existing accepted config infos), admin-motor typecheck baseline clean, markdownlint 0 errors, prettier clean.
- Cross-review: unanimous ALL READY (caller + codex, gemini, deepseek, grok, perplexity; the CAS race was surfaced by codex in round 2 and fixed red-first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)