### PR TITLE
feat(maestro-ai): canonical release link audit and deep SSRF (parity Plan D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.09.00] - 2026-07-06
+
+### Alterado
+
+- **Maestro AI — release link audit canônico e SSRF profundo (Plano D da equiparação com o maestro-app)**: o audit de links sai dos turnos e assume o posicionamento canônico — roda **somente em tentativas de finalização** (convergência, voto READY sem mudança e NOT_READY sem mudança), como estágios 2-3 do release audit unificado: **integridade bibliográfica → capacidade (>30 URLs únicas pausa antes de qualquer fetch) → audit HTTP** (qualquer linha `error`/`blocked` pausa). Todos os estágios pausam como `paused_final_audit` com contexto estruturado (gate, contagens, linhas). Um link quebrado deixa de matar a sessão no meio do run — os audits por draft/retomada/revisão foram removidos (paridade; `blocked_link_audit` vira status legado retomável). **Regras HTTP canônicas**: timeout 15 s, User-Agent identificado, HEAD primeiro com fallback GET em 405/403 ou erro de transporte do HEAD, sem retries, redirects seguidos até 5 hops re-validando cada alvo, extração com regex/trim/dedup/ordem lexicográfica canônicos (scan 80 matches, 30 candidatas), classificação por tom: 2xx/3xx ok, 4xx (inclusive 429) e 5xx falham, códigos fora de 100-599 (ex.: 999) são `warn` e não falham; candidatas bloqueadas/inválidas viram linhas `blocked` sem nenhum fetch. **SSRF profundo**: faixas IPv4 completas (CGNAT 100.64/10, RFC 6890 192.0.0/24, TEST-NETs, benchmarking 198.18/15, multicast/reservado ≥224/8) e IPv6 (multicast ff00::/8, documentação 2001:db8::/32) somadas às já bloqueadas, `localhost.localdomain`, e **pre-flight DNS-over-HTTPS** (Cloudflare DoH, A+AAAA) que bloqueia domínios resolvendo para IP privado/reservado — aplicado ao alvo inicial e a cada hop de redirect (fail-open em indisponibilidade do resolver, paridade com o pre-flight canônico). Desvios web documentados no plano (`docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-d.md`): probing paralelo, cache do audit por execução, ausência do resolver connection-bound do desktop, hardening extra de hostnames.
+
 ## [v02.08.00] - 2026-07-06
 
 ### Adicionado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -633,6 +633,247 @@ describe('Maestro AI revision prompt teaches the block contract', () => {
   });
 });
 
+describe('Maestro AI release link audit (Plan D)', () => {
+  it('extractUrlCandidates follows the canonical regex, trim, dedup, sorted order and caps', () => {
+    const { extractUrlCandidates, countUniqueUrlCandidates } = maestroAiTestHooks;
+    // Canonical stop-set has no `}`; trailing trim is only . , ; :
+    const text =
+      'Veja https://zeta.example/a. e https://alpha.example/b, https://zeta.example/a; ' +
+      'markdown (https://mid.example/c) e https://brace.example/d}tail ' +
+      'e https://bang.example/e! fim';
+    const candidates = extractUrlCandidates(text);
+    const urls = candidates.map((c: { url: string }) => c.url);
+    // Sorted lexicographically (BTreeSet parity), deduped on the cleaned string.
+    expect(urls).toEqual([
+      'https://alpha.example/b',
+      'https://bang.example/e!',
+      'https://brace.example/d}tail',
+      'https://mid.example/c',
+      'https://zeta.example/a',
+    ]);
+    // Public candidates carry no rejection.
+    expect(candidates.every((c: { rejection: string | null }) => c.rejection === null)).toBe(true);
+    // Bracketed IPv6 stops at `]` and surfaces as an invalid (blocked) candidate.
+    const v6 = extractUrlCandidates('interno http://[::1]/admin aqui');
+    expect(v6.length).toBe(1);
+    expect(v6[0]?.url).toBe('http://[::1');
+    expect(v6[0]?.rejection).toMatch(/invalida/i);
+    // Blocked hosts surface with a rejection reason instead of being dropped.
+    const internal = extractUrlCandidates('http://localhost:8787/x e http://10.0.0.5/y');
+    expect(internal.map((c: { rejection: string | null }) => Boolean(c.rejection))).toEqual([true, true]);
+    // Candidate cap: 30 uniques; counter stops at 31.
+    const many = Array.from({ length: 35 }, (_v, i) => `https://cap${String(i).padStart(2, '0')}.example/`).join(' ');
+    expect(extractUrlCandidates(many).length).toBe(30);
+    expect(countUniqueUrlCandidates(many)).toBe(31);
+    expect(countUniqueUrlCandidates('sem links')).toBe(0);
+  });
+
+  it('isBlockedAuditHost covers the canonical deep-SSRF ranges (CGNAT, TEST-NETs, multicast, docs v6)', () => {
+    const { isBlockedAuditHost } = maestroAiTestHooks;
+    const blocked = [
+      '100.64.0.1',
+      '100.127.255.254', // CGNAT 100.64/10
+      '192.0.0.1', // RFC 6890
+      '192.0.2.7', // TEST-NET-1
+      '198.18.0.1',
+      '198.19.255.1', // benchmarking /15
+      '198.51.100.9', // TEST-NET-2
+      '203.0.113.20', // TEST-NET-3
+      '224.0.0.1',
+      '239.255.255.250',
+      '255.255.255.255', // multicast + reserved/broadcast
+      'ff02::1',
+      'ff05::2', // v6 multicast
+      '2001:db8::1', // v6 documentation
+      'localhost.localdomain',
+    ];
+    for (const host of blocked) {
+      expect(isBlockedAuditHost(host), host).toBe(true);
+    }
+    for (const host of [
+      '100.63.255.254',
+      '100.128.0.1',
+      '198.17.0.1',
+      '198.20.0.1',
+      '223.255.255.254',
+      '2001:db9::1',
+    ]) {
+      expect(isBlockedAuditHost(host), host).toBe(false);
+    }
+  });
+
+  it('hostResolvesToBlockedIp uses DoH and fails open on resolver errors', async () => {
+    const { hostResolvesToBlockedIp } = maestroAiTestHooks;
+    const dohCalls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input));
+        dohCalls.push(`${url.searchParams.get('name')}:${url.searchParams.get('type')}`);
+        if (url.hostname !== 'cloudflare-dns.com') throw new Error(`unexpected fetch ${url.hostname}`);
+        const name = url.searchParams.get('name');
+        if (name === 'rebind.example') {
+          return new Response(JSON.stringify({ Answer: [{ type: 1, data: '10.0.0.5' }] }), { status: 200 });
+        }
+        if (name === 'ula.example' && url.searchParams.get('type') === 'AAAA') {
+          return new Response(JSON.stringify({ Answer: [{ type: 28, data: 'fd00::1' }] }), { status: 200 });
+        }
+        if (name === 'down.example') throw new Error('doh outage');
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }),
+    );
+    expect(await hostResolvesToBlockedIp('rebind.example')).toBe(true);
+    expect(await hostResolvesToBlockedIp('ula.example')).toBe(true);
+    expect(await hostResolvesToBlockedIp('public.example')).toBe(false);
+    // Fail-open on DoH outage (canonical pre-flight parity: Err => not blocked).
+    expect(await hostResolvesToBlockedIp('down.example')).toBe(false);
+    expect(dohCalls.some((c) => c.startsWith('rebind.example'))).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('probePublicUrl applies canonical tones: 2xx/3xx ok, 4xx incl 429 and 5xx error, 999 warn', async () => {
+    const { probePublicUrl } = maestroAiTestHooks;
+    const probe = async (status: number) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async (input: RequestInfo | URL) => {
+          const url = new URL(String(input));
+          if (url.hostname === 'cloudflare-dns.com') {
+            return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+          }
+          // The Response constructor rejects statuses outside 200-599 (e.g. 999),
+          // so fake the minimal surface the probe reads.
+          return { status, headers: new Headers() } as unknown as Response;
+        }),
+      );
+      const row = await probePublicUrl('https://tone.example/x');
+      vi.unstubAllGlobals();
+      return row;
+    };
+    expect((await probe(204)).tone).toBe('ok');
+    expect((await probe(404)).tone).toBe('error');
+    expect((await probe(429)).tone).toBe('error');
+    expect((await probe(503)).tone).toBe('error');
+    const warn = await probe(999);
+    expect(warn.tone).toBe('warn');
+    expect(warn.ok).toBe(false);
+    // 3xx without a Location header is a final redirection status: canonical ok.
+    expect((await probe(302)).tone).toBe('ok');
+  });
+
+  it('probePublicUrl falls back HEAD->GET on 405/403 and on HEAD transport error, without retries', async () => {
+    const { probePublicUrl } = maestroAiTestHooks;
+    const methods: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (url.hostname === 'cloudflare-dns.com') {
+          return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+        }
+        methods.push(String(init?.method ?? 'GET'));
+        if (init?.method === 'HEAD') return new Response(null, { status: 405 });
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const row = await probePublicUrl('https://m.example/x');
+    expect(row.tone).toBe('ok');
+    expect(methods).toEqual(['HEAD', 'GET']);
+    vi.unstubAllGlobals();
+
+    // HEAD transport error -> single GET fallback; GET transport error -> error tone.
+    let calls = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(String(input));
+        if (url.hostname === 'cloudflare-dns.com') {
+          return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+        }
+        void init;
+        calls += 1;
+        throw new Error('ECONNRESET');
+      }),
+    );
+    const dead = await probePublicUrl('https://dead.example/x');
+    expect(dead.tone).toBe('error');
+    expect(calls).toBe(2); // HEAD + GET, no retry loop
+    vi.unstubAllGlobals();
+  });
+
+  it('probePublicUrl follows redirects up to 5 hops re-validating each hop, and blocks internal pivots', async () => {
+    const { probePublicUrl } = maestroAiTestHooks;
+    const targets: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input));
+        if (url.hostname === 'cloudflare-dns.com') {
+          return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+        }
+        targets.push(url.toString());
+        if (url.pathname === '/pivot') {
+          return new Response(null, { status: 302, headers: { location: 'http://169.254.169.254/latest' } });
+        }
+        if (url.pathname.startsWith('/hop')) {
+          const hop = Number(url.pathname.replace('/hop', '') || 0);
+          return new Response(null, { status: 301, headers: { location: `https://chain.example/hop${hop + 1}` } });
+        }
+        return new Response(null, { status: 200 });
+      }),
+    );
+    // Redirect into an internal host: blocked, the internal target is never fetched.
+    const pivot = await probePublicUrl('https://chain.example/pivot');
+    expect(pivot.tone).toBe('blocked');
+    expect(targets.some((t) => t.includes('169.254.169.254'))).toBe(false);
+    // Endless chain: stops at the 5-hop cap; final 3xx is canonical ok.
+    targets.length = 0;
+    const looped = await probePublicUrl('https://chain.example/hop0');
+    expect(looped.tone).toBe('ok');
+    expect(targets.length).toBe(6); // initial + 5 followed hops
+    vi.unstubAllGlobals();
+  });
+
+  it('finalReleaseAuditFailure short-circuits bibliographic -> capacity -> HTTP with structured context', async () => {
+    const { finalReleaseAuditFailure } = maestroAiTestHooks;
+    // Stage 1: bibliographic blocker wins without any fetch.
+    const fetchSpy = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const biblio = await finalReleaseAuditFailure('Texto com [EVIDENCIA_PENDENTE] e https://x.example/');
+    expect(biblio?.context?.gate).toBe('bibliographic_integrity');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // Stage 2: capacity (31 unique URLs) pauses before any fetch.
+    const many = Array.from({ length: 31 }, (_v, i) => `https://cap${String(i).padStart(2, '0')}.example/`).join(' ');
+    const capacity = await finalReleaseAuditFailure(`Texto limpo ${many}`);
+    expect(capacity?.context?.gate).toBe('link_audit_capacity');
+    expect(capacity?.context?.urls_found).toBe(31);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+    // Stage 3: HTTP audit fails on a 404 row; 999 (warn) does not fail.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input));
+        if (url.hostname === 'cloudflare-dns.com') {
+          return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+        }
+        if (url.hostname === 'missing.example') return new Response(null, { status: 404 });
+        if (url.hostname === 'weird.example') return { status: 999, headers: new Headers() } as unknown as Response;
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const http = await finalReleaseAuditFailure(
+      'Texto https://ok.example/ https://missing.example/ https://weird.example/',
+    );
+    expect(http?.context?.gate).toBe('link_audit');
+    expect(http?.context?.failed).toBe(1);
+    expect(http?.context?.ok).toBe(1);
+    const clean = await finalReleaseAuditFailure('Texto https://ok.example/ https://weird.example/');
+    expect(clean).toBeNull();
+    vi.unstubAllGlobals();
+  });
+});
+
 describe('Maestro AI provider retry and time budget (Plan C)', () => {
   it('parseRetryAfterHeader handles delta-seconds, HTTP-date and absence', () => {
     const { parseRetryAfterHeader } = maestroAiTestHooks;
@@ -1377,48 +1618,270 @@ describe('runSession orchestrator', () => {
     expect(row?.current_text).toBe('Rascunho valido e completo.');
   });
 
-  it('blocks the session when a link is persistently 5xx (broken after retry)', async () => {
+  it('a broken link no longer kills the draft: the release audit rejects READY-unchanged at finalization (Plan D)', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
-    vi.stubGlobal(
-      'fetch',
-      providerFetch({
-        claudeText: 'Rascunho com link https://example.com/artigo aqui.',
-        codexText: 'MAESTRO_STATUS: READY',
-        linkStatus: 503,
-      }),
-    );
-    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
-    vi.unstubAllGlobals();
-
-    expect(db.__sessions.get('run-1')?.status).toBe('blocked_link_audit');
-  });
-
-  it('blocks the session as blocked_link_audit on a genuinely broken link (404)', async () => {
-    const db = createInMemoryDb({ sessions: [runnableSession()] });
-    const fetchMock = providerFetch({
-      claudeText: 'Rascunho com link https://example.com/missing aqui.',
-      linkStatus: 404,
+    // Draft carries a 404 link. The draft itself proceeds (no per-draft audit);
+    // codex votes READY unchanged, which IS a finalization attempt -> the full
+    // release audit runs, fails on the link, and the vote is ReadyRejected.
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'Rascunho com link https://example.com/missing aqui.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }
+      return new Response('', { status: 404 });
     });
     vi.stubGlobal('fetch', fetchMock);
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
-    expect(db.__sessions.get('run-1')?.status).toBe('blocked_link_audit');
-    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.openai.com')).toBe(false);
+    const row = db.__sessions.get('run-1');
+    // ReadyRejected forever (the link stays broken) -> serial turn cap.
+    expect(row?.status).toBe('paused_cycle_limit');
+    expect(row?.final_text ?? null).toBeNull();
+    const events = JSON.parse(String(row?.events_json)) as Array<{ message?: string }>;
+    expect(
+      events.some((event) =>
+        /READY rejected by release gate: final candidate failed link audit/.test(String(event.message)),
+      ),
+    ).toBe(true);
+    // The broken link WAS probed (finalization attempt), and the per-execution
+    // cache kept the HTTP audit to a single pass despite repeated votes.
+    const linkProbes = fetchMock.mock.calls.filter(([input]) => new URL(String(input)).hostname === 'example.com');
+    expect(linkProbes.length).toBeGreaterThanOrEqual(1);
+    expect(linkProbes.length).toBeLessThanOrEqual(2); // HEAD (+GET fallback at most)
   });
 
-  it('blocks the session when the draft contains an internal-host link, without ever fetching it', async () => {
+  it('pauses as paused_final_audit with durable structured context when a link dies between the vote and finalization', async () => {
     const db = createInMemoryDb({ sessions: [runnableSession()] });
+    // The link is healthy (200) during the READY-unchanged vote's audit, then
+    // dies (404) when the finalization gate re-runs the audit FRESH (canonical:
+    // the desktop has no cache at the finalization call sites).
+    let linkProbes = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (hostOf(url) === 'api.anthropic.com') {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
         return new Response(
           JSON.stringify({
-            content: [{ type: 'text', text: 'Veja http://169.254.169.254/latest/meta e http://localhost:8787/admin' }],
+            content: [{ type: 'text', text: 'Rascunho com link https://example.com/artigo aqui.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }
+      linkProbes += 1;
+      return new Response('', { status: linkProbes === 1 ? 200 : 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    expect(row?.status).toBe('paused_final_audit');
+    expect(row?.final_text ?? null).toBeNull();
+    expect(String(row?.error)).toBe('final candidate failed link audit');
+    // The durable session event carries a machine-structured final_audit field
+    // (gate/reason/context) plus the audit rows, persisted in events_json.
+    const events = JSON.parse(String(row?.events_json)) as Array<{
+      message?: string;
+      link_audit?: unknown[];
+      final_audit?: { gate?: string; reason?: string; context?: Record<string, unknown> };
+    }>;
+    const pauseEvent = events.find((event) => event.final_audit?.gate === 'link_audit');
+    expect(pauseEvent).toBeDefined();
+    expect(pauseEvent?.final_audit?.reason).toBe('final candidate failed link audit');
+    expect(pauseEvent?.final_audit?.context?.urls_found).toBe(1);
+    expect(pauseEvent?.final_audit?.context?.failed).toBe(1);
+    expect(pauseEvent?.final_audit?.context?.rows).toBeUndefined(); // rows travel in link_audit
+    expect(Array.isArray(pauseEvent?.link_audit)).toBe(true);
+  });
+
+  it('records structured final_audit context on the durable turn event for the bibliographic gate', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const fetchSpyTargets: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'Texto com marcador [EVIDENCIA_PENDENTE] ainda presente.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      fetchSpyTargets.push(url.hostname);
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    const events = JSON.parse(String(row?.events_json)) as Array<{
+      final_audit?: { gate?: string; reason?: string };
+    }>;
+    const rejected = events.find((event) => event.final_audit?.gate === 'bibliographic_integrity');
+    expect(rejected).toBeDefined();
+    expect(String(rejected?.final_audit?.reason)).toMatch(/bibliographic integrity gate/);
+    // Stage 1 short-circuits before any URL work: no audit fetches at all.
+    expect(fetchSpyTargets).toEqual([]);
+  });
+
+  it('records structured final_audit context on the durable turn event for the capacity gate, with zero fetches', async () => {
+    const manyLinks = Array.from({ length: 31 }, (_v, i) => `https://cap${String(i).padStart(2, '0')}.example/`).join(
+      ' ',
+    );
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const auditTargets: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: `Texto com muitos links: ${manyLinks}` }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      auditTargets.push(url.hostname);
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    const events = JSON.parse(String(row?.events_json)) as Array<{
+      final_audit?: { gate?: string; context?: Record<string, unknown> };
+    }>;
+    const rejected = events.find((event) => event.final_audit?.gate === 'link_audit_capacity');
+    expect(rejected).toBeDefined();
+    expect(rejected?.final_audit?.context?.urls_found).toBe(31);
+    expect(rejected?.final_audit?.context?.max_urls).toBe(30);
+    // Stage 2 short-circuits before the HTTP stage: no audit fetches at all.
+    expect(auditTargets).toEqual([]);
+  });
+
+  it('converges when the custody link is publicly reachable (release audit passes at finalization)', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const probed: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'Rascunho com link https://example.com/artigo aqui.' }],
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }
+      probed.push(url.hostname);
+      return new Response('', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
+    vi.unstubAllGlobals();
+
+    const row = db.__sessions.get('run-1');
+    expect(row?.status).toBe('converged');
+    expect(row?.final_text).toBe('Rascunho com link https://example.com/artigo aqui.');
+    expect(probed).toContain('example.com');
+  });
+
+  it('rejects finalization of a custody text with internal-host links, without ever fetching them (Plan D SSRF)', async () => {
+    const db = createInMemoryDb({ sessions: [runnableSession()] });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'api.anthropic.com') {
+        return new Response(
+          JSON.stringify({
+            content: [
+              { type: 'text', text: 'Veja http://169.254.169.254/latest/meta e http://localhost:8787/admin agora.' },
+            ],
             usage: {},
           }),
           { status: 200 },
         );
+      }
+      if (url.hostname === 'api.openai.com') {
+        return new Response(
+          JSON.stringify({
+            output_text:
+              'MAESTRO_STATUS: READY\n<maestro_revision_report>custody: "unchanged"\nchanges: []\nno blockers found in the current text</maestro_revision_report>',
+            usage: { input_tokens: 10, output_tokens: 20 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
       }
       return new Response('', { status: 200 });
     });
@@ -1426,12 +1889,14 @@ describe('runSession orchestrator', () => {
     await maestroAiTestHooks.runSession(db, { ...env, BIGDATA_DB: db }, 'run-1');
     vi.unstubAllGlobals();
 
-    expect(db.__sessions.get('run-1')?.status).toBe('blocked_link_audit');
-    // The internal hosts were judged broken WITHOUT any outbound fetch to them.
+    const row = db.__sessions.get('run-1');
+    // Internal links are blocked rows in the release audit: finalization is
+    // rejected (ReadyRejected loop -> turn cap) and no final text is written.
+    expect(row?.status).toBe('paused_cycle_limit');
+    expect(row?.final_text ?? null).toBeNull();
+    // The internal hosts were judged blocked WITHOUT any outbound fetch to them.
     expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === '169.254.169.254')).toBe(false);
     expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'localhost')).toBe(false);
-    // ...and reviewers were never invoked.
-    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === 'api.openai.com')).toBe(false);
   });
 
   it('stops cooperatively when the session is cancelled mid-run and skips remaining reviewers', async () => {
@@ -2186,78 +2651,45 @@ describe('fetchWithTimeout', () => {
   });
 });
 
-describe('checkOneLink (retry + bounded redirect follow)', () => {
-  it('treats a persistently 5xx link as broken (not a free pass)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response('', { status: 500 })),
-    );
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/x');
-    vi.unstubAllGlobals();
-    expect(result.ok).toBe(false);
-  });
+describe('probePublicUrl (canonical redirect follow to final status)', () => {
+  const withDoh = (handler: (url: URL) => Response | Promise<Response>) =>
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }
+      return handler(url);
+    });
 
-  it('passes a momentary 5xx that recovers on retry', async () => {
-    let calls = 0;
+  it('follows a public redirect to its final destination and reports a 404 as error', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => {
-        calls += 1;
-        return new Response('', { status: calls === 1 ? 503 : 200 });
-      }),
-    );
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/x');
-    vi.unstubAllGlobals();
-    expect(result.ok).toBe(true);
-  });
-
-  it('follows a public redirect to its final destination and reports a 404 as broken', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input);
-        if (url.endsWith('/start')) {
+      withDoh((url) => {
+        if (url.pathname === '/start') {
           return new Response('', { status: 301, headers: { location: 'https://example.com/missing' } });
         }
         return new Response('', { status: 404 });
       }),
     );
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/start');
+    const result = await maestroAiTestHooks.probePublicUrl('https://example.com/start');
     vi.unstubAllGlobals();
+    expect(result.tone).toBe('error');
     expect(result.ok).toBe(false);
   });
 
-  it('treats a 3xx with no Location header as broken (not reachable)', async () => {
+  it('treats a persistent 5xx as error with no retry (single probe)', async () => {
+    let probes = 0;
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => new Response('', { status: 302 })),
+      withDoh(() => {
+        probes += 1;
+        return new Response('', { status: 500 });
+      }),
     );
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/x');
+    const result = await maestroAiTestHooks.probePublicUrl('https://example.com/x');
     vi.unstubAllGlobals();
-    expect(result.ok).toBe(false);
-  });
-
-  it('treats an unresolving redirect chain (past the hop limit) as broken', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => new Response('', { status: 301, headers: { location: 'https://example.com/next' } })),
-    );
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/start');
-    vi.unstubAllGlobals();
-    expect(result.ok).toBe(false);
-  });
-
-  it('refuses to follow a redirect into an internal host and never fetches it', async () => {
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (hostOf(url) === '169.254.169.254') return new Response('secret', { status: 200 });
-      return new Response('', { status: 302, headers: { location: 'http://169.254.169.254/latest/meta-data' } });
-    });
-    vi.stubGlobal('fetch', fetchMock);
-    const result = await maestroAiTestHooks.checkOneLink('https://example.com/start');
-    vi.unstubAllGlobals();
-    expect(result.ok).toBe(false);
-    expect(fetchMock.mock.calls.some(([u]) => hostOf(u) === '169.254.169.254')).toBe(false);
+    expect(result.tone).toBe('error');
+    expect(probes).toBe(1); // canonical: no retry loop (HEAD only; 500 is decisive)
   });
 });
 
@@ -2302,43 +2734,27 @@ describe('maestro link-audit host safety (SSRF hardening)', () => {
     expect(maestroAiTestHooks.isBlockedAuditHost('::ffff:808:808')).toBe(false);
   });
 
-  it('never fetches an IPv4-mapped IPv6 loopback target', async () => {
-    const fetchMock = vi.fn();
+  it('runLinkAudit turns blocked/invalid candidates into failed rows WITHOUT any fetch', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input));
+      if (url.hostname === 'cloudflare-dns.com') {
+        return new Response(JSON.stringify({ Answer: [{ type: 1, data: '93.184.216.34' }] }), { status: 200 });
+      }
+      return new Response('', { status: 200 });
+    });
     vi.stubGlobal('fetch', fetchMock);
-    const result = await maestroAiTestHooks.checkOneLink('http://[::ffff:127.0.0.1]/');
-    vi.unstubAllGlobals();
-    expect(result.ok).toBe(false);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('flags a blocked-host URL as broken WITHOUT fetching it (audit failure, not silent omission)', async () => {
-    // extractUrls surfaces the blocked host so the audit can report it...
-    const urls = maestroAiTestHooks.extractUrls(
-      'See https://example.com/ok and http://169.254.169.254/meta and http://localhost:8787/admin',
+    // Internal hosts and a bracketed IPv6 literal (truncated at `]` by the
+    // canonical tokenizer -> invalid URL) all surface as blocked rows; the
+    // public link is probed and passes.
+    const audit = await maestroAiTestHooks.runLinkAudit(
+      'See https://example.com/ok and http://169.254.169.254/meta and http://localhost:8787/admin and http://[::ffff:127.0.0.1]/latest',
     );
-    expect(urls).toContain('https://example.com/ok');
-    expect(urls.some((u: string) => hostOf(u) === '169.254.169.254')).toBe(true);
-    // ...but checkOneLink rejects it as !ok and never performs a fetch.
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
-    const internal = await maestroAiTestHooks.checkOneLink('http://169.254.169.254/meta');
-    const localhost = await maestroAiTestHooks.checkOneLink('http://localhost:8787/admin');
     vi.unstubAllGlobals();
-    expect(internal.ok).toBe(false);
-    expect(localhost.ok).toBe(false);
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it('surfaces bracketed IPv6 URLs so internal IPv6 links are audited, not silently dropped', () => {
-    // The URL tokenizer must not truncate `http://[::ffff:127.0.0.1]/` at the
-    // bracket: an internal IPv6 literal has to reach checkOneLink as a real URL,
-    // otherwise isBlockedAuditHost is never consulted and the link is ignored.
-    const urls = maestroAiTestHooks.extractUrls(
-      'Veja http://[::ffff:127.0.0.1]/latest e http://[::1]/admin e https://example.com/ok',
-    );
-    const hosts = urls.map((u: string) => hostOf(u));
-    expect(hosts).toContain('[::ffff:7f00:1]'); // ::ffff:127.0.0.1 normalized by URL.hostname
-    expect(hosts).toContain('[::1]');
-    expect(urls).toContain('https://example.com/ok');
+    expect(audit.urlsFound).toBe(4);
+    expect(audit.checked).toBe(1);
+    expect(audit.ok).toBe(1);
+    expect(audit.failed).toBe(3);
+    const fetched = fetchMock.mock.calls.map(([input]) => new URL(String(input)).hostname);
+    expect(fetched.every((host) => host === 'cloudflare-dns.com' || host === 'example.com')).toBe(true);
   });
 });

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -174,6 +174,9 @@ type SessionEvent = {
   cost_usd?: number;
   model?: string;
   link_audit?: LinkAuditResult[];
+  /** Structured release-audit context (canonical audit_context), persisted in
+   *  events_json whenever a release-audit failure produces this event. */
+  final_audit?: { gate: string; reason: string; context: Record<string, unknown> };
 };
 
 type LinkAuditResult = {
@@ -181,6 +184,8 @@ type LinkAuditResult = {
   ok: boolean;
   status?: number;
   error?: string;
+  /** Canonical audit tone: ok | error | warn | blocked (warn fails nothing). */
+  tone?: string;
 };
 
 type ArtifactInput = {
@@ -1451,15 +1456,23 @@ function correctiveRetrySection(retryCount: number): string {
  * search content), so the auto-fetch must never reach internal infrastructure
  * (SSRF). Returns true when the host must NOT be fetched.
  */
-/** True when an IPv4 literal falls in a private / loopback / link-local / unspecified range. */
+/** True when an IPv4 literal falls in a blocked range (canonical link_audit.rs
+ *  table): this-network, RFC1918, loopback, CGNAT 100.64/10, link-local,
+ *  RFC6890 192.0.0/24, TEST-NETs, benchmarking 198.18/15, multicast/reserved. */
 function isPrivateIpv4(host: string): boolean {
   const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
   if (!ipv4) return false;
-  const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+  const [a, b, c] = [Number(ipv4[1]), Number(ipv4[2]), Number(ipv4[3])];
   if (a === 10 || a === 127 || a === 0) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
   if (a === 192 && b === 168) return true;
   if (a === 169 && b === 254) return true;
   if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && (c === 0 || c === 2)) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && c === 100) return true;
+  if (a === 203 && b === 0 && c === 113) return true;
+  if (a >= 224) return true;
   return false;
 }
 
@@ -1487,7 +1500,9 @@ function isBlockedAuditHost(hostname: string): boolean {
     .toLowerCase()
     .replace(/^\[|\]$/g, '');
   if (!host) return true;
-  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (host === 'localhost' || host === 'localhost.localdomain' || host.endsWith('.localhost')) return true;
+  // Web hardening beyond the desktop list (documented deviation): `.internal`
+  // and bare single-label hosts are always internal from a Worker's egress.
   if (host.endsWith('.internal') || host.endsWith('.local')) return true;
   // Bare single-label hostnames (no dot) resolve to internal names.
   if (!host.includes('.') && !host.includes(':')) return true;
@@ -1497,11 +1512,14 @@ function isBlockedAuditHost(hostname: string): boolean {
     return isPrivateIpv4(host);
   }
 
-  // IPv6 loopback / unspecified / unique-local (fc00::/7) / link-local (fe80::/10).
+  // IPv6 loopback / unspecified / unique-local (fc00::/7) / link-local
+  // (fe80::/10) / multicast (ff00::/8) / documentation (2001:db8::/32).
   if (host.includes(':')) {
     if (host === '::1' || host === '::') return true;
     if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
     if (/^fe[89ab][0-9a-f]:/.test(host)) return true;
+    if (/^ff[0-9a-f]{2}:/.test(host)) return true;
+    if (/^2001:0?db8:/.test(host)) return true;
     // IPv4-mapped / IPv4-compatible IPv6 (e.g. ::ffff:127.0.0.1): apply the
     // IPv4 private-range check to the embedded address.
     const embedded = embeddedIpv4FromIpv6(host);
@@ -1512,117 +1530,283 @@ function isBlockedAuditHost(hostname: string): boolean {
   return false;
 }
 
-function extractUrls(text: string): string[] {
-  const urls = new Set<string>();
-  // First alternative keeps a bracketed IPv6 host (e.g. http://[::ffff:127.0.0.1]/)
-  // intact so internal IPv6 literals still reach checkOneLink; without it the
-  // generic tokenizer stops at the closing `]` and the URL is dropped as malformed.
-  for (const match of text.matchAll(/https?:\/\/\[[0-9a-f:.]+\][^\s<>"')\]}]*|https?:\/\/[^\s<>"')\]}]+/gi)) {
-    const url = match[0].replace(/[.,;:!?]+$/g, '');
-    try {
-      const parsed = new URL(url);
-      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') continue;
-      // Blocked (internal/private) hosts are NOT filtered out here: checkOneLink
-      // rejects them as broken WITHOUT fetching, so an internal URL in the
-      // content surfaces as an audit failure instead of being silently dropped.
-      urls.add(parsed.toString());
-    } catch {
-      // Ignore malformed candidates; the checker reports only concrete URLs.
-    }
+// ── Plan D: canonical release link audit (port of link_audit.rs) ──
+// The full audit (capacity + HTTP) runs only on finalization attempts:
+// convergence, READY-unchanged and NOT_READY-unchanged turns. Per-revision
+// audits were removed for parity — a broken link pauses the release, it no
+// longer kills the session mid-run.
+const LINK_AUDIT_MAX_UNIQUE_URLS = 30;
+const LINK_AUDIT_MAX_MATCHES = 80;
+const LINK_AUDIT_TIMEOUT_MS = 15_000;
+const LINK_AUDIT_MAX_REDIRECT_HOPS = 5;
+// Canonical extraction regex: stop-set is whitespace and < > " ' ) ] — no `}`.
+const LINK_AUDIT_URL_REGEX = /https?:\/\/[^\s<>"')\]]+/g;
+
+type LinkCandidate = { url: string; rejection: string | null };
+
+/** Canonical rejection reason for a non-public/invalid audit URL, or null. */
+function publicHttpUrlRejectionReason(value: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return 'URL invalida ou incompleta';
   }
-  return [...urls].slice(0, 40);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return 'somente links http:// ou https:// podem ser auditados';
+  }
+  if (!parsed.hostname) return 'link sem host/dominio';
+  if (isBlockedAuditHost(parsed.hostname)) {
+    return 'endereco local, privado ou reservado bloqueado por seguranca';
+  }
+  return null;
 }
 
-/** A 5xx or 429 may be momentary; everything else (e.g. 404) is decisive. */
-function isRetryableLinkStatus(status: number): boolean {
-  return status === 429 || status >= 500;
+/** Canonical extraction: first 80 matches scanned, trailing .,;: trimmed,
+ *  deduped on the cleaned string, capped at 30 candidates, sorted
+ *  lexicographically (BTreeSet parity). Rejected candidates are KEPT with a
+ *  rejection reason so they surface as blocked rows instead of vanishing. */
+function extractUrlCandidates(text: string): LinkCandidate[] {
+  const seen = new Set<string>();
+  const candidates: LinkCandidate[] = [];
+  let matches = 0;
+  for (const match of text.matchAll(LINK_AUDIT_URL_REGEX)) {
+    matches += 1;
+    if (matches > LINK_AUDIT_MAX_MATCHES) break;
+    const cleaned = match[0].replace(/[.,;:]+$/g, '');
+    if (!cleaned || seen.has(cleaned)) continue;
+    seen.add(cleaned);
+    candidates.push({ url: cleaned, rejection: publicHttpUrlRejectionReason(cleaned) });
+    if (candidates.length >= LINK_AUDIT_MAX_UNIQUE_URLS) break;
+  }
+  return candidates.sort((a, b) => (a.url < b.url ? -1 : a.url > b.url ? 1 : 0));
 }
 
-type LinkAttempt = { ok: boolean; status?: number; error?: string; retryable: boolean };
+/** Canonical capacity counter: counts ALL unique cleaned URLs (including
+ *  blocked ones) across the first 80 matches, stopping at 31. */
+function countUniqueUrlCandidates(text: string): number {
+  const seen = new Set<string>();
+  let matches = 0;
+  for (const match of text.matchAll(LINK_AUDIT_URL_REGEX)) {
+    matches += 1;
+    if (matches > LINK_AUDIT_MAX_MATCHES) break;
+    const cleaned = match[0].replace(/[.,;:]+$/g, '');
+    if (cleaned) seen.add(cleaned);
+    if (seen.size > LINK_AUDIT_MAX_UNIQUE_URLS) break;
+  }
+  return seen.size;
+}
+
+/** DoH pre-flight (web analogue of the desktop's system-resolver pre-flight +
+ *  connection-bound resolver, which Workers cannot host): resolves A and AAAA
+ *  via Cloudflare DoH and blocks when ANY answer is in a blocked range.
+ *  Fails open on resolver errors (canonical parity: the fetch would fail to
+ *  connect anyway); the connection-bound anti-rebinding layer has no Workers
+ *  equivalent and is a documented deviation. */
+async function hostResolvesToBlockedIp(host: string): Promise<boolean> {
+  // IP literals are already range-checked lexically; DoH applies to names only.
+  if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || host.includes(':')) return false;
+  const lookups = ['A', 'AAAA'].map(async (type) => {
+    const endpoint = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(host)}&type=${type}`;
+    const response = await fetchWithTimeout(endpoint, { headers: { accept: 'application/dns-json' } }, 5_000);
+    if (!response.ok) return false;
+    const payload = (await response.json()) as { Answer?: Array<{ type?: number; data?: string }> };
+    return (payload.Answer ?? []).some((answer) => {
+      // Type 1 = A, 28 = AAAA; other records (CNAME etc) carry no address.
+      if (answer.type !== 1 && answer.type !== 28) return false;
+      return isBlockedAuditHost(String(answer.data ?? ''));
+    });
+  });
+  try {
+    const results = await Promise.all(lookups);
+    return results.some(Boolean);
+  } catch {
+    return false;
+  }
+}
+
+/** Full per-URL guard: lexical + DoH pre-flight. Returns a rejection reason or null. */
+async function auditTargetRejectionReason(target: URL): Promise<string | null> {
+  const lexical = publicHttpUrlRejectionReason(target.toString());
+  if (lexical) return lexical;
+  if (await hostResolvesToBlockedIp(target.hostname.toLowerCase())) {
+    return 'dominio resolve para IP privado/reservado bloqueado por seguranca';
+  }
+  return null;
+}
+
+/** One HTTP request with the canonical audit client settings. */
+async function auditFetch(target: string, method: 'HEAD' | 'GET'): Promise<Response> {
+  return fetchWithTimeout(
+    target,
+    {
+      method,
+      redirect: 'manual',
+      // Canonical UA is "Maestro Editorial AI/{version}"; the worker has no
+      // package-version binding, so the web port identifies itself as /web.
+      headers: { 'user-agent': 'Maestro Editorial AI/web' },
+    },
+    LINK_AUDIT_TIMEOUT_MS,
+  );
+}
+
+function linkAuditRow(
+  url: string,
+  status: number | undefined,
+  error: string | undefined,
+  tone: string,
+): LinkAuditResult {
+  return {
+    url: sanitizeText(url, 240),
+    ok: tone === 'ok',
+    ...(status !== undefined ? { status } : {}),
+    ...(error !== undefined ? { error: sanitizeText(error, 180) } : {}),
+    tone: sanitizeText(tone, 16),
+  };
+}
+
+/** Canonical tone for a final HTTP status: 2xx/3xx ok; 4xx/5xx error; anything
+ *  else (1xx, non-standard like 999) warn — counted in neither ok nor failed. */
+function toneForStatus(status: number): 'ok' | 'error' | 'warn' {
+  if (status >= 200 && status < 400) return 'ok';
+  if (status >= 400 && status < 600) return 'error';
+  return 'warn';
+}
 
 /**
- * One link-reachability attempt. Follows redirects MANUALLY (bounded) so a
- * public link that redirects into an internal host is never fetched (SSRF
- * pivot), while a public redirect chain is still followed to its final status
- * so a redirect that ends in a 404 is correctly reported as broken.
+ * Canonical probe: HEAD first; GET fallback on 405/403 or HEAD transport
+ * error; no retries. Redirects are followed manually up to 5 hops, re-running
+ * the full guard (lexical + DoH) on every hop; a hop into a blocked target is
+ * a `blocked` row. A chain still redirecting at the hop cap keeps its final
+ * 3xx status, which is canonically `ok`.
  */
-async function attemptLink(url: string, timeoutMs = 8000): Promise<LinkAttempt> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+async function probePublicUrl(url: string): Promise<LinkAuditResult> {
   const headOrGet = async (target: string): Promise<Response> => {
-    let res = await fetch(target, { method: 'HEAD', redirect: 'manual', signal: controller.signal });
-    if (res.status === 405 || res.status === 403) {
-      res = await fetch(target, { method: 'GET', redirect: 'manual', signal: controller.signal });
+    let response: Response;
+    try {
+      response = await auditFetch(target, 'HEAD');
+    } catch {
+      return auditFetch(target, 'GET');
     }
-    return res;
+    if (response.status === 405 || response.status === 403) {
+      return auditFetch(target, 'GET');
+    }
+    return response;
   };
   try {
     let current = url;
     let response = await headOrGet(current);
-    for (let hops = 0; response.status >= 300 && response.status < 400 && hops < 3; hops += 1) {
+    for (
+      let hops = 0;
+      response.status >= 300 && response.status < 400 && hops < LINK_AUDIT_MAX_REDIRECT_HOPS;
+      hops += 1
+    ) {
       const location = response.headers.get('location');
-      if (!location) break; // 3xx without Location — stop following; judged not-reachable by the 2xx check below.
+      if (!location) break; // 3xx without Location: final status, canonical ok.
       let target: URL;
       try {
         target = new URL(location, current);
       } catch {
-        return { ok: false, status: response.status, error: 'redirect invalido', retryable: false };
+        return linkAuditRow(url, response.status, 'redirect invalido', 'blocked');
       }
-      if (target.protocol !== 'http:' && target.protocol !== 'https:') {
-        return { ok: false, status: response.status, error: 'redirect nao-http', retryable: false };
-      }
-      if (isBlockedAuditHost(target.hostname)) {
-        return { ok: false, status: response.status, error: 'redirect para host bloqueado', retryable: false };
+      const rejection = await auditTargetRejectionReason(target);
+      if (rejection) {
+        return linkAuditRow(url, response.status, `redirect bloqueado: ${rejection}`, 'blocked');
       }
       current = target.toString();
       response = await headOrGet(current);
     }
-    // After resolving redirects ourselves, only a final 2xx confirms the link is
-    // reachable. A leftover 3xx (redirect without a Location header, or a chain
-    // still redirecting past the hop limit) is NOT confirmed and counts as broken.
-    const ok = response.status >= 200 && response.status < 300;
-    return { ok, status: response.status, retryable: !ok && isRetryableLinkStatus(response.status) };
+    return linkAuditRow(url, response.status, undefined, toneForStatus(response.status));
   } catch (error) {
+    return linkAuditRow(url, undefined, error instanceof Error ? error.message : String(error), 'error');
+  }
+}
+
+type LinkAuditAggregate = {
+  urlsFound: number;
+  checked: number;
+  ok: number;
+  failed: number;
+  rows: LinkAuditResult[];
+};
+
+/**
+ * Canonical run_link_audit: blocked/invalid candidates become `blocked` rows
+ * without any fetch; public candidates are probed. Desktop probes sequentially
+ * on a blocking client — the web probes in parallel (documented deviation for
+ * the Worker budget) but rows keep the canonical lexicographic order.
+ * `failed` counts error+blocked; `warn` rows count in neither ok nor failed.
+ */
+async function runLinkAudit(text: string): Promise<LinkAuditAggregate> {
+  const candidates = extractUrlCandidates(text);
+  const rows = await Promise.all(
+    candidates.map(async (candidate) => {
+      if (candidate.rejection) return linkAuditRow(candidate.url, undefined, candidate.rejection, 'blocked');
+      const dohRejection = await hostResolvesToBlockedIp(new URL(candidate.url).hostname.toLowerCase());
+      if (dohRejection) {
+        return linkAuditRow(
+          candidate.url,
+          undefined,
+          'dominio resolve para IP privado/reservado bloqueado por seguranca',
+          'blocked',
+        );
+      }
+      return probePublicUrl(candidate.url);
+    }),
+  );
+  const checked = candidates.filter((candidate) => candidate.rejection === null).length;
+  const ok = rows.filter((row) => row.tone === 'ok').length;
+  const failed = rows.filter((row) => row.tone === 'error' || row.tone === 'blocked').length;
+  return { urlsFound: candidates.length, checked, ok, failed, rows };
+}
+
+type FinalReleaseAuditFailure = {
+  reason: string;
+  context: Record<string, unknown> & { gate: string };
+};
+
+/**
+ * Canonical final_release_audit_failure: three short-circuiting stages —
+ * bibliographic integrity, link-audit capacity (> 30 unique URLs), HTTP link
+ * audit (failed > 0). All three funnel into the single paused_final_audit
+ * status (desktop PAUSED_FINAL_REFERENCE_AUDIT).
+ */
+async function finalReleaseAuditFailure(text: string): Promise<FinalReleaseAuditFailure | null> {
+  const bibliographicError = validateFinalReleaseCandidate(text);
+  if (bibliographicError) {
     return {
-      ok: false,
-      error: error instanceof Error ? sanitizeText(error.message, 240) : String(error),
-      retryable: true,
+      reason: bibliographicError,
+      context: { gate: 'bibliographic_integrity', policy: 'final_text_must_not_hide_unverified_references' },
     };
-  } finally {
-    clearTimeout(timer);
   }
-}
-
-async function checkOneLink(url: string): Promise<LinkAuditResult> {
-  // A blocked (internal/private/loopback) host is reported as broken WITHOUT any
-  // fetch — this is the single point that both prevents SSRF and surfaces an
-  // internal URL in the content as an audit failure (extractUrls no longer drops it).
-  try {
-    if (isBlockedAuditHost(new URL(url).hostname)) {
-      return { url, ok: false, error: 'host bloqueado' };
-    }
-  } catch {
-    return { url, ok: false, error: 'url invalida' };
+  const urlCount = countUniqueUrlCandidates(text);
+  if (urlCount > LINK_AUDIT_MAX_UNIQUE_URLS) {
+    return {
+      reason: 'final candidate exceeds link audit capacity',
+      context: {
+        gate: 'link_audit_capacity',
+        urls_found: urlCount,
+        max_urls: LINK_AUDIT_MAX_UNIQUE_URLS,
+        policy: 'final_text_must_not_contain_unaudited_public_links',
+      },
+    };
   }
-  // A single retry absorbs a momentary failure (timeout / network / 429 / 5xx)
-  // without giving a PERSISTENTLY broken link a free pass: if the retry also
-  // fails, the link is reported as broken and the session is blocked.
-  let attempt = await attemptLink(url);
-  if (!attempt.ok && attempt.retryable) {
-    attempt = await attemptLink(url);
+  const audit = await runLinkAudit(text);
+  if (audit.failed > 0) {
+    return {
+      reason: 'final candidate failed link audit',
+      context: {
+        gate: 'link_audit',
+        urls_found: audit.urlsFound,
+        checked: audit.checked,
+        ok: audit.ok,
+        failed: audit.failed,
+        rows: audit.rows,
+        policy: 'all_final_public_links_must_be_valid_before_release',
+      },
+    };
   }
-  return {
-    url,
-    ok: attempt.ok,
-    ...(attempt.status !== undefined ? { status: attempt.status } : {}),
-    ...(attempt.error !== undefined ? { error: attempt.error } : {}),
-  };
-}
-
-async function auditLinks(text: string): Promise<LinkAuditResult[]> {
-  const urls = extractUrls(text);
-  if (urls.length === 0) return [];
-  return Promise.all(urls.map((url) => checkOneLink(url)));
+  return null;
 }
 
 function buildDraftPrompt(input: MaestroResolvedSessionInput, runId: string): string {
@@ -2126,8 +2310,12 @@ export const maestroAiTestHooks = {
   closingTurnHasRequiredPriorReviews,
   selectSerialReviewerIndex,
   isBlockedAuditHost,
-  extractUrls,
-  checkOneLink,
+  extractUrlCandidates,
+  countUniqueUrlCandidates,
+  hostResolvesToBlockedIp,
+  probePublicUrl,
+  runLinkAudit,
+  finalReleaseAuditFailure,
   fetchWithTimeout,
   parseRetryAfterHeader,
   remainingSessionMs,
@@ -2286,6 +2474,26 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
     return remaining === null ? PROVIDER_TIMEOUT_MS : Math.max(1, Math.min(PROVIDER_TIMEOUT_MS, remaining));
   };
   const callOptions = (): ProviderCallOptions => ({ timeoutMs: callTimeoutMs(), isCancelled });
+  // Plan D (documented web deviation): the desktop re-runs the full release
+  // audit (incl. HTTP) on every unchanged turn; on Workers that would multiply
+  // subrequests past the platform budget, so within ONE execution the audit
+  // result is cached per custody text.
+  const releaseAuditCache = new Map<string, FinalReleaseAuditFailure | null>();
+  const cachedFinalReleaseAuditFailure = async (text: string): Promise<FinalReleaseAuditFailure | null> => {
+    if (releaseAuditCache.has(text)) return releaseAuditCache.get(text) ?? null;
+    const failure = await finalReleaseAuditFailure(text);
+    releaseAuditCache.set(text, failure);
+    return failure;
+  };
+  // Machine-readable release-audit context for durable session events
+  // (canonical audit_context): rows are excluded from the summary because they
+  // travel in the event's own link_audit field.
+  const finalAuditEventField = (
+    failure: FinalReleaseAuditFailure,
+  ): { gate: string; reason: string; context: Record<string, unknown> } => {
+    const { rows: _rows, ...contextSummary } = failure.context;
+    return { gate: failure.context.gate, reason: failure.reason, context: contextSummary };
+  };
 
   try {
     logMaestro('info', 'session_started', { session_id: id, initial_agent: initialAgent, active_agents: activeAgents });
@@ -2298,40 +2506,20 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
       return;
     }
     let currentText = '';
-    let currentLinkAudit: Awaited<ReturnType<typeof auditLinks>> = [];
     if (isResume) {
       // Canonical resume (limited recovery): custody text/author are restored,
       // the draft phase is skipped, and the review circuit restarts with empty
-      // approval/round accounting.
+      // approval/round accounting. Link auditing happens only at finalization
+      // attempts (Plan D canonical placement), not here.
       currentText = String(row.current_text);
       currentAuthor = sanitizeAgent(row.current_author ?? '', initialAgent);
-      currentLinkAudit = await auditLinks(currentText);
-      const brokenResumeLinks = currentLinkAudit.filter((result) => !result.ok);
       await pushEvent({
         at: nowIso(),
         agent: currentAuthor,
         role: 'draft',
-        status: brokenResumeLinks.length ? 'blocked' : 'running',
+        status: 'running',
         message: 'Session resumed: draft phase skipped, custody text recovered.',
-        link_audit: currentLinkAudit,
       });
-      if (brokenResumeLinks.length) {
-        await persistSession(
-          db,
-          id,
-          {
-            status: 'blocked_link_audit',
-            current_author: currentAuthor,
-            current_text: currentText,
-            observed_cost_usd: observedCost,
-            error: `Link audit blocked resumed custody text: ${brokenResumeLinks
-              .map((result) => `${result.url} (${result.status ?? result.error ?? 'invalid'})`)
-              .join('; ')}`,
-          },
-          { ifStatusIn: ['queued', 'running'] },
-        );
-        return;
-      }
       await persistSession(db, id, { status: 'running' }, { ifStatusIn: ['queued', 'running'] });
     } else {
       // Canonical draft fallback: the lead drafts first; an operational failure
@@ -2459,11 +2647,8 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
       }
       currentText = draft.text;
       currentAuthor = draftAuthor;
-      currentLinkAudit = await auditLinks(currentText);
-      // M4: only a genuinely broken link (4xx other than 429) blocks the session.
-      // Transient failures (timeout / network / 429 / 5xx) must not terminate a
-      // paid session — they are logged but the run proceeds.
-      const brokenDraftLinks = currentLinkAudit.filter((result) => !result.ok);
+      // Plan D canonical placement: no per-draft link audit — links are audited
+      // only when a text attempts finalization (release audit stages 2-3).
       artifactTurn += 1;
       const draftArtifact = await createArtifact(db, {
         sessionId: id,
@@ -2471,16 +2656,16 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
         turn: artifactTurn,
         agent: draftAuthor,
         role: 'draft',
-        status: brokenDraftLinks.length ? 'blocked' : 'ready',
+        status: 'ready',
         title: input.title,
         contentMd: currentText,
         revisionReport: JSON.stringify({
           reviewer: draftAuthor,
           role: 'initial_drafter',
-          status: brokenDraftLinks.length ? 'blocked' : 'ready',
+          status: 'ready',
           custody: 'created',
         }),
-        linkAudit: currentLinkAudit,
+        linkAudit: [],
         costUsd: draftCost,
         model: draft.model,
         previousArtifactId,
@@ -2490,31 +2675,11 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
         at: nowIso(),
         agent: draftAuthor,
         role: 'draft',
-        status: brokenDraftLinks.length ? 'blocked' : 'ready',
-        message: brokenDraftLinks.length
-          ? `Initial draft produced with ${brokenDraftLinks.length} broken link(s).`
-          : 'Initial draft produced.',
+        status: 'ready',
+        message: 'Initial draft produced.',
         cost_usd: draftCost,
         model: draft.model,
-        link_audit: currentLinkAudit,
       });
-      if (brokenDraftLinks.length) {
-        await persistSession(
-          db,
-          id,
-          {
-            status: 'blocked_link_audit',
-            current_author: currentAuthor,
-            current_text: currentText,
-            observed_cost_usd: observedCost,
-            error: `Link audit blocked draft: ${brokenDraftLinks
-              .map((result) => `${result.url} (${result.status ?? result.error ?? 'invalid'})`)
-              .join('; ')}`,
-          },
-          { ifStatusIn: ['queued', 'running'] },
-        );
-        return;
-      }
       await persistSession(
         db,
         id,
@@ -2804,19 +2969,26 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
           const revisedText = extractTagged(result.text, 'maestro_final_text');
           let effectiveStatus: 'READY' | 'NOT_READY' = status;
           let readyRejectedReason: string | null = null;
+          // Structured audit context (canonical audit_context) of the unchanged
+          // turn's release audit, propagated into the durable turn event.
+          let unchangedAuditFailure: FinalReleaseAuditFailure | null = null;
           let contractError = validateSerialTurnOutput(result.text, status, report, revisedText);
           if (!contractError && revisedText === null) {
-            // Desktop parity (unrevised-turn audit): a READY vote on a custody
-            // text that still fails the release gate is rewritten to NOT_READY
-            // without retry (ReadyRejected); NOT_READY without a corrective text
-            // is itself a contract violation and goes to corrective retry.
-            const custodyReleaseError = validateFinalReleaseCandidate(currentText);
-            if (status === 'READY' && custodyReleaseError) {
+            // Desktop parity (unrevised-turn audit): an unchanged turn is a
+            // finalization attempt, so it runs the FULL release audit
+            // (bibliographic -> capacity -> HTTP, Plan D). A READY vote on a
+            // custody text that fails is rewritten to NOT_READY without retry
+            // (ReadyRejected); NOT_READY without a corrective text takes the
+            // audit failure (or the unchanged-ban) to corrective retry.
+            const custodyReleaseFailure = await cachedFinalReleaseAuditFailure(currentText);
+            if (status === 'READY' && custodyReleaseFailure) {
               effectiveStatus = 'NOT_READY';
-              readyRejectedReason = custodyReleaseError;
+              readyRejectedReason = custodyReleaseFailure.reason;
+              unchangedAuditFailure = custodyReleaseFailure;
             } else if (status === 'NOT_READY') {
+              if (custodyReleaseFailure) unchangedAuditFailure = custodyReleaseFailure;
               contractError =
-                custodyReleaseError ??
+                custodyReleaseFailure?.reason ??
                 'NOT_READY unchanged is not a valid serial-review outcome: the reviewer must either return READY unchanged when no blocker remains, or return a revised complete text that resolves the concrete blocker.';
             }
           }
@@ -2864,6 +3036,14 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
               message: `Reclassificado para CONTRACT_VIOLATION: ${sanitizeText(contractError, 300)}`,
               cost_usd: cost,
               model: result.model,
+              ...(unchangedAuditFailure
+                ? {
+                    final_audit: finalAuditEventField(unchangedAuditFailure),
+                    ...(unchangedAuditFailure.context.rows
+                      ? { link_audit: unchangedAuditFailure.context.rows as LinkAuditResult[] }
+                      : {}),
+                  }
+                : {}),
             });
             await persistSession(db, id, { observed_cost_usd: observedCost });
             if (retryCount <= MAX_CORRECTIVE_CONTRACT_RETRIES_PER_TURN) {
@@ -2934,12 +3114,8 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             break;
           }
           const candidateText = revisedText && changedByReviewer ? revisedText : currentText;
-          // M4: re-audit only when the custody text actually changed. Unchanged
-          // text already passed the previous audit, so re-fetching its links only
-          // risks a transient failure killing an otherwise-valid session.
-          const linkAudit = changedByReviewer ? await auditLinks(candidateText) : currentLinkAudit;
-          if (changedByReviewer) currentLinkAudit = linkAudit;
-          const brokenLinks = linkAudit.filter((link) => !link.ok);
+          // Plan D canonical placement: revision turns carry no link audit —
+          // links are audited only when a text attempts finalization.
           artifactTurn += 1;
           const artifact = await createArtifact(db, {
             sessionId: id,
@@ -2947,43 +3123,16 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             turn: artifactTurn,
             agent: reviewer,
             role: 'revision',
-            status: brokenLinks.length ? 'blocked' : effectiveStatus.toLowerCase(),
+            status: effectiveStatus.toLowerCase(),
             title: input.title,
             contentMd: candidateText,
             revisionReport: report ?? '',
-            linkAudit,
+            linkAudit: [],
             costUsd: cost,
             model: result.model,
             previousArtifactId,
           });
           previousArtifactId = artifact.id;
-          if (brokenLinks.length) {
-            await pushEvent({
-              at: nowIso(),
-              agent: reviewer,
-              role: 'revision',
-              status: 'blocked',
-              message: `Automatic link audit blocked ${brokenLinks.length} broken link(s).`,
-              cost_usd: cost,
-              model: result.model,
-              link_audit: linkAudit,
-            });
-            await persistSession(
-              db,
-              id,
-              {
-                status: 'blocked_link_audit',
-                current_author: currentAuthor,
-                current_text: currentText,
-                observed_cost_usd: observedCost,
-                error: `Link audit blocked revision: ${brokenLinks
-                  .map((link) => `${link.url} (${link.status ?? link.error ?? 'invalid'})`)
-                  .join('; ')}`,
-              },
-              { ifStatusIn: ['queued', 'running'] },
-            );
-            return;
-          }
           // Desktop parity: ReadyRejected turns do not count as valid round
           // agents; every other accepted turn feeds the closure gating. Any
           // accepted turn is a clean provider response: outage streak resets.
@@ -3012,7 +3161,14 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
                 : 'Reviewer left custody unchanged.',
             cost_usd: cost,
             model: result.model,
-            link_audit: linkAudit,
+            ...(unchangedAuditFailure && readyRejectedReason
+              ? {
+                  final_audit: finalAuditEventField(unchangedAuditFailure),
+                  ...(unchangedAuditFailure.context.rows
+                    ? { link_audit: unchangedAuditFailure.context.rows as LinkAuditResult[] }
+                    : {}),
+                }
+              : {}),
           });
           // Do NOT re-assert status:'running' here. The session is already
           // 'running'; rewriting it would clobber a concurrent operator cancel
@@ -3035,15 +3191,34 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
     }
 
     if (converged) {
-      // Desktop parity (final release audit, bibliographic stage): a
-      // unanimous version that still carries evidence markers or lacunae is
-      // not deliverable. Capacity/HTTP stages arrive with Plan D.
-      const finalGateError = validateFinalReleaseCandidate(currentText);
-      if (finalGateError) {
+      // Desktop parity (final release audit, all three canonical stages):
+      // bibliographic integrity -> link-audit capacity (> 30 unique URLs) ->
+      // HTTP link audit (any error/blocked row). A unanimous version that
+      // fails any stage is not deliverable and pauses for the operator.
+      // Canonical parity: the finalization gate re-runs the audit FRESH (the
+      // desktop has no cache here — a link that died between the last vote and
+      // finalization must still pause). The per-execution cache only serves
+      // the repeated unchanged-turn votes.
+      const finalGateFailure = await finalReleaseAuditFailure(currentText);
+      if (finalGateFailure) {
+        const auditRows = finalGateFailure.context.rows as LinkAuditResult[] | undefined;
+        // Canonical macro parity (pause_final_reference_audit!): the pause is
+        // logged with the FULL structured audit context, and the event carries
+        // a compact context summary (gate/policy/counts) plus the rows.
+        logMaestro('warn', 'session_final_reference_audit_blocked', {
+          session_id: id,
+          reason: finalGateFailure.reason,
+          audit: finalGateFailure.context,
+        });
         await pushEvent({
           at: nowIso(),
           status: 'blocked',
-          message: `Final release audit failed: ${sanitizeText(finalGateError, 300)}`,
+          message: `Final release audit failed (${finalGateFailure.context.gate}): ${sanitizeText(
+            finalGateFailure.reason,
+            300,
+          )}`,
+          final_audit: finalAuditEventField(finalGateFailure),
+          ...(auditRows ? { link_audit: auditRows } : {}),
         });
         await persistSession(
           db,
@@ -3054,7 +3229,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             current_text: currentText,
             observed_cost_usd: observedCost,
             events_json: JSON.stringify(events),
-            error: finalGateError,
+            error: finalGateFailure.reason,
           },
           { ifStatusIn: ['queued', 'running'] },
         );

--- a/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-d.md
+++ b/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-d.md
@@ -1,0 +1,32 @@
+# Maestro AI Parity Plan D — Release Link Audit e SSRF Profundo
+
+> Blueprint de execução; fonte canônica: `link_audit.rs` (integral), `session_orchestration.rs` (gate 2222-2263, macro 675-719, call sites 803/874/1574/1769, ready/not-ready-unchanged 2003-2016, blocker bibliográfico 2112-2220).
+
+**Goal:** O audit de links sai dos turnos e passa a ser o estágio 2-3 do release audit canônico na finalização (bibliográfico → capacity → HTTP), com regras HTTP canônicas (15 s, 5 hops, HEAD→GET, 3xx-ok, 429=falha, warn fora de 100-599) e SSRF profundo (faixas completas RFC + DoH pre-flight).
+
+## Semântica canônica adotada
+
+1. **Onde audita** (canônico): o audit completo (capacity + HTTP) roda SOMENTE em tentativas de finalização: (a) convergência; (b) turno **READY-unchanged** (é tentativa de release → falha vira ReadyRejected); (c) turno **NOT_READY-unchanged** (falha vira a razão do contract error → retry corretivo). Turno revisado: SÓ gate bibliográfico (inalterado). **Os audits web de draft/resume/revisão são REMOVIDOS** (o desktop não os tem; um link quebrado deixa de matar a sessão no meio e passa a pausar a finalização). `blocked_link_audit` vira status legado (permanece em RESUMABLE_STATUSES e no statusLabel).
+2. **Gate unificado 3 estágios** (`final_release_audit_failure`, curto-circuito): 1) bibliográfico (`containsFinalReleaseBlocker`); 2) capacity: únicos > 30 → gate `link_audit_capacity`; 3) HTTP: `failed > 0` → gate `link_audit`. Todos pausam como `paused_final_audit` (análogo de PAUSED_FINAL_REFERENCE_AUDIT), com contexto estruturado (gate, urls_found, checked, ok, failed, rows) no evento e no error.
+3. **Extração canônica**: regex `https?://[^\s<>"')\]]+` (stop-set SEM `}`), trim de cauda só `.,;:`, dedup da string limpa, scan cap 80 matches, candidates cap 30, **ordem lexicográfica** (BTreeSet). Candidates bloqueados/inválidos NÃO são descartados: viram rows `blocked` (contam em failed). IPv6 bracketed corta no `]` → "URL invalida" → row blocked (mesmo desfecho de pausa do desktop).
+4. **Capacity**: `count_unique_url_candidates` conta TODOS os únicos (incl. bloqueados), para em 31; `> 30` → pausa antes de qualquer fetch.
+5. **HTTP canônico**: timeout 15 s por request; User-Agent `Maestro Editorial AI/{APP_VERSION}`; redirects seguidos até 5 hops re-validando CADA hop (léxico + DoH); HEAD primeiro, GET fallback em 405/403 OU erro de transporte do HEAD; SEM retry. Tones: 2xx/3xx=`ok`; 4xx (incl. **429**)/5xx=`error`; erro de transporte no GET=`error`; SSRF/inválida=`blocked`; 1xx e fora de 100-599 (ex.: 999)=`warn` (nem ok nem failed). `failed = error+blocked`; `failed > 0` pausa. Rows sanitizadas (url 240 / status 160 / invalidity 180 / tone 16).
+6. **SSRF profundo**: v4 += 100.64.0.0/10 (CGNAT), 192.0.0.0/24, 192.0.2.0/24, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, ≥224.0.0.0 (multicast+reservado+broadcast); v6 += ff00::/8 (multicast), 2001:db8::/32 (documentação); mantidos loopback/unspecified/RFC1918/link-local/ULA/v4-mapped. Hostnames: += `localhost.localdomain`. **DoH pre-flight**: resolver A+AAAA via `https://cloudflare-dns.com/dns-query` (application/dns-json); QUALQUER IP resolvido em faixa bloqueada → `blocked`; erro/timeout de DoH → não bloqueia (fail-open, paridade com o pre-flight canônico). Aplicado ao alvo inicial e a cada hop de redirect.
+
+## Desvios web documentados
+
+- **Sem resolver connection-bound**: Workers `fetch` não expõe/pina IPs resolvidos; a 2ª camada anti-rebinding do desktop (`PublicOnlyResolver`) é arquiteturalmente impossível — a defesa web é léxica + DoH pre-flight por hop (janela de rebinding residual documentada).
+- **Probing paralelo** (`Promise.all`) em vez de sequencial: 30 URLs × 15 s sequencial estoura o budget do Worker; rows apresentadas em ordem lexicográfica (paridade de output).
+- **Cache por execução** do release audit keyed no texto de custódia: o desktop re-roda o audit HTTP a cada turno unchanged; em Workers isso multiplicaria subrequests além do limite da plataforma — dentro de UMA execução, a mesma custódia unchanged reusa o resultado.
+- **Web bloqueia MAIS hostnames** que o desktop (hardening consciente mantido): `*.internal` e bare single-label — o desktop confia no resolver do sistema para esses; em Workers são sempre internos.
+- Shape das rows mantém `{url, ok, status?, error?}` do front + campo novo `tone`; `ok = tone==='ok'`.
+
+## Tasks (TDD, red-first cada uma)
+
+1. Extração canônica: `extractUrlCandidates` ({url, rejection}) + `countUniqueUrlCandidates` + matriz (stop-set, trim, dedup, sorted, caps 80/30, bracketed-IPv6 → inválida).
+2. SSRF: faixas novas v4/v6 + `localhost.localdomain` + matriz; DoH pre-flight `hostResolvesToBlockedIp` (mock dns-json: A privado bloqueia; AAAA ULA bloqueia; erro DoH não bloqueia; sem fetch do alvo quando bloqueado).
+3. `probePublicUrl` + `runLinkAudit`: tones (2xx/3xx ok; 404/429/500 error; 999 warn; GET transport error), HEAD→GET (405/403/Err), 5 hops re-validados, UA, 15 s, agregado ok/failed/warn + rows sorted.
+4. `finalReleaseAuditFailure` 3 estágios curto-circuito + contexto estruturado.
+5. Wiring: remover audits de draft/resume/revisão (e `currentLinkAudit`); gate completo na convergência; READY-unchanged → ReadyRejected via audit completo; NOT_READY-unchanged → contract error via audit; cache por execução.
+6. Testes runner reescritos: 404 na custódia → ReadyRejected loop → `paused_cycle_limit` (nunca blocked_link_audit); convergência limpa com fetch 200; capacity 31 URLs → paused_final_audit gate capacity; 999 não pausa; internal-host → row blocked sem fetch.
+7. Gates + bump v02.09.00 + CHANGELOG + cross-review (draft auto-contido; evidência front-loaded) + ship.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.08.00';
+const APP_VERSION = 'APP v02.09.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary

Plan D of the maestro-app parity program: the release link audit assumes its canonical placement and the SSRF surface reaches full canonical depth.

- **Canonical placement**: the audit runs only on finalization attempts (convergence, READY-unchanged → ReadyRejected, NOT_READY-unchanged → corrective retry) as stages 2-3 of the unified release gate — bibliographic integrity → capacity (>30 unique URLs, zero fetches) → HTTP audit. All stages pause as the resumable `paused_final_audit`. Per-draft/resume/revision audits removed: a broken link pauses the release instead of killing a paid session mid-run.
- **Canonical extraction & HTTP**: stop-set without `}`, trim `.,;:`, dedup, lexicographic order, caps 80/30; 15 s timeout, identified UA, HEAD→GET on 405/403 or HEAD transport error, no retries, 5 re-validated redirect hops; tones 2xx/3xx ok, 4xx (incl. 429) + 5xx error, outside 100-599 warn; blocked/invalid candidates become blocked rows with zero fetches.
- **Deep SSRF**: CGNAT 100.64/10, RFC 6890 192.0.0/24, TEST-NETs, benchmarking 198.18/15, multicast/reserved ≥224/8, ff00::/8, 2001:db8::/32, `localhost.localdomain` + **DoH pre-flight** (Cloudflare, A+AAAA) on the initial target and every redirect hop, failing open on resolver outage (canonical parity).
- **Structured durable audit context** (cross-review finding): typed `final_audit` field ({gate, reason, context}) on session events persisted in `events_json`, emitted at the finalization pause, on ReadyRejected turns and on audit-originated contract violations; the finalization gate re-runs the audit fresh (desktop parity) while the per-execution cache serves only repeated unchanged votes.

Documented web deviations: `docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-d.md` (no connection-bound resolver in Workers, parallel probing with lexicographic rows, unchanged-vote cache, extra hostname hardening, UA `/web`).

## Test plan

- 170/170 vitest: 7 Plan D unit tests (extraction matrix, deep-SSRF ranges with boundary neighbors, DoH block/fail-open, tone matrix incl. 429-error/999-warn, HEAD→GET matrix, 5-hop re-validation + pivot block, 3-stage short-circuit) + 6 rewritten/new runner integrations (ReadyRejected loop with cached probes, clean convergence with real probe, SSRF finalization rejection with zero internal fetches, vote-passes-then-link-dies finalization pause, structured `final_audit` events for the bibliographic and capacity gates with zero fetches).
- Gates: eslint clean, biome clean (2 pre-existing accepted config infos), typecheck baseline clean, markdownlint 0, prettier clean.
- Cross-review: unanimous ALL READY (caller + codex, gemini, deepseek, grok, perplexity; 4 rounds — codex drove the structured `final_audit` events and the fresh finalization audit; its pause-on-unchanged-turns claim was refuted with verbatim canonical Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)