### PR TITLE
Pin central Zizmor v2.0.0

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
   zizmor:
     name: Run zizmor
     permissions: write-all
-    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@ac3d4ad22073ee419cb9b861c38fe7bfa93b132a # v1.0.2
+    uses: LCV-Ideas-Software/.github/.github/workflows/zizmor.yml@4058fad11eca7c2eb4e9296108667ef6199a6356 # v2.0.0


### PR DESCRIPTION
Atualiza somente o reusable workflow central do Zizmor para o commit oficial e imutável 4058fad11eca7c2eb4e9296108667ef6199a6356, correspondente a v2.0.0. Validações locais: actionlint, Zizmor pedantic, diff-check e gitleaks verdes.