### PR TITLE
fix(security): resolve PostCSS and Socket scan failures

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -34,7 +34,7 @@ jobs:
             api.github.com:443
 
       - name: Process one guarded queue mutation
-        uses: LCV-Ideas-Software/.github/dependabot-automerge@d8f67ca034edb6173ce9baaff41ccb320ef4bf2d
+        uses: LCV-Ideas-Software/.github/dependabot-automerge@3f62b39a76f767d09a5482b8e380746883be3b94
         with:
           github_token: ${{ github.token }}
           automation_token: ${{ secrets.LCV_AUTOMATION_TOKEN }}

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -55,8 +55,12 @@ jobs:
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           GH_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOCKET_PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
+          SOCKET_SCAN_COMMIT_SHA: ${{ github.sha }}
         run: |
+          SOCKET_SCAN_COMMIT_MESSAGE="$(git show -s --format=%s "$SOCKET_SCAN_COMMIT_SHA")"
           socketcli \
             --target-path "$GITHUB_WORKSPACE" \
             --scm github \
+            --commit-sha "$SOCKET_SCAN_COMMIT_SHA" \
+            --commit-message="$SOCKET_SCAN_COMMIT_MESSAGE" \
             --pr-number "$SOCKET_PR_NUMBER"

--- a/tlsrpt-motor/package-lock.json
+++ b/tlsrpt-motor/package-lock.json
@@ -2421,9 +2421,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2491,9 +2491,9 @@
 			"license": "MIT-0"
 		},
 		"node_modules/postcss": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"version": "8.5.22",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+			"integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2511,7 +2511,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},

--- a/tlsrpt-motor/package.json
+++ b/tlsrpt-motor/package.json
@@ -23,7 +23,6 @@
 	},
 	"overrides": {
 		"picomatch": "4.0.4",
-		"postcss": "8.5.10",
 		"undici": "6.27.0",
 		"vite": "8.0.16",
 		"ws": "8.21.0",


### PR DESCRIPTION
Removes the vulnerable PostCSS 8.5.10 override, resolves 8.5.22, fixes bounded Socket metadata transport, and pins the hardened Dependabot controller. Local audit total 0; install, lint, tests, and zizmor passed.