### PR TITLE
fix(maestro-ai): replace unused-var destructuring that broke the CI lint gate

### DIFF
--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2491,7 +2491,10 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
   const finalAuditEventField = (
     failure: FinalReleaseAuditFailure,
   ): { gate: string; reason: string; context: Record<string, unknown> } => {
-    const { rows: _rows, ...contextSummary } = failure.context;
+    const contextSummary: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(failure.context)) {
+      if (key !== 'rows') contextSummary[key] = value;
+    }
     return { gate: failure.context.gate, reason: failure.reason, context: contextSummary };
   };
 


### PR DESCRIPTION
## Summary

The Plan D merge (#302) broke the main Deploy at the CI lint step: the stricter CI eslint config rejects the `const { rows: _rows, ...rest }` discard pattern (`@typescript-eslint/no-unused-vars`). This builds the context summary without destructuring — mechanical, no behavior change, covered by the existing 170-test suite.

Applied under the broken-gate self-repair exception to restore the main Deploy.

## Test plan

- 170/170 vitest, eslint clean, biome clean (2 pre-existing accepted config infos), typecheck baseline clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)