### PR TITLE
feat(maestro-ai): prior-reports feed, canonical prompt and live model resolution (parity Plans E/F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.10.00] - 2026-07-06
+
+### Alterado
+
+- **Maestro AI — prior-reports feed, prompt canônico completo e resolução viva de modelos (Planos E/F da equiparação com o maestro-app)**: fecham o roadmap A–F. **(F1)** O prompt de revisão troca a seção de últimos 12 eventos JSON pelo feed canônico `Prior Serial Revision Reports` (port de `build_revision_history_block`): todos os turnos seriais anteriores em ordem cronológica, cada um com header `nome / papel / status`, referência de artefato e o `maestro_revision_report` truncado a 12.000 caracteres Unicode; turno sem report ganha o placeholder canônico de falha de contrato; turnos operacionais ficam de fora; o texto final nunca entra. Turnos de violação e de rejeição do tier guard entram com o report tentado. **(F2)** Language Contract ganha a regra canônica de citação por seção compacta (`§V.14`/`§11.7`) e o marcador de protocolo; Role Contract ganha os bullets canônicos de `SELF_REVIEW_BLOCKED`, do redator de fechamento (com o flag `Closing redactor turn:` alimentado pelo closure gating) e o header `Round turn:`; o Quality Gate ganha os bullets canônicos de justificação por mudança (passagem exata + requisito exato do protocolo + por que preservar seria inseguro + em dúvida, preserve). **(F3)** Resolução viva de modelos (port de `resolve_*_model`/`choose_preferred_model`): quando o operador não configurou um modelo explícito (diferente do default semeado), o motor consulta o endpoint `/models` do provider e escolhe o primeiro candidato canônico presente na lista viva (senão o primeiro listado; senão o fallback canônico), com cache por execução; Perplexity segue sem resolução viva (canônico). Corrigido drift do default do Grok (sufixo `-0309` inexistente no desktop). **(E)** Exceções adotadas e documentadas, sem mudança de código: `request_usd_per_1k`, `DEFAULT_RATES` semeadas, rejeição pré-start com <2 agentes e `DEFAULT_PROTOCOL` semeado permanecem no web. Desvios documentados em `docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-ef.md`.
+
 ## [v02.09.00] - 2026-07-06
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.test.ts
@@ -444,7 +444,7 @@ describe('Maestro AI settings', () => {
       codex: 'gpt-5.5',
       gemini: 'gemini-2.5-pro',
       deepseek: 'deepseek-v4-pro',
-      grok: 'grok-4.20-multi-agent-0309',
+      grok: 'grok-4.20-multi-agent',
       perplexity: 'sonar-reasoning-pro',
     });
     expect(JSON.stringify(payload)).not.toContain('secret-claude');
@@ -453,6 +453,7 @@ describe('Maestro AI settings', () => {
   it('saves API keys through Cloudflare Secret Store and not into D1 settings JSON', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (url.includes('/secrets?') && !init?.method) {
         return new Response(JSON.stringify({ success: true, result: [] }), { status: 200 });
       }
@@ -500,6 +501,7 @@ describe('Maestro AI settings', () => {
     }));
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (url.includes('/secrets') && !url.includes('/secrets/') && (!init?.method || init.method === 'GET')) {
         const page = new URL(url).searchParams.get('page');
         const result =
@@ -618,7 +620,8 @@ describe('Maestro AI revision prompt teaches the block contract', () => {
       currentText: '# Titulo\n\nCorpo do artigo em custodia.',
       currentAuthor: 'claude',
       reviewer: 'codex',
-      history: [],
+      serialReports: [],
+      closingTurn: false,
     });
     expect(prompt).toContain('## Current Text Block Manifest');
     expect(prompt).toContain('| block_id | kind | chars | sha256_12 | locked_by_default | excerpt |');
@@ -630,6 +633,128 @@ describe('Maestro AI revision prompt teaches the block contract', () => {
     expect(prompt).toContain('Missing evidence by itself is not a sufficient reason to pass the blocker forward.');
     expect(prompt).toContain('A text is not final-deliverable while it still depends on unresolved evidence markers');
     expect(prompt).toContain('MAESTRO_STATUS: NOT_READY with custody: "unchanged" is a contract violation');
+  });
+});
+
+describe('Maestro AI prior-reports feed, prompt sections and model resolution (Plan F)', () => {
+  const promptInput = {
+    title: 'Sessao',
+    prompt: 'Escreva.',
+    protocol_text: protocolText,
+    initial_agent: 'claude',
+    active_agents: ['claude', 'codex'],
+    initial_content: '',
+    max_cost_usd: 10,
+    max_runtime_minutes: null,
+    rates,
+    models: {},
+    max_cycles: 2,
+  } as Parameters<(typeof maestroAiTestHooks)['buildRevisionPrompt']>[0]['input'];
+
+  it('buildRevisionHistoryBlock formats prior reports canonically (cap, placeholder, skip, order, empty)', () => {
+    const { buildRevisionHistoryBlock } = maestroAiTestHooks;
+    // Empty history -> canonical fallback sentence.
+    expect(buildRevisionHistoryBlock([])).toBe('No prior revision reports are recorded for this serial cycle.');
+    const block = buildRevisionHistoryBlock([
+      {
+        name: 'Codex',
+        role: 'review',
+        status: 'NOT_READY',
+        report: 'reviewer: codex\ncustody: "revised"',
+        artifact: 'art-1',
+      },
+      { name: 'Claude', role: 'review', status: 'READY', report: null, artifact: 'art-2' },
+      { name: 'Gemini', role: 'review', status: 'READY', report: '   ', artifact: 'art-3' },
+    ]);
+    // Chronological order with the canonical header/artifact/fence shape.
+    expect(block).toContain('### Codex / review / `NOT_READY`');
+    expect(block).toContain('Artifact: `art-1`');
+    expect(block).toContain('```text\nreviewer: codex\ncustody: "revised"\n```');
+    // Missing report -> canonical contract-failure placeholder.
+    expect(block).toContain(
+      'No complete maestro_revision_report block was returned by Claude. Treat this artifact as a contract failure, not as deliberative substance.',
+    );
+    // Whitespace-only extracted report -> the turn is skipped entirely.
+    expect(block).not.toContain('Gemini');
+    expect(block.indexOf('Codex')).toBeLessThan(block.indexOf('Claude'));
+    // Per-report cap: 12,000 Unicode chars.
+    const long = buildRevisionHistoryBlock([
+      { name: 'Codex', role: 'review', status: 'READY', report: 'x'.repeat(15_000), artifact: 'a' },
+    ]);
+    const fenced = /```text\n(x+)\n```/.exec(long);
+    expect(fenced?.[1]?.length).toBe(12_000);
+  });
+
+  it('revision prompt carries the canonical sections: section-ID rule, closing redactor, quality justification, prior reports', async () => {
+    const prompt = await maestroAiTestHooks.buildRevisionPrompt({
+      input: promptInput,
+      runId: 'run-1',
+      turn: 2,
+      currentText: '# Titulo\n\nCorpo.',
+      currentAuthor: 'codex',
+      reviewer: 'claude',
+      serialReports: [
+        { name: 'Codex', role: 'review', status: 'NOT_READY', report: 'custody: "revised"', artifact: 'art-9' },
+      ],
+      closingTurn: true,
+    });
+    // Canonical Language Contract additions.
+    expect(prompt).toContain('Cite compact section IDs only, such as `§V.14` or `§11.7`.');
+    expect(prompt).toContain('Keep protocol markers exactly as specified.');
+    // Canonical Role Contract additions.
+    expect(prompt).toContain('Closing redactor turn: `true`.');
+    expect(prompt).toContain('state `SELF_REVIEW_BLOCKED`');
+    expect(prompt).toContain(
+      'The original redactor may act in the closing redactor turn only when the current version author is another peer.',
+    );
+    // Canonical header.
+    expect(prompt).toContain('Round turn: `2`');
+    // Canonical Quality gate justification bullets.
+    expect(prompt).toContain(
+      'Any deletion, compression, simplification, or structural narrowing must be justified in the report with:',
+    );
+    expect(prompt).toContain('- the exact passage changed;');
+    expect(prompt).toContain('why preserving the stronger formulation would be unsafe or incorrect');
+    expect(prompt).toContain('If you are unsure, preserve the passage and report the concern instead of rewriting it.');
+    // Prior reports replace the raw event feed.
+    expect(prompt).toContain('## Prior Serial Revision Reports');
+    expect(prompt).toContain('### Codex / review / `NOT_READY`');
+    expect(prompt).not.toContain('## Prior Session Events');
+  });
+
+  it('choosePreferredModel picks the first live candidate, else first live model, else the fallback', () => {
+    const { choosePreferredModel } = maestroAiTestHooks;
+    expect(choosePreferredModel(['a', 'gpt-5.4', 'gpt-5.5'], ['gpt-5.5', 'gpt-5.4'], 'fb')).toBe('gpt-5.5');
+    expect(choosePreferredModel(['a', 'gpt-5.4'], ['gpt-5.5', 'gpt-5.4'], 'fb')).toBe('gpt-5.4');
+    expect(choosePreferredModel(['other-1', 'other-2'], ['gpt-5.5'], 'fb')).toBe('other-1');
+    expect(choosePreferredModel([], ['gpt-5.5'], 'fb')).toBe('fb');
+  });
+
+  it('resolveProviderModel queries /models with canonical candidates, falls back on failure, and skips perplexity', async () => {
+    const { resolveProviderModel } = maestroAiTestHooks;
+    const endpoints: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = new URL(String(input));
+        endpoints.push(url.toString());
+        if (url.hostname === 'api.openai.com') {
+          return new Response(JSON.stringify({ data: [{ id: 'gpt-5.3' }, { id: 'gpt-4.1' }] }), { status: 200 });
+        }
+        if (url.hostname === 'api.x.ai') throw new Error('network down');
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }),
+    );
+    // Candidate match: gpt-5.3 is the first canonical candidate present.
+    expect(await resolveProviderModel('codex', 'key')).toBe('gpt-5.3');
+    expect(endpoints.some((e) => e.includes('api.openai.com/v1/models'))).toBe(true);
+    // Endpoint failure -> canonical hardcoded fallback.
+    expect(await resolveProviderModel('grok', 'key')).toBe('grok-4.20-multi-agent');
+    // Perplexity has NO live resolution (canonical): no fetch, default returned.
+    endpoints.length = 0;
+    expect(await resolveProviderModel('perplexity', 'key')).toBe('sonar-reasoning-pro');
+    expect(endpoints).toEqual([]);
+    vi.unstubAllGlobals();
   });
 });
 
@@ -1313,6 +1438,9 @@ describe('runSession orchestrator', () => {
   }) =>
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      // Plan F live model resolution: serve /models probes an empty list so the
+      // canonical fallback model is used without touching turn-call counters.
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         opts.onAnthropic?.();
         return new Response(
@@ -1363,6 +1491,7 @@ describe('runSession orchestrator', () => {
     // Override: anthropic returns empty ONLY for the draft (first anthropic call).
     let anthropicCalls = 0;
     const withEmptyFirstDraft = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(String(input)) === 'api.anthropic.com') {
         anthropicCalls += 1;
         if (anthropicCalls === 1) {
@@ -1418,6 +1547,7 @@ describe('runSession orchestrator', () => {
     const codexBodies: string[] = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         return new Response(
           JSON.stringify({
@@ -1455,6 +1585,7 @@ describe('runSession orchestrator', () => {
     const codexBodies: string[] = [];
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         return new Response(
           JSON.stringify({
@@ -1495,6 +1626,7 @@ describe('runSession orchestrator', () => {
     let claudeReviewCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         claudeReviewCalls += 1;
         return new Response(
@@ -1564,6 +1696,7 @@ describe('runSession orchestrator', () => {
     let deepseekCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         return new Response(
           JSON.stringify({
@@ -1613,7 +1746,9 @@ describe('runSession orchestrator', () => {
     // failure that skips the turn; the third consecutive one pauses the session.
     expect(row?.status).toBe('paused_reviewer_outage');
     expect(String(row?.error)).toMatch(/consecutive reviewer turns failed/i);
-    expect(fetchMock.mock.calls.filter(([u]) => hostOf(u) === 'api.openai.com').length).toBe(3);
+    expect(
+      fetchMock.mock.calls.filter(([u]) => hostOf(u) === 'api.openai.com' && !String(u).includes('/models')).length,
+    ).toBe(3);
     // The custody text survives the pause for a later resume.
     expect(row?.current_text).toBe('Rascunho valido e completo.');
   });
@@ -1909,6 +2044,7 @@ describe('runSession orchestrator', () => {
     // The pre-turn check before deepseek must detect it and stop.
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         return new Response(JSON.stringify({ content: [{ type: 'text', text: 'Rascunho valido.' }], usage: {} }), {
           status: 200,
@@ -2011,6 +2147,7 @@ describe('runSession orchestrator', () => {
     });
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url.includes('/models')) return new Response(JSON.stringify({ data: [] }), { status: 200 });
       if (hostOf(url) === 'api.anthropic.com') {
         return new Response(
           JSON.stringify({ content: [{ type: 'text', text: 'Rascunho valido e robusto.' }], usage: {} }),
@@ -2414,7 +2551,7 @@ describe('maestro provider request construction', () => {
     const request = maestroAiTestHooks.buildProviderHttpRequest(
       'grok',
       'xai-secret',
-      'grok-4.20-multi-agent-0309',
+      'grok-4.20-multi-agent',
       system,
       prompt,
     );
@@ -2422,7 +2559,7 @@ describe('maestro provider request construction', () => {
 
     expect(request.endpoint).toBe('https://api.x.ai/v1/responses');
     expect(request.init.headers).toMatchObject({ authorization: 'Bearer xai-secret' });
-    expect(body.model).toBe('grok-4.20-multi-agent-0309');
+    expect(body.model).toBe('grok-4.20-multi-agent');
     expect(body.input).toEqual([{ role: 'user', content: [{ type: 'input_text', text: prompt }] }]);
   });
 

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -218,7 +218,7 @@ const DEFAULT_MODELS: Record<ProviderKey, string> = {
   codex: 'gpt-5.5',
   gemini: 'gemini-2.5-pro',
   deepseek: 'deepseek-v4-pro',
-  grok: 'grok-4.20-multi-agent-0309',
+  grok: 'grok-4.20-multi-agent',
   perplexity: 'sonar-reasoning-pro',
 };
 
@@ -1844,6 +1844,40 @@ ${input.protocol_text}
 `;
 }
 
+// Canonical serial-turn record for the prior-reports feed (Plan F): the web
+// analogue of the desktop's EditorialAgentResult slice — one entry per
+// accepted/rejected serial turn, oldest first. Operational failures never
+// enter the list (is_operational_agent_result parity).
+type SerialTurnReport = {
+  name: string;
+  role: string;
+  status: string;
+  /** The turn's maestro_revision_report; null when the agent returned none. */
+  report: string | null;
+  /** Artifact reference — the D1 artifact id (desktop uses the file path). */
+  artifact: string;
+};
+
+/** Port of build_revision_history_block (editorial_prompts.rs:327-363): prior
+ *  revision REPORTS only (never the final text), each capped at 12,000 Unicode
+ *  chars, chronological, no count/total cap; a missing report becomes the
+ *  canonical contract-failure placeholder; an extracted-but-empty report skips
+ *  the turn. */
+function buildRevisionHistoryBlock(reports: SerialTurnReport[]): string {
+  let history = '';
+  for (const turn of reports) {
+    const extracted =
+      turn.report === null
+        ? `No complete maestro_revision_report block was returned by ${turn.name}. Treat this artifact as a contract failure, not as deliberative substance.`
+        : turn.report;
+    const report = extracted.trim();
+    if (!report) continue;
+    const capped = [...report].slice(0, 12_000).join('');
+    history += `\n### ${turn.name} / ${turn.role} / \`${turn.status}\`\n\nArtifact: \`${turn.artifact}\`\n\n\`\`\`text\n${capped}\n\`\`\`\n`;
+  }
+  return history.trim() ? history : 'No prior revision reports are recorded for this serial cycle.';
+}
+
 async function buildRevisionPrompt(args: {
   input: MaestroResolvedSessionInput;
   runId: string;
@@ -1851,29 +1885,35 @@ async function buildRevisionPrompt(args: {
   currentText: string;
   currentAuthor: ProviderKey;
   reviewer: ProviderKey;
-  history: SessionEvent[];
+  serialReports: SerialTurnReport[];
+  closingTurn: boolean;
 }): Promise<string> {
   const blockManifest = await formatBlockManifestForPrompt(args.currentText);
+  const revisionHistory = buildRevisionHistoryBlock(args.serialReports);
   return `# Maestro Editorial AI - Web/API Serial Review-Rewrite Turn
 
 Run: \`${args.runId}\`
-Turn: \`${args.turn}\`
+Round turn: \`${args.turn}\`
 Session: ${sanitizeText(args.input.title, 200)}
 
 ## Language Contract
 
-- Internal coordination, critique, changelog, and revision report MUST be written in en_US.
-- The operator-facing article inside <maestro_final_text> MUST be written in Brazilian Portuguese (pt_BR).
-- The editorial protocol is authoritative input, not output. Read and obey it, but do not quote, summarize, restate, or reproduce protocol text in the artifact.
+- Internal coordination, critique, changelog, retry diagnostics, JSON/report fields, and every non-user-facing agent message MUST be written in en_US.
+- The operator-facing article inside \`<maestro_final_text>\` MUST be written in Brazilian Portuguese (pt_BR).
+- Keep protocol markers exactly as specified.
+- The editorial protocol is authoritative input, not output. Read and obey it, but do not quote, summarize, restate, or reproduce protocol text in the artifact. Cite compact section IDs only, such as \`§V.14\` or \`§11.7\`.
 
 ## Role Contract
 
 - Current version author/curator: \`${args.currentAuthor}\`.
 - Current reviewer-reviser: \`${args.reviewer}\`.
+- Closing redactor turn: \`${args.closingTurn}\`.
 - You are not allowed to revise a version you just produced.
-- You must act as reviewer and reviser in one turn: inspect the current text, apply only authorized corrections, and return the complete current article only when custody changes.
-- A Maestro round is a full circular pass through every configured eligible AI agent. A new round can start only after custody has completed the full circle and returned to the original drafter.
-- The web engine validates links automatically after each draft/revision. Do not fabricate URLs. If a link cannot be verified from the provided context, mark it as [EVIDENCIA_PENDENTE] instead of inventing one.
+- If you are the current version author, return \`MAESTRO_STATUS: NOT_READY\`, set \`custody\` to \`"unchanged"\`, omit \`<maestro_final_text>\`, and state \`SELF_REVIEW_BLOCKED\`. This condition is a scheduler invariant violation, not an editorial turn.
+- The original redactor may act in the closing redactor turn only when the current version author is another peer. In that case, the original redactor reviews the completed peer circuit, may revise only issues raised by prior reviewers or concrete final-delivery blockers, and must preserve all approved content.
+- You must act as reviewer and reviser in one turn: inspect the current text, apply only authorized corrections, and return the complete current article.
+- A Maestro round is a full circular pass through all active AI agents. This call is one turn inside that round; do not call it a new round in your own report.
+- The web engine audits public links automatically when a text attempts finalization. Do not fabricate URLs. If a link cannot be verified from the provided context, mark it as [EVIDENCIA_PENDENTE] instead of inventing one.
 
 ## Sovereign Approved-Content Lock
 
@@ -1892,6 +1932,13 @@ If a concern is optional, stylistic, vague, or outside scope, mark it as OUT_OF_
 Codex and Claude are the strongest long-form writers in this system. Gemini is second. DeepSeek, Grok, and Perplexity are useful reviewers but must not flatten stronger prose.
 Preserve the strongest existing formulation unless a concrete editorial-protocol defect requires a narrow change.
 Do not reduce breadth, depth, articulation, nuance, reflexivity, or argumentative amplitude.
+Any deletion, compression, simplification, or structural narrowing must be justified in the report with:
+
+- the exact passage changed;
+- the exact protocol requirement;
+- why preserving the stronger formulation would be unsafe or incorrect.
+
+If you are unsure, preserve the passage and report the concern instead of rewriting it.
 
 ## Evidence and Bibliographic Integrity Gate
 
@@ -1953,11 +2000,8 @@ ${args.input.protocol_text}
 ${args.currentText}
 \`\`\`
 
-## Prior Session Events
-
-\`\`\`json
-${JSON.stringify(args.history.slice(-12), null, 2)}
-\`\`\`
+## Prior Serial Revision Reports
+${revisionHistory}
 `;
 }
 
@@ -2092,6 +2136,115 @@ interface ProviderCallOptions {
   timeoutMs?: number;
   /** Cooperative cancel check; enables retry waits + in-flight abort polling. */
   isCancelled?: () => Promise<boolean>;
+  /** Per-execution cache for live model resolution (documented web deviation:
+   *  the desktop resolves on every call; Workers budget subrequests). */
+  modelCache?: Map<ProviderKey, string>;
+}
+
+// ── Plan F: canonical live model resolution (port of resolve_*_model +
+// choose_preferred_model, provider_runners.rs:1184-1269 and the DeepSeek/Grok
+// variants). Perplexity has NO live resolution (canonical). Precedence in the
+// web: operator-configured model -> live candidate list -> first live model ->
+// canonical hardcoded fallback.
+const MODEL_RESOLUTION: Partial<
+  Record<
+    ProviderKey,
+    { endpoint: string; auth: 'bearer' | 'x-api-key' | 'query-key'; candidates: string[]; fallback: string }
+  >
+> = {
+  codex: {
+    endpoint: 'https://api.openai.com/v1/models',
+    auth: 'bearer',
+    candidates: ['gpt-5.5', 'gpt-5.4', 'gpt-5.3', 'gpt-5.2', 'gpt-5', 'gpt-4.1'],
+    fallback: 'gpt-5.4',
+  },
+  claude: {
+    endpoint: 'https://api.anthropic.com/v1/models',
+    auth: 'x-api-key',
+    candidates: [
+      'claude-opus-4-7',
+      'claude-opus-4-1-20250805',
+      'claude-opus-4-20250514',
+      'claude-sonnet-4-20250514',
+      'claude-3-7-sonnet-latest',
+    ],
+    fallback: 'claude-opus-4-1-20250805',
+  },
+  gemini: {
+    endpoint: 'https://generativelanguage.googleapis.com/v1beta/models',
+    auth: 'query-key',
+    candidates: [
+      'gemini-3.1-pro-preview',
+      'gemini-3-pro-preview',
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+      'gemini-1.5-pro',
+    ],
+    fallback: 'gemini-2.5-pro',
+  },
+  deepseek: {
+    endpoint: 'https://api.deepseek.com/models',
+    auth: 'bearer',
+    candidates: ['deepseek-v4-pro', 'deepseek-reasoner', 'deepseek-chat', 'deepseek-v4-flash'],
+    fallback: 'deepseek-reasoner',
+  },
+  grok: {
+    endpoint: 'https://api.x.ai/v1/models',
+    auth: 'bearer',
+    candidates: [
+      'grok-4.20-multi-agent',
+      'grok-4-latest',
+      'grok-4.3',
+      'grok-4.20-reasoning',
+      'grok-4.20',
+      'grok-4-1-fast',
+      'grok-4',
+    ],
+    fallback: 'grok-4.20-multi-agent',
+  },
+};
+
+/** Port of choose_preferred_model: first candidate present in the live list;
+ *  else the first live model; else the fallback. */
+function choosePreferredModel(models: string[], candidates: string[], fallback: string): string {
+  for (const candidate of candidates) {
+    if (models.includes(candidate)) return candidate;
+  }
+  return models[0] ?? fallback;
+}
+
+/** Resolve the model for a provider via its live /models endpoint. Any HTTP or
+ *  parse failure falls back to the canonical hardcoded default (desktop
+ *  parity). Perplexity (no live resolution) returns its default directly. */
+async function resolveProviderModel(agent: ProviderKey, apiKey: string): Promise<string> {
+  const resolution = MODEL_RESOLUTION[agent];
+  if (!resolution) return DEFAULT_MODELS[agent];
+  try {
+    const target =
+      resolution.auth === 'query-key'
+        ? `${resolution.endpoint}?key=${encodeURIComponent(apiKey)}`
+        : resolution.endpoint;
+    const headers: Record<string, string> = {};
+    if (resolution.auth === 'bearer') headers.authorization = `Bearer ${apiKey}`;
+    if (resolution.auth === 'x-api-key') {
+      headers['x-api-key'] = apiKey;
+      headers['anthropic-version'] = '2023-06-01';
+    }
+    const response = await fetchWithTimeout(target, { headers }, 15_000);
+    if (!response.ok) return resolution.fallback;
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string }>;
+      models?: Array<{ name?: string }>;
+    };
+    // OpenAI/Anthropic/DeepSeek/Grok list under data[].id; Gemini under
+    // models[].name with a "models/" prefix.
+    const ids = payload.data
+      ? payload.data.map((model) => String(model.id ?? '')).filter(Boolean)
+      : (payload.models ?? []).map((model) => String(model.name ?? '').replace(/^models\//, '')).filter(Boolean);
+    return choosePreferredModel(ids, resolution.candidates, resolution.fallback);
+  } catch {
+    return resolution.fallback;
+  }
 }
 
 async function callProvider(
@@ -2105,7 +2258,18 @@ async function callProvider(
 ): Promise<ProviderCallResult> {
   const apiKey = secretForAgent(env, agent);
   if (!apiKey) throw new Error(`${AGENT_LABELS[agent]} API key is not configured in admin-motor secrets.`);
-  const model = sanitizeText(models[agent], 120) || DEFAULT_MODELS[agent];
+  // Plan F precedence: an operator-configured model (anything other than the
+  // seeded default) wins; otherwise resolve live against the provider's
+  // /models list (canonical), memoized per execution via options.modelCache.
+  const configured = sanitizeText(models[agent], 120);
+  let model = configured && configured !== DEFAULT_MODELS[agent] ? configured : '';
+  if (!model) {
+    model = options?.modelCache?.get(agent) ?? '';
+    if (!model) {
+      model = await resolveProviderModel(agent, apiKey);
+      options?.modelCache?.set(agent, model);
+    }
+  }
   const system =
     systemOverride ??
     `You are ${AGENT_LABELS[agent]} inside Maestro Editorial AI. Internal coordination must be in en_US. Operator-facing deliverables must be in pt_BR. Follow the current Maestro role contract exactly.`;
@@ -2321,6 +2485,9 @@ export const maestroAiTestHooks = {
   remainingSessionMs,
   sessionTimeExhausted,
   fetchProviderWithRetry,
+  buildRevisionHistoryBlock,
+  choosePreferredModel,
+  resolveProviderModel,
   persistSession,
   runSession,
   sweepStaleSessions,
@@ -2473,7 +2640,11 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
     const remaining = remainingSessionMs(timeAnchorMs, input.max_runtime_minutes);
     return remaining === null ? PROVIDER_TIMEOUT_MS : Math.max(1, Math.min(PROVIDER_TIMEOUT_MS, remaining));
   };
-  const callOptions = (): ProviderCallOptions => ({ timeoutMs: callTimeoutMs(), isCancelled });
+  // Plan F: per-execution live-model cache + the prior-reports feed list (the
+  // web analogue of the desktop's append-only EditorialAgentResult slice).
+  const modelCache = new Map<ProviderKey, string>();
+  const serialReports: SerialTurnReport[] = [];
+  const callOptions = (): ProviderCallOptions => ({ timeoutMs: callTimeoutMs(), isCancelled, modelCache });
   // Plan D (documented web deviation): the desktop re-runs the full release
   // audit (incl. HTTP) on every unchanged turn; on Workers that would multiply
   // subrequests past the platform budget, so within ONE execution the audit
@@ -2888,11 +3059,14 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             (await buildRevisionPrompt({
               input,
               runId: id,
-              turn: events.length + 1,
+              turn: roundTurnIndex + 1,
               currentText,
               currentAuthor,
               reviewer,
-              history: events,
+              serialReports,
+              // Canonical closing-turn flag: the configured lead closing the
+              // circuit (the scheduler only makes it eligible via closure gating).
+              closingTurn: reviewer === initialAgent && reviewer !== currentAuthor,
             })) + (correctiveRetryCount > 0 ? correctiveRetrySection(correctiveRetryCount) : '');
           const rates = input.rates?.[reviewer] ?? {};
           const projected = estimateCost(prompt, MAX_OUTPUT_TOKENS, rates);
@@ -3010,7 +3184,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             // stable-approval set.
             stableApprovals.clear();
             artifactTurn += 1;
-            await createArtifact(db, {
+            const violationArtifact = await createArtifact(db, {
               sessionId: id,
               cycle: round,
               turn: artifactTurn,
@@ -3030,6 +3204,15 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
               costUsd: cost,
               model: result.model,
               previousArtifactId,
+            });
+            // Prior-reports feed (canonical): a violating turn enters with its
+            // attempted report (or the contract-failure placeholder when none).
+            serialReports.push({
+              name: AGENT_LABELS[reviewer],
+              role: 'review',
+              status: 'CONTRACT_VIOLATION',
+              report,
+              artifact: violationArtifact.id,
             });
             await pushEvent({
               at: nowIso(),
@@ -3073,7 +3256,7 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             // revision from a lower-tier reviewer is rejected and discarded; the
             // custody text and author stay unchanged and the session continues.
             artifactTurn += 1;
-            await createArtifact(db, {
+            const ratchetArtifact = await createArtifact(db, {
               sessionId: id,
               cycle: round,
               turn: artifactTurn,
@@ -3091,6 +3274,15 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
               costUsd: cost,
               model: result.model,
               previousArtifactId,
+            });
+            // Prior-reports feed (canonical): the rejected turn's report still
+            // informs later reviewers.
+            serialReports.push({
+              name: AGENT_LABELS[reviewer],
+              role: 'review',
+              status: 'QUALITY_GUARD_REJECTED',
+              report,
+              artifact: ratchetArtifact.id,
             });
             await pushEvent({
               at: nowIso(),
@@ -3136,6 +3328,15 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
             previousArtifactId,
           });
           previousArtifactId = artifact.id;
+          // Prior-reports feed (canonical): every accepted turn's report joins
+          // the chronological history fed to later reviewers.
+          serialReports.push({
+            name: AGENT_LABELS[reviewer],
+            role: 'review',
+            status: readyRejectedReason ? 'READY_REJECTED' : effectiveStatus,
+            report,
+            artifact: artifact.id,
+          });
           // Desktop parity: ReadyRejected turns do not count as valid round
           // agents; every other accepted turn feeds the closure gating. Any
           // accepted turn is a clean provider response: outage streak resets.

--- a/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-ef.md
+++ b/docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-ef.md
@@ -1,0 +1,33 @@
+# Maestro AI Parity Plans E/F — Exceções de Custo/Defaults + Prompts Restantes e Modelos
+
+> Blueprint de execução; fonte canônica: `editorial_prompts.rs` (build_serial_revision_prompt 387-526, build_revision_history_block 327-363, is_operational_agent_result 365-384), `provider_runners.rs` (resolve_*_model 1184-1257, choose_preferred_model 1259-1269), `provider_deepseek.rs` (resolve_deepseek_model 513-550), `provider_grok.rs` (resolve_grok_model 266-306), `provider_perplexity.rs` (252-255).
+
+## Plano E — exceções ADOTADAS (autorização standing do operador, 2026-07-06; sem mudança de código)
+
+1. `request_usd_per_1k` mantido no web (o desktop não o tem; removê-lo perderia a contabilidade real do Perplexity).
+2. `DEFAULT_RATES` semeadas mantidas no web (o desktop exige configuração explícita).
+3. Rejeição pré-start com <2 agentes mantida no web (o desktop aceita e pausa após o draft; rejeitar antes evita custo de draft fadado à pausa).
+4. (Do F) `DEFAULT_PROTOCOL` semeado mantido no web (o desktop exige importação de protocolo ≥100 chars).
+
+## Plano F — semântica canônica adotada
+
+1. **Prior-reports feed** (port de `build_revision_history_block`): a seção `## Prior Session Events` (últimos 12 eventos em JSON) é SUBSTITUÍDA por `## Prior Serial Revision Reports` — para cada turno serial anterior (ordem cronológica, SEM cap de quantidade nem cap total): header "### {name} / {role} / \`{status}\`" + linha "Artifact: \`{id}\`" + fence de código (text) com o `maestro_revision_report` do turno truncado a **12.000 chars Unicode**; turno sem report ganha o placeholder canônico "No complete maestro_revision_report block was returned by {name}. Treat this artifact as a contract failure, not as deliberative substance."; histórico vazio → "No prior revision reports are recorded for this serial cycle."; turnos operacionais (falha de provider/vazio) EXCLUÍDOS (paridade com `is_operational_agent_result`); o texto final do turno NUNCA entra (só o report). Web: lista em memória no runner (`serialReports`), alimentada em cada desfecho de turno (aceito, ReadyRejected, violação com attempted report, tier-guard) — análogo do `agents` Vec (append-only, oldest-first).
+2. **Regra §-ID** (Language Contract, verbatim de editorial_prompts.rs:412): "The editorial protocol is authoritative input, not output. Read and obey it, but do not quote, summarize, restate, or reproduce protocol text in the artifact. Cite compact section IDs only, such as `§V.14` or `§11.7`."
+3. **Gaps de prompt fechados** (build_serial_revision_prompt): bullets de justificação do Quality/Anti-Impoverishment Gate (442-448: exact passage + exact protocol requirement + why unsafe to preserve + "If you are unsure, preserve"); bullets do Role Contract sobre SELF_REVIEW_BLOCKED e closing redactor; flag/header `Closing redactor turn:` (o loop web já sabe quando o lead fecha via closure gating do B3 — passa `closingTurn` ao prompt); header `Round turn:`.
+4. **Fix de drift**: grok `grok-4.20-multi-agent-0309` → `grok-4.20-multi-agent` (o sufixo -0309 não existe no desktop).
+5. **Live model resolution** (port de resolve_*_model + choose_preferred_model): por chamada, GET no endpoint /models do provider; escolhe o PRIMEIRO candidato canônico presente na lista viva; senão o primeiro modelo listado; senão o fallback canônico. Candidatos/fallbacks verbatim: codex `gpt-5.5, gpt-5.4, gpt-5.3, gpt-5.2, gpt-5, gpt-4.1` / fb `gpt-5.4`; claude `claude-opus-4-7, claude-opus-4-1-20250805, claude-opus-4-20250514, claude-sonnet-4-20250514, claude-3-7-sonnet-latest` / fb `claude-opus-4-1-20250805`; gemini `gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-2.5-pro, gemini-2.5-flash, gemini-1.5-pro` / fb `gemini-2.5-pro`; deepseek `deepseek-v4-pro, deepseek-reasoner, deepseek-chat, deepseek-v4-flash` / fb `deepseek-reasoner`; grok `grok-4.20-multi-agent, grok-4-latest, grok-4.3, grok-4.20-reasoning, grok-4.20, grok-4-1-fast, grok-4` / fb `grok-4.20-multi-agent`; perplexity SEM live resolution (canônico) → configured/default direto. Precedência web: **modelo configurado pelo operador (models[agent]) → live candidates → primeiro da lista viva → DEFAULT_MODELS[agent]** (o configurado equivale ao env-override canônico do DeepSeek/Grok, estendido a todos por decisão web já vigente). Falha do GET /models → fallback silencioso ao DEFAULT_MODELS (paridade com o desktop, que cai no fallback constant).
+
+## Desvios web documentados
+
+- `Artifact:` referencia o ID do artifact D1 (o desktop usa o path do arquivo; Workers não têm filesystem).
+- Cache por execução do resultado de /models por provider (o desktop resolve a cada chamada sem cache; em Workers cada GET conta no budget de subrequests — dentro de UMA execução a lista viva não muda de forma relevante).
+- Sem `evidence_block` no final do prompt (o web não tem o subsistema de evidence imports do operador; fica para quando a UI existir).
+- DEFAULT_MODELS do web permanece a tabela de defaults de settings (inclui `gpt-5.5`/`claude-opus-4-7` = topo dos candidates canônicos); o fallback final da live resolution usa os fallbacks canônicos por provider.
+- Violações de contrato entram no feed com o attempted report (o desktop embute o que o artifact tiver; o web guarda o attempted_report no artifact de violação).
+
+## Tasks (TDD, red-first cada uma)
+
+1. `buildRevisionHistoryBlock(serialReports)` puro + matriz (formato/cap 12k chars Unicode/placeholder/vazio/ordem/exclusão operacional) e integração no buildRevisionPrompt (seção renomeada) + `serialReports` no runner.
+2. Prompt: bullet §-ID + quality justification bullets + SELF_REVIEW_BLOCKED/closing-redactor bullets + headers `Round turn:`/`Closing redactor turn:` (+ passar closingTurn do loop) + testes de conteúdo.
+3. Modelos: fix grok drift; `choosePreferredModel` + `resolveProviderModel` (candidates/fallbacks canônicos; cache por execução; perplexity sem live) + wiring no callProvider (configured → live → fallback) + testes (candidate presente; ausente → primeiro da lista; GET falha → fallback; configured vence; perplexity nunca chama /models).
+4. Gates + bump v02.10.00 + CHANGELOG (E documentado como exceções adotadas) + cross-review + ship.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.09.00';
+const APP_VERSION = 'APP v02.10.00';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary

Plans E/F close the maestro-app desktop-parity roadmap (A-F).

- **Prior-reports feed** (port of `build_revision_history_block`): the revision prompt replaces the last-12-events JSON with the canonical `Prior Serial Revision Reports` block — every prior serial turn chronologically, name/role/status header + artifact reference + the turn's `maestro_revision_report` capped at 12,000 Unicode chars; canonical placeholder for missing reports; operational failures and the final text never enter; violation/tier-guard turns enter with their attempted report.
- **Canonical prompt sections**: compact section-ID citation rule (`§V.14`/`§11.7`) and protocol-markers bullet; `SELF_REVIEW_BLOCKED` and closing-redactor bullets with the `Closing redactor turn:` flag fed by the B3 closure gating; `Round turn:` header; Quality-gate per-change justification bullets.
- **Live model resolution** (port of `resolve_*_model` + `choose_preferred_model`): canonical candidate lists/fallbacks per provider; operator-configured models win; seeded defaults trigger the live `/models` lookup (first canonical candidate → first listed → fallback), memoized per execution; Perplexity has no live resolution (canonical). Fixed the Grok default drift (`-0309` suffix absent from the desktop).
- **Plan E adopted exceptions** (documented, no code change): `request_usd_per_1k`, seeded `DEFAULT_RATES`, pre-start rejection with <2 agents, seeded `DEFAULT_PROTOCOL`.

Documented web deviations: `docs/superpowers/plans/2026-07-06-maestro-ai-parity-plan-ef.md`.

## Test plan

- 174/174 vitest: 4 new Plan F tests (history-block matrix, canonical prompt sections incl. absence of the old events feed, choosePreferredModel matrix, resolveProviderModel incl. perplexity zero-fetch) + all prior plan suites intact (runner mocks serve `/models` probes without touching turn counters).
- Gates: eslint clean, biome clean (2 pre-existing accepted config infos), typecheck baseline clean, markdownlint 0, prettier clean.
- Cross-review: unanimous ALL READY (caller + codex, gemini, deepseek, grok, perplexity; 2 rounds — round 2 supplied side-by-side canonical Rust hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)