### PR TITLE
fix(maestro-ai): seed the reviewer redraw from a non-cryptographic source (CodeQL alert 64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v02.10.01] - 2026-07-06
+
+### Segurança
+
+- **Alerta CodeQL #64 (js/biased-cryptographic-random, high)**: o seed do redraw de seleção de reviewer deixa de vir de `crypto.getRandomValues` — o par CSPRNG+módulo era o que a query flagra. A fonte volta ao espírito canônico do desktop, que semeia de timestamp de relógio (fonte não-criptográfica) para uma decisão de mera equidade de escalonamento: `Math.random` com variabilidade sub-milissegundo (o análogo direto de `Date.now` repetiria dentro do loop). Nenhuma mudança na semântica de seleção; funções puras e testes de seed determinístico intactos.
+
 ## [v02.10.00] - 2026-07-06
 
 ### Alterado

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2978,7 +2978,13 @@ async function runSession(db: D1Database, env: MaestroAiEnv, id: string): Promis
       // desktop has no round cap, only the turn cap above; the operator's
       // max_cycles setting is honored as an outer round bound meanwhile.
       if (round > maxCycles) break;
-      const selectionSeed = crypto.getRandomValues(new Uint32Array(1))[0] ?? 0;
+      // Scheduling-fairness seed for the redraw, NOT a cryptographic value: the
+      // desktop seeds from a wall-clock timestamp (session_orchestration.rs:864,
+      // timestamp_nanos % pending). Math.random keeps that non-cryptographic
+      // semantics with sub-millisecond variability (Date.now alone can repeat
+      // within a tight loop) and avoids pairing a CSPRNG with a biased modulo
+      // (CodeQL js/biased-cryptographic-random, alert #64).
+      const selectionSeed = Math.floor(Math.random() * 0x100000000);
       const selectedIndex = selectSerialReviewerIndex(
         order,
         roundTurnIndex,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.10.00';
+const APP_VERSION = 'APP v02.10.01';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
## Summary

Fixes code-scanning alert #64 (`js/biased-cryptographic-random`, high): the serial reviewer redraw paired a CSPRNG (`crypto.getRandomValues`) with a biased modulo. The redraw is scheduling fairness, not a cryptographic decision — the canonical desktop seeds it from a wall-clock timestamp (`session_orchestration.rs:864` `timestamp_nanos`, `% pending.len()` at 2653). The CSPRNG source was a web-port embellishment and exactly what created the flagged flow.

One production line changed: the seed source becomes `Math.floor(Math.random() * 2^32)` (non-cryptographic, sub-millisecond variability, same uint32 domain). The pure `selectSerialReviewerIndex`, its deterministic-seed tests, and all selection dynamics are untouched. `crypto.getRandomValues` no longer appears in the maestro-ai module.

## Test plan

- 174/174 vitest; eslint/biome/typecheck/markdownlint/prettier clean.
- Cross-review: unanimous ALL READY (caller + codex, gemini, deepseek, grok, perplexity; 2 rounds).
- Post-merge: verify alert #64 transitions to `fixed` (Default Setup scans main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)