### PR TITLE
test(governance): public native queue canary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# Native merge-queue public canary: 2026-08-08.
 * text=auto eol=lf
 
 *.png binary


### PR DESCRIPTION
## Purpose

Public native merge-queue canary after the `admin-app` wrapper and rulesets were activated.

## Change

Adds one inert comment to `.gitattributes`; repository behavior and attributes remain unchanged.

## Expected path

The signed exact head must pass the repository checks, the default-branch native wrapper must enable auto-merge, GitHub must create a `merge_group`, all five required contexts must pass on the synthetic SHA, and GitHub must create one verified squash and delete this branch. No manual merge or bypass will be used.