### PR TITLE
feat(ai): migração admin-motor para Vertex AI (SA OAuth) — v02.15.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,18 @@
   (sem abortar a mint, que é compartilhada) e a requisição recebe apenas o tempo
   restante, de modo que nada continue faturando depois do prazo do handler.
   Padrões: 20s em `countTokens`, 80s em `generateContent`, 20s no catálogo das
-  rotas de modelos e 15s na resolução de modelo do Maestro; em `generate-all` de
-  resumos, cada post recebe o que resta do teto de 40s do lote.
-- **Catálogo de publisher models** via `models.list` (paginado, com abort por
-  página): existe apenas no host global `v1beta1` (`publishers/google/models`),
-  enquanto a geração segue no `v1` regional/global. Com `VERTEX_LOCATION`
-  regional o Maestro não consulta esse catálogo, já que ele anuncia modelos
-  (previews) que a região pode não servir.
+  rotas de modelos e 15s na resolução de modelo do Maestro. Onde o handler já
+  tinha um prazo próprio, vale o instante-limite dele: `generate-all` de resumos
+  reparte o teto de 40s do lote entre os posts, a descoberta de feeds desconta o
+  tempo da consulta ao D1 dos seus 6s, e o import de conversas divide um único
+  orçamento de 95s entre a busca via Jina e as tentativas de extração.
+- **Catálogo de publisher models** via `models.list` (paginado, com o mesmo
+  orçamento cobrindo mint e páginas): existe apenas no host global `v1beta1`
+  (`publishers/google/models`), enquanto a geração segue no `v1`
+  regional/global. Com `VERTEX_LOCATION` regional, o Maestro não consulta o
+  catálogo e as rotas de modelos omitem ids preview/exp — verificado no projeto
+  `lcv-ideas-and-software` que `gemini-3.1-pro-preview` responde 200 em `global`
+  e 404 em `us-central1`, enquanto `gemini-2.5-pro` responde 200 nos dois.
 - **Safety settings e schema de saída em literais REST.** Os enums `HarmCategory`/
   `HarmBlockThreshold` do SDK dão lugar às strings equivalentes da API v1, e o
   `responseSchema` (OpenAPI) do import de conversas trafega no `generationConfig`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,32 @@
   `gemini` do Maestro AI. Prompts, contratos de rota, códigos de status e
   mensagens de negócio permanecem inalterados.
 - **Cliente Vertex compartilhado** (`admin-motor/src/handlers/_shared/vertex.ts`):
-  cache de token com margem de 300s, single-flight na mint, timeouts por chamada
-  (20s `countTokens`, 80s `generateContent`), erros `VertexHttpError` com status e
-  operação de origem. Catálogo de publisher models via `models.list`, que existe
-  apenas no host global `v1beta1` (`publishers/google/models`) — a geração segue
-  no `v1` regional/global.
+  cache de token com margem de 300s, single-flight na mint e erros
+  `VertexHttpError` com status e operação de origem. O `httpOptions.timeout` é o
+  orçamento da **chamada inteira** — a espera pela mint OAuth é limitada por ele
+  (sem abortar a mint, que é compartilhada) e a requisição recebe apenas o tempo
+  restante, de modo que nada continue faturando depois do prazo do handler.
+  Padrões: 20s em `countTokens`, 80s em `generateContent`, 20s no catálogo das
+  rotas de modelos e 15s na resolução de modelo do Maestro; em `generate-all` de
+  resumos, cada post recebe o que resta do teto de 40s do lote.
+- **Catálogo de publisher models** via `models.list` (paginado, com abort por
+  página): existe apenas no host global `v1beta1` (`publishers/google/models`),
+  enquanto a geração segue no `v1` regional/global. Com `VERTEX_LOCATION`
+  regional o Maestro não consulta esse catálogo, já que ele anuncia modelos
+  (previews) que a região pode não servir.
 - **Safety settings e schema de saída em literais REST.** Os enums `HarmCategory`/
   `HarmBlockThreshold` do SDK dão lugar às strings equivalentes da API v1, e o
   `responseSchema` (OpenAPI) do import de conversas trafega no `generationConfig`.
 - **Credencial do Gemini no Maestro AI.** O painel passa a exibir `VERTEX_SA_KEY`
-  como secret do provider e recusa gravação de chave Gemini pela UI: a Service
-  Account é compartilhada por toda a frota (secret `vertex-sa-key` no Secrets
-  Store, exposto pelo novo binding `VERTEX_SA_KEY` em `admin-motor/wrangler.json`),
-  e gravá-la pelo painel rotacionaria a credencial dos demais apps.
-  `VERTEX_PROJECT` (default: `project_id` da própria SA) e `VERTEX_LOCATION`
-  (default: `global`) são opcionais.
+  como secret do provider, com o campo de chave desabilitado e uma nota visível
+  (associada por `aria-describedby`) explicando que a credencial é de
+  infraestrutura: a Service Account é compartilhada por toda a frota (secret
+  `vertex-sa-key` no Secrets Store, exposto pelo novo binding `VERTEX_SA_KEY` em
+  `admin-motor/wrangler.json`), e gravá-la pelo painel rotacionaria a credencial
+  dos demais apps. O backend rejeita a chave do Gemini **antes** de gravar
+  qualquer secret, mantendo a atualização atômica. `VERTEX_PROJECT` (default:
+  `project_id` da própria SA) e `VERTEX_LOCATION` (default: `global`) são
+  opcionais.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## [Unreleased]
 
+## [v02.15.16] - 2026-08-09
+
+### Changed
+
+- **Migração Gemini AI Studio → Vertex AI (service account OAuth).** Todo consumo
+  de IA do `admin-motor` passa a autenticar por Service Account (JWT RS256 →
+  OAuth2, escopo `cloud-platform`) contra `aiplatform.googleapis.com`, sem API
+  key: catálogos de modelos (`/api/{oraculo,astrologo,mainsite,calculadora}/modelos`),
+  transformação de texto do editor MainSite, importação de conversas do Gemini
+  Share, resumos de post, camada opcional de descoberta de feeds e o provider
+  `gemini` do Maestro AI. Prompts, contratos de rota, códigos de status e
+  mensagens de negócio permanecem inalterados.
+- **Cliente Vertex compartilhado** (`admin-motor/src/handlers/_shared/vertex.ts`):
+  cache de token com margem de 300s, single-flight na mint, timeouts por chamada
+  (20s `countTokens`, 80s `generateContent`), erros `VertexHttpError` com status e
+  operação de origem. Catálogo de publisher models via `models.list`, que existe
+  apenas no host global `v1beta1` (`publishers/google/models`) — a geração segue
+  no `v1` regional/global.
+- **Safety settings e schema de saída em literais REST.** Os enums `HarmCategory`/
+  `HarmBlockThreshold` do SDK dão lugar às strings equivalentes da API v1, e o
+  `responseSchema` (OpenAPI) do import de conversas trafega no `generationConfig`.
+- **Credencial do Gemini no Maestro AI.** O painel passa a exibir `VERTEX_SA_KEY`
+  como secret do provider e recusa gravação de chave Gemini pela UI: a Service
+  Account é compartilhada por toda a frota (secret `vertex-sa-key` no Secrets
+  Store, exposto pelo novo binding `VERTEX_SA_KEY` em `admin-motor/wrangler.json`),
+  e gravá-la pelo painel rotacionaria a credencial dos demais apps.
+  `VERTEX_PROJECT` (default: `project_id` da própria SA) e `VERTEX_LOCATION`
+  (default: `global`) são opcionais.
+
+### Removed
+
+- Dependência direta `@google/genai` e o override órfão de `protobufjs`, que só
+  existia para essa árvore.
+
 ## [v02.15.15] - 2026-08-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@
 
 **Operator admin dashboard** for a multi-app Cloudflare workspace. Single-tenant by design: it's the operator's control plane for moderation, configuration, AI model selection, DNS, Pages/Workers ops, and operational telemetry across a fleet of public apps that share a single Cloudflare D1 database.
 
-**Status.** Stable. Current release target: **v02.15.15**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
+**Status.** Stable. Current release target: **v02.15.16**. See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 The version history at a glance:
 
 | Release         | Scope                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`v02.15.16`** | **Gemini AI Studio → Vertex AI (service account OAuth).** Every AI endpoint in `admin-motor` authenticates with a Service Account instead of an API key: model catalogs, MainSite editor transform, Gemini share import, post summaries, the optional news-discovery layer and the Maestro AI Gemini provider. Adds the shared Vertex client (token cache, per-call timeouts, publisher-model catalog on the global `v1beta1` host) and drops the direct `@google/genai` dependency. |
 | **`v02.15.15`** | **Security and current dependency baseline.** Ships the accumulated Maestro AI/editor updates with current Cloudflare tooling, scoped Undici and PostCSS remediations, brace-expansion 5.0.9, CodeQL 4.37.4 and the settled organization Dependabot controller. |
 | **`v02.15.14`** | **Maestro AI parity with desktop v0.5.56.** Persists the complete circular chain of custody and version-bound approvals, resumes without losing progress, keeps rejected attempts as append-only evidence and converges only after every eligible non-author approves the current version. |
 | **`v02.15.13`** | **Maestro AI: gate de retenção OpenAI alinhado à lista oficial.** `gpt-5.5*`/`gpt-5.4*` passam a receber `prompt_cache_retention: "24h"` (doc oficial); família 5.6 segue sem o campo (só `30m` é suportado). |
@@ -94,10 +95,11 @@ Provider API keys can be entered in `Configurações`, but raw values are used o
 | ---------------------------- | ---------------------------- |
 | `MAESTRO_OPENAI_API_KEY`     | `MAESTRO_OPENAI_API_KEY`     |
 | `MAESTRO_ANTHROPIC_API_KEY`  | `MAESTRO_ANTHROPIC_API_KEY`  |
-| `MAESTRO_GEMINI_API_KEY`     | `MAESTRO_GEMINI_API_KEY`     |
 | `MAESTRO_DEEPSEEK_API_KEY`   | `MAESTRO_DEEPSEEK_API_KEY`   |
 | `MAESTRO_GROK_API_KEY`       | `MAESTRO_GROK_API_KEY`       |
 | `MAESTRO_PERPLEXITY_API_KEY` | `MAESTRO_PERPLEXITY_API_KEY` |
+
+Gemini is the exception: it runs on Vertex AI with service-account OAuth, so its credential is not a typed-in API key but the fleet-wide Service Account JSON — Secret Store entry `vertex-sa-key`, bound as `VERTEX_SA_KEY`. `Configurações` reports the provider secret as `VERTEX_SA_KEY` and rejects attempts to save a Gemini key through the panel, since writing it there would rotate the credential for every other app that shares it.
 
 The Worker also uses infrastructure-only bindings/vars to write provider keys into the same Secret Store:
 
@@ -223,7 +225,9 @@ npx wrangler secret put ENFORCE_JWT_VALIDATION --config admin-motor/wrangler.jso
 
 ### 6. Configure additional secrets
 
-Per `admin-motor/wrangler.json`'s `secrets_store_secrets` list, set values for the keys you intend to use (Gemini, Resend, GCP, JINA, Cloudflare DNS/Cache/Account-ID tokens, etc.). `GCP_SA_KEY` (Service Account JSON, >1024 chars) cannot live in Secrets Store and must be a native Worker secret:
+Per `admin-motor/wrangler.json`'s `secrets_store_secrets` list, set values for the keys you intend to use (Vertex AI, Resend, JINA, Cloudflare DNS/Cache/Account-ID tokens, etc.). `VERTEX_SA_KEY` (Secret Store `vertex-sa-key`, the same Service Account the other LCV apps use) is required by every AI endpoint: `/api/{oraculo,astrologo,mainsite,calculadora}/modelos`, the MainSite editor transform, Gemini share import, post summaries, the optional news-discovery layer and the Maestro AI Gemini provider. Optional companions: `VERTEX_PROJECT` (defaults to the `project_id` inside the Service Account JSON) and `VERTEX_LOCATION` (defaults to `global`).
+
+`GCP_SA_KEY` (Cloud Monitoring Service Account) is provisioned as a native Worker secret instead:
 
 ```bash
 npx wrangler secret put GCP_SA_KEY --config admin-motor/wrangler.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported source/release target: v02.15.15. The current `main` branch is
+Latest supported source/release target: v02.15.16. The current `main` branch is
 also supported for security fixes. This patch resolves the current
 Hono, `brace-expansion`, Undici and PostCSS findings in the root and TLS
 reporting toolchains while preserving scoped overrides for incompatible

--- a/admin-motor/src/handlers/_shared/deadlines.ts
+++ b/admin-motor/src/handlers/_shared/deadlines.ts
@@ -1,0 +1,18 @@
+// Módulo: admin-motor/src/handlers/_shared/deadlines.ts
+// Orçamento de tempo compartilhado pelos handlers que chamam IA.
+//
+// O proxy do Cloudflare Pages devolve 524 quando a função passa de ~100s, e
+// nesse ponto o cliente recebe HTML de erro no lugar do JSON do handler. Cada
+// rota fixa UM instante-limite no início e reparte o que sobra entre suas
+// etapas; nenhuma tentativa individual pode reiniciar o relógio, senão dois
+// retries de 80s somados ao countTokens já estouram o teto.
+
+/** Teto por request, com margem para serialização da resposta antes do 524. */
+export const PROXY_REQUEST_BUDGET_MS = 95_000;
+
+/** Milissegundos restantes até o instante-limite (nunca negativo). */
+export const msUntil = (deadlineAt: number): number => Math.max(0, deadlineAt - Date.now());
+
+/** Recorte de uma etapa: o menor entre o teto próprio dela e o que resta. */
+export const stageBudget = (deadlineAt: number, stageCeilingMs: number): number =>
+  Math.min(stageCeilingMs, msUntil(deadlineAt));

--- a/admin-motor/src/handlers/_shared/vertex.test.ts
+++ b/admin-motor/src/handlers/_shared/vertex.test.ts
@@ -1,0 +1,649 @@
+import { describe, expect, it } from 'vitest';
+import type { PublisherModelSummary } from './vertex';
+import { VertexGenAI, VertexHttpError } from './vertex';
+
+const te = new TextEncoder();
+
+const b64urlToBuf = (s: string): Uint8Array<ArrayBuffer> => {
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/');
+  return new Uint8Array(Buffer.from(b64, 'base64'));
+};
+
+const b64urlToJson = (s: string): Record<string, unknown> =>
+  JSON.parse(Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8'));
+
+const makeTestSa = async (kid: string) => {
+  const pair = (await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]) },
+    true,
+    ['sign', 'verify'],
+  )) as CryptoKeyPair;
+  // workers-types tipa exportKey como ArrayBuffer | JsonWebKey; 'pkcs8' sempre retorna ArrayBuffer.
+  const pkcs8Raw = (await crypto.subtle.exportKey('pkcs8', pair.privateKey)) as ArrayBuffer;
+  const pkcs8 = Buffer.from(new Uint8Array(pkcs8Raw)).toString('base64');
+  const pem = `-----BEGIN PRIVATE KEY-----\n${(pkcs8.match(/.{1,64}/g) ?? []).join('\n')}\n-----END PRIVATE KEY-----\n`;
+  return {
+    publicKey: pair.publicKey,
+    saJson: JSON.stringify({
+      type: 'service_account',
+      project_id: 'proj-x',
+      private_key_id: kid,
+      private_key: pem,
+      client_email: `${kid}@proj-x.iam.gserviceaccount.com`,
+      token_uri: 'https://oauth2.test.invalid/token',
+    }),
+  };
+};
+
+const jsonResponse = (status: number, payload: unknown): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  }) as unknown as Response;
+
+interface MockOpts {
+  tokenPayload?: unknown;
+  apiPayload?: unknown;
+  tokenStatus?: number;
+  apiStatus?: number;
+  tokenDelay?: () => Promise<void>;
+}
+
+const makeFetchMock = (opts: MockOpts = {}) => {
+  const { tokenPayload, apiPayload, tokenStatus = 200, apiStatus = 200, tokenDelay } = opts;
+  const calls: {
+    token: Array<{ url: string; init: RequestInit }>;
+    api: Array<{ url: string; init: RequestInit }>;
+  } = { token: [], api: [] };
+  const fetchImpl = (async (url: string | URL, init: RequestInit) => {
+    if (String(url).includes('oauth2.test.invalid')) {
+      calls.token.push({ url: String(url), init });
+      if (tokenDelay) await tokenDelay();
+      return jsonResponse(tokenStatus, tokenPayload ?? { access_token: 'tok-1', expires_in: 3600 });
+    }
+    calls.api.push({ url: String(url), init });
+    return jsonResponse(
+      apiStatus,
+      apiPayload ?? {
+        candidates: [{ content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 1 },
+      },
+    );
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+};
+
+const client = (sa: { saJson: string }, mock: ReturnType<typeof makeFetchMock>, extra: Record<string, unknown> = {}) =>
+  new VertexGenAI({
+    saKeyJson: sa.saJson,
+    project: 'proj-x',
+    location: 'global',
+    fetchImpl: mock.fetchImpl,
+    ...extra,
+  });
+
+describe('autenticação por service account (JWT RS256 → OAuth2)', () => {
+  it('minta JWT com header/claims do fluxo oficial e troca por access token no token_uri', async () => {
+    const sa = await makeTestSa('kid-claims');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.countTokens({ model: 'm', contents: 'oi' });
+
+    expect(mock.calls.token).toHaveLength(1);
+    const req = mock.calls.token[0]!;
+    expect(req.url).toBe('https://oauth2.test.invalid/token');
+    expect(req.init.method).toBe('POST');
+    const params = new URLSearchParams(req.init.body as string);
+    expect(params.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+
+    const assertion = params.get('assertion') ?? '';
+    const [h = '', c = '', s = ''] = assertion.split('.');
+    expect(b64urlToJson(h)).toEqual({ alg: 'RS256', typ: 'JWT', kid: 'kid-claims' });
+    const claims = b64urlToJson(c) as { iss: string; scope: string; aud: string; iat: number; exp: number };
+    expect(claims.iss).toBe('kid-claims@proj-x.iam.gserviceaccount.com');
+    expect(claims.scope).toBe('https://www.googleapis.com/auth/cloud-platform');
+    expect(claims.aud).toBe('https://oauth2.test.invalid/token');
+    expect(claims.exp - claims.iat).toBe(3600);
+
+    const valid = await crypto.subtle.verify('RSASSA-PKCS1-v1_5', sa.publicKey, b64urlToBuf(s), te.encode(`${h}.${c}`));
+    expect(valid).toBe(true);
+  });
+
+  it('nunca envia api key: sem ?key= na URL e sem x-goog-api-key nos headers', async () => {
+    const sa = await makeTestSa('kid-nokey');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.generateContent({ model: 'm', contents: 'oi' });
+    const { url, init } = mock.calls.api[0]!;
+    expect(url).not.toMatch(/[?&]key=/u);
+    const headers = init.headers as Record<string, string>;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain('x-goog-api-key');
+    expect(headers.Authorization).toBe('Bearer tok-1');
+  });
+
+  it('reusa o access token dentro da validade e reminta após a margem de expiração', async () => {
+    const sa = await makeTestSa('kid-cache');
+    const mock = makeFetchMock();
+    let nowMs = 1_700_000_000_000;
+    const ai = client(sa, mock, { now: () => nowMs });
+    await ai.models.countTokens({ model: 'm', contents: '1' });
+    await ai.models.generateContent({ model: 'm', contents: '2' });
+    expect(mock.calls.token).toHaveLength(1);
+    nowMs += (3600 - 240) * 1000;
+    await ai.models.countTokens({ model: 'm', contents: '3' });
+    expect(mock.calls.token).toHaveLength(2);
+  });
+
+  it('single-flight: chamadas concorrentes compartilham uma única mint', async () => {
+    const sa = await makeTestSa('kid-flight');
+    let release: () => void = () => {};
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const mock = makeFetchMock({ tokenDelay: () => gate });
+    const ai = client(sa, mock);
+    const p1 = ai.models.countTokens({ model: 'm', contents: '1' });
+    const p2 = ai.models.generateContent({ model: 'm', contents: '2' });
+    release();
+    await Promise.all([p1, p2]);
+    expect(mock.calls.token).toHaveLength(1);
+  });
+
+  it('o cache é por identidade de chave (kid distinto minta separadamente)', async () => {
+    const sa1 = await makeTestSa('kid-iso-1');
+    const sa2 = await makeTestSa('kid-iso-2');
+    const mock = makeFetchMock();
+    await client(sa1, mock).models.countTokens({ model: 'm', contents: 'a' });
+    await client(sa2, mock).models.countTokens({ model: 'm', contents: 'b' });
+    expect(mock.calls.token).toHaveLength(2);
+  });
+});
+
+describe('montagem das requisições REST do Vertex', () => {
+  it('monta a URL global do generateContent e a regional quando location não é global', async () => {
+    const sa = await makeTestSa('kid-url');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.generateContent({ model: 'gemini-2.5-flash', contents: 'oi' });
+    expect(mock.calls.api[0]!.url).toBe(
+      'https://aiplatform.googleapis.com/v1/projects/proj-x/locations/global/publishers/google/models/gemini-2.5-flash:generateContent',
+    );
+
+    const mock2 = makeFetchMock();
+    const regional = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'proj-x',
+      location: 'us-central1',
+      fetchImpl: mock2.fetchImpl,
+    });
+    await regional.models.countTokens({ model: 'm', contents: 'oi' });
+    expect(mock2.calls.api[0]!.url).toBe(
+      'https://us-central1-aiplatform.googleapis.com/v1/projects/proj-x/locations/us-central1/publishers/google/models/m:countTokens',
+    );
+  });
+
+  it.each([
+    ['us', 'https://aiplatform.us.rep.googleapis.com'],
+    ['eu', 'https://aiplatform.eu.rep.googleapis.com'],
+  ])('mapeia a multirregião %s para o hostname oficial', async (location, endpoint) => {
+    const sa = await makeTestSa(`kid-${location}`);
+    const mock = makeFetchMock();
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: 'proj-x', location, fetchImpl: mock.fetchImpl });
+
+    await ai.models.countTokens({ model: 'm', contents: 'oi' });
+
+    expect(mock.calls.api[0]!.url).toBe(
+      `${endpoint}/v1/projects/proj-x/locations/${location}/publishers/google/models/m:countTokens`,
+    );
+  });
+
+  it.each(['europe-west10', 'asia-south2', 'northamerica-northeast1'])(
+    'aceita qualquer região oficial do Vertex sem lista hard-coded que envelheça (%s)',
+    async (location) => {
+      const sa = await makeTestSa(`kid-region-${location}`);
+      const mock = makeFetchMock();
+      const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: 'proj-x', location, fetchImpl: mock.fetchImpl });
+
+      await ai.models.countTokens({ model: 'm', contents: 'oi' });
+
+      expect(mock.calls.api[0]!.url).toBe(
+        `https://${location}-aiplatform.googleapis.com/v1/projects/proj-x/locations/${location}/publishers/google/models/m:countTokens`,
+      );
+    },
+  );
+
+  it.each([
+    'attacker.example/path?',
+    'evil.com',
+    'aiplatform.googleapis.com.evil',
+    'Us-Central1',
+    'us..central1',
+    '-us-central1',
+    '',
+  ])(
+    'rejeita VERTEX_LOCATION que não é rótulo DNS minúsculo único (%s) antes de obter ou transmitir o bearer token',
+    async (location) => {
+      const sa = await makeTestSa('kid-location-origin');
+      const mock = makeFetchMock();
+
+      expect(
+        () =>
+          new VertexGenAI({
+            saKeyJson: sa.saJson,
+            project: 'proj-x',
+            location,
+            fetchImpl: mock.fetchImpl,
+          }),
+      ).toThrow(/VERTEX_LOCATION/);
+      expect(mock.calls.token).toHaveLength(0);
+      expect(mock.calls.api).toHaveLength(0);
+    },
+  );
+
+  it('mapeia config do formato do SDK para o corpo REST (generationConfig + top-level)', async () => {
+    const sa = await makeTestSa('kid-map');
+    const mock = makeFetchMock();
+    const safetySettings = [{ category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' }];
+    await client(sa, mock).models.generateContent({
+      model: 'm',
+      contents: 'pergunta',
+      config: {
+        systemInstruction: 'seja literal',
+        temperature: 0.3,
+        maxOutputTokens: 8192,
+        safetySettings,
+        responseMimeType: 'application/json',
+      },
+    });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'pergunta' }] }]);
+    expect(body.systemInstruction).toEqual({ role: 'user', parts: [{ text: 'seja literal' }] });
+    expect(body.generationConfig).toEqual({
+      temperature: 0.3,
+      maxOutputTokens: 8192,
+      responseMimeType: 'application/json',
+    });
+    expect(body.safetySettings).toEqual(safetySettings);
+    expect(body.config).toBeUndefined();
+    expect(body.httpOptions).toBeUndefined();
+  });
+
+  it('transporta responseSchema (OpenAPI) para generationConfig.responseSchema', async () => {
+    const sa = await makeTestSa('kid-schema');
+    const mock = makeFetchMock();
+    const responseSchema = {
+      type: 'OBJECT',
+      properties: {
+        title: { type: 'STRING', description: 'Título da conversa' },
+        markdown: { type: 'STRING', description: 'Conteúdo em Markdown' },
+      },
+      required: ['title', 'markdown'],
+    };
+    await client(sa, mock).models.generateContent({
+      model: 'm',
+      contents: 'extraia',
+      config: { responseMimeType: 'application/json', responseSchema },
+    });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.generationConfig).toEqual({
+      responseMimeType: 'application/json',
+      responseSchema,
+    });
+  });
+
+  it('normaliza array misto de parts (inlineData + string) em um único content de usuário', async () => {
+    const sa = await makeTestSa('kid-multimodal');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.generateContent({
+      model: 'm',
+      contents: [{ inlineData: { data: 'QUJD', mimeType: 'application/pdf' } }, 'Extraia os dados deste arquivo.'],
+      config: { maxOutputTokens: 300 },
+    });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.contents).toEqual([
+      {
+        role: 'user',
+        parts: [
+          { inlineData: { data: 'QUJD', mimeType: 'application/pdf' } },
+          { text: 'Extraia os dados deste arquivo.' },
+        ],
+      },
+    ]);
+  });
+
+  it('normaliza o mesmo array misto no countTokens', async () => {
+    const sa = await makeTestSa('kid-multimodal-count');
+    const mock = makeFetchMock({ apiPayload: { totalTokens: 570 } });
+    const res = await client(sa, mock).models.countTokens({
+      model: 'm',
+      contents: [{ inlineData: { data: 'QUJD', mimeType: 'image/png' } }, 'Descreva.'],
+    });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.contents).toEqual([
+      { role: 'user', parts: [{ inlineData: { data: 'QUJD', mimeType: 'image/png' } }, { text: 'Descreva.' }] },
+    ]);
+    expect(res.totalTokens).toBe(570);
+  });
+
+  it('deriva o project do project_id da SA quando options.project não é fornecido', async () => {
+    const sa = await makeTestSa('kid-derive');
+    const mock = makeFetchMock();
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, location: 'global', fetchImpl: mock.fetchImpl });
+    await ai.models.countTokens({ model: 'm', contents: 'oi' });
+    expect(mock.calls.api[0]!.url).toBe(
+      'https://aiplatform.googleapis.com/v1/projects/proj-x/locations/global/publishers/google/models/m:countTokens',
+    );
+  });
+
+  it('project vazio (resolver de secrets do admin-motor devolve "") também deriva da SA', async () => {
+    const sa = await makeTestSa('kid-empty-project');
+    const mock = makeFetchMock();
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: '', location: 'global', fetchImpl: mock.fetchImpl });
+    await ai.models.countTokens({ model: 'm', contents: 'oi' });
+    expect(mock.calls.api[0]!.url).toContain('/projects/proj-x/');
+  });
+
+  it('options.project explícito tem precedência sobre o project_id da SA', async () => {
+    const sa = await makeTestSa('kid-precedence');
+    const mock = makeFetchMock();
+    const ai = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'projeto-explicito',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    await ai.models.countTokens({ model: 'm', contents: 'oi' });
+    expect(mock.calls.api[0]!.url).toContain('/projects/projeto-explicito/');
+  });
+
+  it('falha com erro diagnóstico quando nem options.project nem project_id existem', async () => {
+    const sa = await makeTestSa('kid-noproj');
+    const semProjeto = JSON.stringify({ ...JSON.parse(sa.saJson), project_id: undefined });
+    const mock = makeFetchMock();
+    const ai = new VertexGenAI({ saKeyJson: semProjeto, location: 'global', fetchImpl: mock.fetchImpl });
+    await expect(ai.models.countTokens({ model: 'm', contents: 'oi' })).rejects.toThrow(/VERTEX_PROJECT|project_id/u);
+  });
+
+  it('passa adiante contents que já são Content[] com role e parts', async () => {
+    const sa = await makeTestSa('kid-passthrough');
+    const mock = makeFetchMock();
+    const contents = [{ role: 'user', parts: [{ text: 'já normalizado' }] }];
+    await client(sa, mock).models.generateContent({ model: 'm', contents });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.contents).toEqual(contents);
+  });
+
+  it('httpOptions.timeout instala um AbortSignal na chamada da API sem afetar a mint de token', async () => {
+    const sa = await makeTestSa('kid-timeout');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.generateContent({
+      model: 'm',
+      contents: 'x',
+      config: { httpOptions: { timeout: 20_000 } },
+    });
+    expect(mock.calls.token[0]!.init.signal).toBeInstanceOf(AbortSignal); // teto próprio da mint (20s)
+    expect(mock.calls.api[0]!.init.signal).toBeInstanceOf(AbortSignal);
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.generationConfig).toBeUndefined();
+  });
+
+  it('omite campos ausentes sem enviar chaves vazias', async () => {
+    const sa = await makeTestSa('kid-min');
+    const mock = makeFetchMock();
+    await client(sa, mock).models.generateContent({ model: 'm', contents: 'x' });
+    const body = JSON.parse(mock.calls.api[0]!.init.body as string);
+    expect(body.generationConfig).toBeUndefined();
+    expect(body.systemInstruction).toBeUndefined();
+    expect(body.safetySettings).toBeUndefined();
+    expect(mock.calls.api[0]!.init.signal ?? undefined).toBeUndefined();
+    expect(mock.calls.token[0]!.init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe('normalização das respostas', () => {
+  it('expõe .text sem thought parts, candidates com finishReason e usageMetadata com thoughtsTokenCount', async () => {
+    const sa = await makeTestSa('kid-resp');
+    const apiPayload = {
+      candidates: [
+        {
+          content: { parts: [{ thought: true, text: 'raciocínio' }, { text: 'olá ' }, { text: 'mundo' }] },
+          finishReason: 'STOP',
+        },
+      ],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2, thoughtsTokenCount: 7 },
+    };
+    const mock = makeFetchMock({ apiPayload });
+    const res = await client(sa, mock).models.generateContent({ model: 'm', contents: 'oi' });
+    expect(res.text).toBe('olá mundo');
+    expect(res.candidates?.[0]?.finishReason).toBe('STOP');
+    expect(res.usageMetadata?.thoughtsTokenCount).toBe(7);
+  });
+
+  it('.text é vazio quando não há candidates', async () => {
+    const sa = await makeTestSa('kid-vazio');
+    const mock = makeFetchMock({ apiPayload: { candidates: [] } });
+    const res = await client(sa, mock).models.generateContent({ model: 'm', contents: 'oi' });
+    expect(res.text).toBe('');
+  });
+
+  it('countTokens monta a URL própria e repassa totalTokens', async () => {
+    const sa = await makeTestSa('kid-count');
+    const mock = makeFetchMock({ apiPayload: { totalTokens: 42 } });
+    const res = await client(sa, mock).models.countTokens({ model: 'm', contents: 'conte' });
+    expect(mock.calls.api[0]!.url).toMatch(/:countTokens$/u);
+    expect(res.totalTokens).toBe(42);
+  });
+});
+
+describe('regressão workerd e erros diagnósticos', () => {
+  it('invoca o fetch global desacoplado do this da instância (regressão: Illegal invocation no workerd)', async () => {
+    const sa = await makeTestSa('kid-global-fetch');
+    const urls: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = function (this: unknown, url: string | URL) {
+      if (this !== undefined && this !== globalThis) {
+        throw new TypeError('Illegal invocation: function called with incorrect `this` reference.');
+      }
+      urls.push(String(url));
+      if (String(url).includes('oauth2.test.invalid')) {
+        return Promise.resolve(jsonResponse(200, { access_token: 'tok-g', expires_in: 3600 }));
+      }
+      return Promise.resolve(jsonResponse(200, { totalTokens: 1 }));
+    } as unknown as typeof fetch;
+    try {
+      const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: 'proj-x', location: 'global' });
+      const res = await ai.models.countTokens({ model: 'm', contents: 'x' });
+      expect(res.totalTokens).toBe(1);
+      expect(urls).toHaveLength(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('erro HTTP do Vertex vira VertexHttpError com propriedade status numérica (classificador de retry)', async () => {
+    const sa = await makeTestSa('kid-status');
+    const mock = makeFetchMock({ apiStatus: 429, apiPayload: { error: { code: 429, message: 'Resource exhausted' } } });
+    const failure = await client(sa, mock)
+      .models.generateContent({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect(failure).toBeInstanceOf(VertexHttpError);
+    expect((failure as VertexHttpError).status).toBe(429);
+    expect(String((failure as Error).message)).toMatch(/429.*Resource exhausted/su);
+  });
+
+  it('VertexHttpError carrega a operação de origem — generateContent, countTokens e oauth-token são distinguíveis', async () => {
+    const saGen = await makeTestSa('kid-op-gen');
+    const gen404 = makeFetchMock({
+      apiStatus: 404,
+      apiPayload: { error: { code: 404, message: 'Publisher Model not found' } },
+    });
+    const genFailure = await client(saGen, gen404)
+      .models.generateContent({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect((genFailure as VertexHttpError).operation).toBe('generateContent');
+
+    const saCount = await makeTestSa('kid-op-count');
+    const count404 = makeFetchMock({
+      apiStatus: 404,
+      apiPayload: { error: { code: 404, message: 'Publisher Model not found' } },
+    });
+    const countFailure = await client(saCount, count404)
+      .models.countTokens({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect((countFailure as VertexHttpError).operation).toBe('countTokens');
+  });
+
+  it('erro do token endpoint também carrega status e detalhe do OAuth', async () => {
+    const sa = await makeTestSa('kid-err-token');
+    const mock = makeFetchMock({
+      tokenStatus: 400,
+      tokenPayload: { error: 'invalid_grant', error_description: 'Invalid JWT Signature.' },
+    });
+    const failure = await client(sa, mock)
+      .models.countTokens({ model: 'm', contents: 'x' })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+    expect(failure).toBeInstanceOf(VertexHttpError);
+    expect((failure as VertexHttpError).status).toBe(400);
+    expect((failure as VertexHttpError).operation).toBe('oauth-token');
+    expect(String((failure as Error).message)).toMatch(/invalid_grant.*Invalid JWT Signature/su);
+  });
+
+  it('credencial JSON malformada ou sem campo obrigatório falha com erro diagnóstico', async () => {
+    const mock = makeFetchMock();
+    const broken = new VertexGenAI({
+      saKeyJson: 'não-é-json',
+      project: 'p',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    await expect(broken.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/VERTEX_SA_KEY.*JSON/su);
+
+    const sa = await makeTestSa('kid-campo');
+    const missing = JSON.stringify({ ...JSON.parse(sa.saJson), private_key: undefined });
+    const partial = new VertexGenAI({
+      saKeyJson: missing,
+      project: 'p',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    await expect(partial.models.countTokens({ model: 'm', contents: 'x' })).rejects.toThrow(/private_key/u);
+  });
+});
+
+describe('models.list (catálogo de publisher models, v1beta1 global)', () => {
+  const listFetch = (pages: Array<{ publisherModels?: unknown[]; nextPageToken?: string }>, status = 200) => {
+    const calls: string[] = [];
+    let page = 0;
+    const fetchImpl = (async (url: string | URL) => {
+      if (String(url).includes('oauth2.test.invalid')) {
+        return jsonResponse(200, { access_token: 'tok-1', expires_in: 3600 });
+      }
+      calls.push(String(url));
+      const payload = pages[Math.min(page, pages.length - 1)] ?? {};
+      page += 1;
+      return jsonResponse(status, status === 200 ? payload : { error: { code: status, message: 'boom' } });
+    }) as unknown as typeof fetch;
+    return { fetchImpl, calls };
+  };
+
+  it('monta a URL v1beta1 global sem projeto no path, com bearer token, e itera os publisherModels', async () => {
+    const sa = await makeTestSa('kid-list');
+    const mock = listFetch([
+      {
+        publisherModels: [
+          { name: 'publishers/google/models/gemini-2.5-pro' },
+          { name: 'publishers/google/models/gemini-2.5-flash' },
+        ],
+      },
+    ]);
+    const ai = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'proj-x',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    const names: string[] = [];
+    const pager = await ai.models.list({ config: { pageSize: 1000 } });
+    for await (const m of pager) {
+      if (m.name) names.push(m.name);
+    }
+    expect(names).toEqual(['publishers/google/models/gemini-2.5-pro', 'publishers/google/models/gemini-2.5-flash']);
+    expect(mock.calls).toHaveLength(1);
+    expect(mock.calls[0]).toBe('https://aiplatform.googleapis.com/v1beta1/publishers/google/models?pageSize=1000');
+  });
+
+  it('pagina com pageToken até esgotar e agrega todas as páginas', async () => {
+    const sa = await makeTestSa('kid-list-pages');
+    const mock = listFetch([
+      { publisherModels: [{ name: 'publishers/google/models/a' }], nextPageToken: 'tok-2' },
+      { publisherModels: [{ name: 'publishers/google/models/b' }] },
+    ]);
+    const ai = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'proj-x',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    const names: string[] = [];
+    for await (const m of ai.models.list()) {
+      if (m.name) names.push(m.name);
+    }
+    expect(names).toEqual(['publishers/google/models/a', 'publishers/google/models/b']);
+    expect(mock.calls).toHaveLength(2);
+    expect(mock.calls[1]).toContain('pageToken=tok-2');
+  });
+
+  it('usa o host global mesmo com location regional (o catálogo é global e o v1 regional responde 404)', async () => {
+    const sa = await makeTestSa('kid-list-regional');
+    const mock = listFetch([{ publisherModels: [] }]);
+    const ai = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'proj-x',
+      location: 'us-central1',
+      fetchImpl: mock.fetchImpl,
+    });
+    const drained: PublisherModelSummary[] = [];
+    for await (const model of ai.models.list()) {
+      drained.push(model);
+    }
+    expect(drained).toHaveLength(0);
+    expect(mock.calls[0]).toMatch(/^https:\/\/aiplatform\.googleapis\.com\/v1beta1\//u);
+  });
+
+  it('falha HTTP vira VertexHttpError com operation listModels', async () => {
+    const sa = await makeTestSa('kid-list-err');
+    const mock = listFetch([{}], 403);
+    const ai = new VertexGenAI({
+      saKeyJson: sa.saJson,
+      project: 'proj-x',
+      location: 'global',
+      fetchImpl: mock.fetchImpl,
+    });
+    const yielded: PublisherModelSummary[] = [];
+    const failure = await (async () => {
+      try {
+        for await (const model of ai.models.list()) {
+          yielded.push(model);
+        }
+        return null;
+      } catch (err) {
+        return err;
+      }
+    })();
+    expect(yielded).toHaveLength(0);
+    expect(failure).toBeInstanceOf(VertexHttpError);
+    expect((failure as VertexHttpError).status).toBe(403);
+    expect((failure as VertexHttpError).operation).toBe('listModels');
+  });
+});

--- a/admin-motor/src/handlers/_shared/vertex.test.ts
+++ b/admin-motor/src/handlers/_shared/vertex.test.ts
@@ -679,6 +679,42 @@ describe('models.list (catálogo de publisher models, v1beta1 global)', () => {
     expect(mock.calls[0]).toMatch(/^https:\/\/aiplatform\.googleapis\.com\/v1beta1\//u);
   });
 
+  it('o orçamento do catálogo cobre a mint: uma mint pendurada estoura antes de pedir a primeira página', async () => {
+    const sa = await makeTestSa('kid-list-budget');
+    const paginas: string[] = [];
+    let liberar: () => void = () => {};
+    const mintPendurada = new Promise<void>((resolve) => {
+      liberar = resolve;
+    });
+    const fetchImpl = (async (url: string | URL) => {
+      if (String(url).includes('oauth2.test.invalid')) {
+        await mintPendurada;
+        return jsonResponse(200, { access_token: 'tok-1', expires_in: 3600 });
+      }
+      paginas.push(String(url));
+      return jsonResponse(200, { publisherModels: [] });
+    }) as unknown as typeof fetch;
+
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, location: 'global', fetchImpl });
+    const emitidos: PublisherModelSummary[] = [];
+    const erro = await (async () => {
+      try {
+        for await (const model of ai.models.list({ config: { httpOptions: { timeout: 60 } } })) {
+          emitidos.push(model);
+        }
+        return null;
+      } catch (err) {
+        return err;
+      }
+    })();
+    expect(emitidos).toHaveLength(0);
+
+    expect(erro).toBeInstanceOf(Error);
+    expect((erro as Error).message).toContain('orçamento');
+    expect(paginas).toHaveLength(0);
+    liberar();
+  });
+
   it('falha HTTP vira VertexHttpError com operation listModels', async () => {
     const sa = await makeTestSa('kid-list-err');
     const mock = listFetch([{}], 403);

--- a/admin-motor/src/handlers/_shared/vertex.test.ts
+++ b/admin-motor/src/handlers/_shared/vertex.test.ts
@@ -290,6 +290,35 @@ describe('montagem das requisições REST do Vertex', () => {
     });
   });
 
+  it('o httpOptions.timeout é orçamento da chamada inteira: uma mint pendurada estoura antes de chamar a API', async () => {
+    const sa = await makeTestSa('kid-budget');
+    const apiCalls: string[] = [];
+    let liberar: () => void = () => {};
+    const mintPendurada = new Promise<void>((resolve) => {
+      liberar = resolve;
+    });
+    const fetchImpl = (async (url: string | URL) => {
+      if (String(url).includes('oauth2.test.invalid')) {
+        await mintPendurada;
+        return jsonResponse(200, { access_token: 'tok-1', expires_in: 3600 });
+      }
+      apiCalls.push(String(url));
+      return jsonResponse(200, { candidates: [] });
+    }) as unknown as typeof fetch;
+
+    const ai = new VertexGenAI({ saKeyJson: sa.saJson, project: 'proj-x', location: 'global', fetchImpl });
+    const erro = await ai.models
+      .generateContent({ model: 'm', contents: 'oi', config: { httpOptions: { timeout: 60 } } })
+      .then(() => null)
+      .catch((err: unknown) => err);
+
+    expect(erro).toBeInstanceOf(Error);
+    expect((erro as Error).message).toContain('orçamento');
+    // A chamada da API nunca acontece: o orçamento acabou ainda na mint.
+    expect(apiCalls).toHaveLength(0);
+    liberar();
+  });
+
   it('normaliza array misto de parts (inlineData + string) em um único content de usuário', async () => {
     const sa = await makeTestSa('kid-multimodal');
     const mock = makeFetchMock();

--- a/admin-motor/src/handlers/_shared/vertex.test.ts
+++ b/admin-motor/src/handlers/_shared/vertex.test.ts
@@ -544,18 +544,47 @@ describe('regressão workerd e erros diagnósticos', () => {
 describe('models.list (catálogo de publisher models, v1beta1 global)', () => {
   const listFetch = (pages: Array<{ publisherModels?: unknown[]; nextPageToken?: string }>, status = 200) => {
     const calls: string[] = [];
+    const inits: RequestInit[] = [];
     let page = 0;
-    const fetchImpl = (async (url: string | URL) => {
+    const fetchImpl = (async (url: string | URL, init: RequestInit) => {
       if (String(url).includes('oauth2.test.invalid')) {
         return jsonResponse(200, { access_token: 'tok-1', expires_in: 3600 });
       }
       calls.push(String(url));
+      inits.push(init);
       const payload = pages[Math.min(page, pages.length - 1)] ?? {};
       page += 1;
       return jsonResponse(status, status === 200 ? payload : { error: { code: status, message: 'boom' } });
     }) as unknown as typeof fetch;
-    return { fetchImpl, calls };
+    return { fetchImpl, calls, inits };
   };
+
+  it('sem timeout configurado não envia signal; com timeout, cada página vai com AbortSignal', async () => {
+    const sa = await makeTestSa('kid-list-timeout');
+    const semTimeout = listFetch([{ publisherModels: [] }]);
+    const semLimite = new VertexGenAI({ saKeyJson: sa.saJson, location: 'global', fetchImpl: semTimeout.fetchImpl });
+    const semLimiteVistos: PublisherModelSummary[] = [];
+    for await (const model of semLimite.models.list()) {
+      semLimiteVistos.push(model);
+    }
+    expect(semLimiteVistos).toHaveLength(0);
+    expect(semTimeout.inits[0]?.signal).toBeUndefined();
+
+    const comTimeout = listFetch([
+      { publisherModels: [{ name: 'publishers/google/models/a' }], nextPageToken: 'tok-2' },
+      { publisherModels: [{ name: 'publishers/google/models/b' }] },
+    ]);
+    const comLimite = new VertexGenAI({ saKeyJson: sa.saJson, location: 'global', fetchImpl: comTimeout.fetchImpl });
+    const comLimiteVistos: PublisherModelSummary[] = [];
+    for await (const model of comLimite.models.list({ config: { pageSize: 10, httpOptions: { timeout: 15_000 } } })) {
+      comLimiteVistos.push(model);
+    }
+    expect(comLimiteVistos).toHaveLength(2);
+    expect(comTimeout.calls).toHaveLength(2);
+    for (const init of comTimeout.inits) {
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
 
   it('monta a URL v1beta1 global sem projeto no path, com bearer token, e itera os publisherModels', async () => {
     const sa = await makeTestSa('kid-list');

--- a/admin-motor/src/handlers/_shared/vertex.ts
+++ b/admin-motor/src/handlers/_shared/vertex.ts
@@ -1,0 +1,404 @@
+// Módulo: admin-motor/src/handlers/_shared/vertex.ts
+// Cliente REST mínimo do Vertex AI (Gemini Enterprise Agent Platform).
+// Autentica com service account via JWT RS256 (WebCrypto) trocado por access
+// token OAuth2, com cache por identidade de chave e single-flight para mints
+// concorrentes. Espelha a superfície do SDK @google/genai consumida pelos
+// handlers do admin-motor (models.generateContent / models.countTokens /
+// models.list), incluindo httpOptions.timeout (AbortSignal na chamada da
+// API), saída estruturada (responseMimeType) e entrada multimodal: um array
+// misto de parts (inlineData + string) é normalizado em um único content de
+// usuário, formato validado empiricamente no REST v1. A listagem de publisher
+// models existe apenas no v1beta1 e apenas no host global (provado
+// empiricamente: v1 responde 404) — models.list usa esse endpoint fixo.
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  private_key_id: string;
+  token_uri: string;
+  project_id?: string;
+}
+
+export interface VertexGenAIOptions {
+  saKeyJson: string;
+  /** Opcional: quando ausente, o project é derivado do project_id da própria service account. */
+  project?: string | undefined;
+  location: string;
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+interface HttpOptions {
+  timeout?: number;
+}
+
+interface GenerateContentConfig {
+  temperature?: number;
+  topP?: number;
+  maxOutputTokens?: number;
+  thinkingConfig?: Record<string, unknown>;
+  safetySettings?: unknown[];
+  systemInstruction?: string | Record<string, unknown>;
+  responseMimeType?: string;
+  responseJsonSchema?: unknown;
+  /** Schema OpenAPI-style do Vertex (type OBJECT/STRING…) — provado no v1 em 2026-08-09. */
+  responseSchema?: unknown;
+  httpOptions?: HttpOptions;
+}
+
+interface GenerateContentArgs {
+  model: string;
+  contents: unknown;
+  config?: GenerateContentConfig;
+}
+
+interface CountTokensArgs {
+  model: string;
+  contents: unknown;
+  config?: { httpOptions?: HttpOptions };
+}
+
+interface VertexResponsePart {
+  text?: string;
+  thought?: boolean;
+}
+
+interface VertexCandidate {
+  content?: { parts?: VertexResponsePart[] };
+  finishReason?: string;
+}
+
+export interface VertexGenerateContentResponse {
+  candidates?: VertexCandidate[];
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+    cachedContentTokenCount?: number;
+    thoughtsTokenCount?: number;
+    totalTokenCount?: number;
+  };
+  modelVersion?: string;
+  text: string;
+}
+
+/** Operação de origem de um VertexHttpError — permite ao caller distinguir um
+ * 404 de publisher model (fallback de seletor) de falhas da mint OAuth. */
+export type VertexOperation = 'oauth-token' | 'generateContent' | 'countTokens' | 'listModels';
+
+/** Item do catálogo de publisher models (v1beta1); name no formato
+ * "publishers/google/models/<id>". */
+export interface PublisherModelSummary {
+  name?: string;
+  displayName?: string;
+  versionId?: string;
+}
+
+interface ListModelsArgs {
+  config?: { pageSize?: number };
+}
+
+// Catálogo de publisher models: existe apenas no v1beta1 e apenas no host
+// global — o v1 e os hosts regionais respondem 404 (provado empiricamente).
+const LIST_MODELS_BASE_URL = 'https://aiplatform.googleapis.com/v1beta1/publishers/google/models';
+
+/** Erro HTTP com status numérico e operação de origem preservados para o classificador de retry/fallback do caller. */
+export class VertexHttpError extends Error {
+  override readonly name = 'VertexHttpError';
+
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly operation: VertexOperation,
+  ) {
+    super(message);
+  }
+}
+
+const OAUTH_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+const OAUTH_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+const JWT_LIFETIME_S = 3600; // máximo permitido pelo fluxo server-to-server do Google
+const JWT_CLOCK_SKEW_S = 30;
+const TOKEN_SAFETY_MARGIN_S = 300;
+const ERROR_BODY_EXCERPT = 300;
+// A mint de token não herda o httpOptions.timeout do caller (esse contrato é
+// da chamada da API); um teto próprio evita que um endpoint OAuth travado
+// pendure o single-flight e todos os callers que aguardam a mesma mint.
+const TOKEN_MINT_TIMEOUT_MS = 20_000;
+
+// O location compõe o HOST do service endpoint regional
+// (`<location>-aiplatform.googleapis.com`). A validação de rótulo DNS único
+// minúsculo (sem pontos, barras ou espaços) garante que nenhuma configuração
+// livre desloque a origem de uma requisição com bearer token para fora de
+// googleapis.com, sem manter uma lista hard-coded que envelhece quando o
+// Google adiciona regiões (ex.: europe-west10, asia-south2). Uma região
+// bem-formada porém inexistente falha na resolução DNS da própria chamada.
+// Fonte: https://cloud.google.com/vertex-ai/docs/reference/rest#service-endpoint
+const VALID_VERTEX_LOCATION_LABEL = /^[a-z](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+const resolveVertexBaseUrl = (location: string): string => {
+  if (location === 'global') return 'https://aiplatform.googleapis.com';
+  if (location === 'us' || location === 'eu') return `https://aiplatform.${location}.rep.googleapis.com`;
+  if (VALID_VERTEX_LOCATION_LABEL.test(location)) return `https://${location}-aiplatform.googleapis.com`;
+
+  throw new Error(
+    'VERTEX_LOCATION inválida: use global, us, eu ou uma região oficial do Vertex AI (rótulo DNS minúsculo único, sem pontos).',
+  );
+};
+
+// Cache module-level: sobrevive entre requests no mesmo isolate. Chaveado pela
+// identidade da chave para nunca vazar token entre credenciais distintas.
+const tokenCache = new Map<string, { token: string; expiresAtMs: number }>();
+const inflightMints = new Map<string, Promise<string>>();
+
+const base64UrlFromBytes = (bytes: Uint8Array): string => {
+  let binary = '';
+  for (const b of bytes) {
+    binary += String.fromCharCode(b);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const base64UrlFromJson = (value: unknown): string =>
+  base64UrlFromBytes(new TextEncoder().encode(JSON.stringify(value)));
+
+const pemToPkcs8Bytes = (pem: string): Uint8Array<ArrayBuffer> => {
+  const body = pem.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '').replace(/\s+/g, '');
+  const binary = atob(body);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const parseServiceAccountKey = (saKeyJson: string): ServiceAccountKey => {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(saKeyJson) as Record<string, unknown>;
+  } catch {
+    // Mensagem genérica de propósito: o SyntaxError do V8 pode embutir trechos
+    // do input (a própria SA, incluindo a chave privada) e os handlers logam
+    // a cadeia de erros — nada do parse pode vazar para logs.
+    throw new Error('VERTEX_SA_KEY inválido: o conteúdo do secret não é JSON parseável.');
+  }
+  for (const field of ['client_email', 'private_key', 'private_key_id', 'token_uri'] as const) {
+    if (typeof parsed[field] !== 'string' || !parsed[field]) {
+      throw new Error(`VERTEX_SA_KEY inválido: campo obrigatório ausente ou vazio: ${field}`);
+    }
+  }
+  return parsed as unknown as ServiceAccountKey;
+};
+
+const mintAccessToken = async (
+  sa: ServiceAccountKey,
+  fetchImpl: typeof fetch,
+  nowMs: number,
+): Promise<{ token: string; expiresInS: number }> => {
+  const cryptoKey = await crypto.subtle.importKey(
+    'pkcs8',
+    pemToPkcs8Bytes(sa.private_key),
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const iat = Math.floor(nowMs / 1000) - JWT_CLOCK_SKEW_S;
+  const header = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id };
+  const claims = { iss: sa.client_email, scope: OAUTH_SCOPE, aud: sa.token_uri, iat, exp: iat + JWT_LIFETIME_S };
+  const signingInput = `${base64UrlFromJson(header)}.${base64UrlFromJson(claims)}`;
+  const signature = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', cryptoKey, new TextEncoder().encode(signingInput));
+  const assertion = `${signingInput}.${base64UrlFromBytes(new Uint8Array(signature))}`;
+
+  const res = await fetchImpl(sa.token_uri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: OAUTH_GRANT_TYPE, assertion }).toString(),
+    signal: AbortSignal.timeout(TOKEN_MINT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
+    throw new VertexHttpError(
+      `Falha ao obter access token OAuth para ${sa.client_email} (HTTP ${res.status}): ${detail}`,
+      res.status,
+      'oauth-token',
+    );
+  }
+  const data = (await res.json()) as { access_token?: string; expires_in?: number };
+  if (!data.access_token) {
+    throw new Error(`Resposta do token endpoint sem access_token (HTTP ${res.status}).`);
+  }
+  return { token: data.access_token, expiresInS: data.expires_in ?? JWT_LIFETIME_S };
+};
+
+const getAccessToken = async (sa: ServiceAccountKey, fetchImpl: typeof fetch, now: () => number): Promise<string> => {
+  const cacheKey = `${sa.client_email}|${sa.private_key_id}|${sa.token_uri}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > now()) return cached.token;
+  const existing = inflightMints.get(cacheKey);
+  if (existing) return existing;
+  const mint = (async () => {
+    const { token, expiresInS } = await mintAccessToken(sa, fetchImpl, now());
+    tokenCache.set(cacheKey, { token, expiresAtMs: now() + (expiresInS - TOKEN_SAFETY_MARGIN_S) * 1000 });
+    return token;
+  })();
+  inflightMints.set(cacheKey, mint);
+  try {
+    return await mint;
+  } finally {
+    inflightMints.delete(cacheKey);
+  }
+};
+
+const isContent = (item: unknown): boolean =>
+  typeof item === 'object' && item !== null && 'role' in item && 'parts' in item;
+
+// Os handlers do oraculo passam contents no formato do SDK: uma string simples
+// ou um array misto de parts ({ inlineData } + string de prompt). O REST v1
+// exige Content[] com role e parts — um array que ainda não é Content[] vira
+// um único content de usuário, com strings promovidas a { text }.
+const toContents = (contents: unknown): unknown => {
+  if (typeof contents === 'string') return [{ role: 'user', parts: [{ text: contents }] }];
+  if (Array.isArray(contents) && !contents.every(isContent)) {
+    return [
+      {
+        role: 'user',
+        parts: contents.map((item) => (typeof item === 'string' ? { text: item } : item)),
+      },
+    ];
+  }
+  return contents;
+};
+
+const toRestBody = (args: GenerateContentArgs): Record<string, unknown> => {
+  const body: Record<string, unknown> = { contents: toContents(args.contents) };
+  const config = args.config;
+  if (!config) return body;
+  const generationConfig: Record<string, unknown> = {};
+  for (const field of [
+    'temperature',
+    'topP',
+    'maxOutputTokens',
+    'thinkingConfig',
+    'responseMimeType',
+    'responseJsonSchema',
+    'responseSchema',
+  ] as const) {
+    if (config[field] !== undefined) generationConfig[field] = config[field];
+  }
+  if (Object.keys(generationConfig).length > 0) body.generationConfig = generationConfig;
+  if (config.systemInstruction !== undefined) {
+    body.systemInstruction =
+      typeof config.systemInstruction === 'string'
+        ? { role: 'user', parts: [{ text: config.systemInstruction }] }
+        : config.systemInstruction;
+  }
+  if (config.safetySettings !== undefined) body.safetySettings = config.safetySettings;
+  return body;
+};
+
+const extractText = (candidates: VertexCandidate[] | undefined): string => {
+  const parts = candidates?.[0]?.content?.parts ?? [];
+  return parts
+    .filter((p) => typeof p.text === 'string' && !p.thought)
+    .map((p) => p.text)
+    .join('');
+};
+
+/** Espelha a superfície do SDK @google/genai consumida por analisar-ia.ts e tesouro-ipca-vision.ts. */
+export class VertexGenAI {
+  private readonly options: VertexGenAIOptions;
+  private readonly vertexBaseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+
+  readonly models = {
+    generateContent: async (args: GenerateContentArgs): Promise<VertexGenerateContentResponse> => {
+      const data = (await this.request(
+        args.model,
+        'generateContent',
+        toRestBody(args),
+        args.config?.httpOptions?.timeout,
+      )) as Omit<VertexGenerateContentResponse, 'text'>;
+      return { ...data, text: extractText(data.candidates) };
+    },
+    countTokens: async (args: CountTokensArgs): Promise<{ totalTokens?: number }> =>
+      (await this.request(
+        args.model,
+        'countTokens',
+        { contents: toContents(args.contents) },
+        args.config?.httpOptions?.timeout,
+      )) as { totalTokens?: number },
+    list: (args: ListModelsArgs = {}): AsyncGenerator<PublisherModelSummary, void, undefined> => this.listModels(args),
+  };
+
+  constructor(options: VertexGenAIOptions) {
+    this.vertexBaseUrl = resolveVertexBaseUrl(options.location);
+    this.options = Object.freeze({ ...options });
+    // O fetch global do workerd exige `this` global; chamar via this.fetchImpl
+    // vazaria a instância como `this` e lança Illegal invocation em produção.
+    this.fetchImpl = options.fetchImpl ?? ((input, init) => fetch(input, init));
+    this.now = options.now ?? Date.now;
+  }
+
+  private baseUrl(): string {
+    return this.vertexBaseUrl;
+  }
+
+  private async *listModels(args: ListModelsArgs): AsyncGenerator<PublisherModelSummary, void, undefined> {
+    const sa = parseServiceAccountKey(this.options.saKeyJson);
+    const token = await getAccessToken(sa, this.fetchImpl, this.now);
+    const pageSize = args.config?.pageSize;
+    let pageToken: string | undefined;
+    do {
+      const params = new URLSearchParams();
+      if (pageSize !== undefined) params.set('pageSize', String(pageSize));
+      if (pageToken) params.set('pageToken', pageToken);
+      const qs = params.toString();
+      const url = `${LIST_MODELS_BASE_URL}${qs ? `?${qs}` : ''}`;
+      const res = await this.fetchImpl(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) {
+        const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
+        throw new VertexHttpError(`Vertex listModels falhou (HTTP ${res.status}): ${detail}`, res.status, 'listModels');
+      }
+      const data = (await res.json()) as { publisherModels?: PublisherModelSummary[]; nextPageToken?: string };
+      for (const m of data.publisherModels ?? []) {
+        yield m;
+      }
+      pageToken = data.nextPageToken;
+    } while (pageToken);
+  }
+
+  private async request(
+    model: string,
+    verb: 'generateContent' | 'countTokens',
+    body: Record<string, unknown>,
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    const sa = parseServiceAccountKey(this.options.saKeyJson);
+    const token = await getAccessToken(sa, this.fetchImpl, this.now);
+    const { location } = this.options;
+    // Deploys de terceiros (forks) configuram apenas VERTEX_SA_KEY: sem project
+    // explícito, o correto é o projeto dono da própria service account.
+    const project = this.options.project || sa.project_id;
+    if (!project) {
+      throw new Error(
+        'Projeto Vertex indefinido: a service account não tem project_id e VERTEX_PROJECT não está configurado.',
+      );
+    }
+    const url = `${this.baseUrl()}/v1/projects/${project}/locations/${location}/publishers/google/models/${model}:${verb}`;
+    const res = await this.fetchImpl(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      ...(Number.isFinite(timeoutMs) && Number(timeoutMs) > 0
+        ? { signal: AbortSignal.timeout(Number(timeoutMs)) }
+        : {}),
+    });
+    if (!res.ok) {
+      const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);
+      throw new VertexHttpError(`Vertex ${verb} falhou (HTTP ${res.status}): ${detail}`, res.status, verb);
+    }
+    return res.json();
+  }
+}

--- a/admin-motor/src/handlers/_shared/vertex.ts
+++ b/admin-motor/src/handlers/_shared/vertex.ts
@@ -371,9 +371,21 @@ export class VertexGenAI {
 
   private async *listModels(args: ListModelsArgs): AsyncGenerator<PublisherModelSummary, void, undefined> {
     const sa = parseServiceAccountKey(this.options.saKeyJson);
-    const token = await getAccessToken(sa, this.fetchImpl, this.now);
-    const pageSize = args.config?.pageSize;
     const timeoutMs = args.config?.httpOptions?.timeout;
+    // Mesmo contrato do request(): o timeout é orçamento da listagem inteira,
+    // mint incluída — senão uma mint fria consumiria o teto do caller (15s no
+    // Maestro) e ainda somaria o prazo próprio de cada página.
+    const hasBudget = Number.isFinite(timeoutMs) && Number(timeoutMs) > 0;
+    const budgetMs = hasBudget ? Number(timeoutMs) : 0;
+    const startedAt = this.now();
+    const remainingMs = () => budgetMs - (this.now() - startedAt);
+    const token = await getAccessToken(
+      sa,
+      this.fetchImpl,
+      this.now,
+      hasBudget ? { ms: budgetMs, operation: 'listModels' } : undefined,
+    );
+    const pageSize = args.config?.pageSize;
     let pageToken: string | undefined;
     do {
       const params = new URLSearchParams();
@@ -381,11 +393,13 @@ export class VertexGenAI {
       if (pageToken) params.set('pageToken', pageToken);
       const qs = params.toString();
       const url = `${LIST_MODELS_BASE_URL}${qs ? `?${qs}` : ''}`;
-      // O timeout vale por página: um catálogo que aceita a conexão e nunca
-      // responde travaria o caller (rota de catálogo ou resolução de modelo).
+      const pageBudget = hasBudget ? remainingMs() : 0;
+      if (hasBudget && pageBudget <= 0) {
+        throw new Error(`Vertex listModels: orçamento de ${budgetMs}ms esgotado antes de pedir a próxima página.`);
+      }
       const res = await this.fetchImpl(url, {
         headers: { Authorization: `Bearer ${token}` },
-        ...(timeoutMs !== undefined ? { signal: AbortSignal.timeout(Number(timeoutMs)) } : {}),
+        ...(hasBudget ? { signal: AbortSignal.timeout(pageBudget) } : {}),
       });
       if (!res.ok) {
         const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);

--- a/admin-motor/src/handlers/_shared/vertex.ts
+++ b/admin-motor/src/handlers/_shared/vertex.ts
@@ -94,7 +94,7 @@ export interface PublisherModelSummary {
 }
 
 interface ListModelsArgs {
-  config?: { pageSize?: number };
+  config?: { pageSize?: number; httpOptions?: HttpOptions };
 }
 
 // Catálogo de publisher models: existe apenas no v1beta1 e apenas no host
@@ -347,6 +347,7 @@ export class VertexGenAI {
     const sa = parseServiceAccountKey(this.options.saKeyJson);
     const token = await getAccessToken(sa, this.fetchImpl, this.now);
     const pageSize = args.config?.pageSize;
+    const timeoutMs = args.config?.httpOptions?.timeout;
     let pageToken: string | undefined;
     do {
       const params = new URLSearchParams();
@@ -354,8 +355,11 @@ export class VertexGenAI {
       if (pageToken) params.set('pageToken', pageToken);
       const qs = params.toString();
       const url = `${LIST_MODELS_BASE_URL}${qs ? `?${qs}` : ''}`;
+      // O timeout vale por página: um catálogo que aceita a conexão e nunca
+      // responde travaria o caller (rota de catálogo ou resolução de modelo).
       const res = await this.fetchImpl(url, {
         headers: { Authorization: `Bearer ${token}` },
+        ...(timeoutMs !== undefined ? { signal: AbortSignal.timeout(Number(timeoutMs)) } : {}),
       });
       if (!res.ok) {
         const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);

--- a/admin-motor/src/handlers/_shared/vertex.ts
+++ b/admin-motor/src/handlers/_shared/vertex.ts
@@ -229,23 +229,49 @@ const mintAccessToken = async (
   return { token: data.access_token, expiresInS: data.expires_in ?? JWT_LIFETIME_S };
 };
 
-const getAccessToken = async (sa: ServiceAccountKey, fetchImpl: typeof fetch, now: () => number): Promise<string> => {
+/** Espera a mint sem nunca abortá-la: ela é compartilhada por single-flight e
+ * outro caller pode ter orçamento maior. Quem estourou desiste sozinho. */
+const awaitWithinBudget = async <T>(promise: Promise<T>, budgetMs: number, operation: VertexOperation): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(new Error(`Vertex ${operation}: orçamento de ${budgetMs}ms esgotado durante a mint do access token.`)),
+      budgetMs,
+    );
+  });
+  try {
+    return await Promise.race([promise, budget]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
+
+const getAccessToken = async (
+  sa: ServiceAccountKey,
+  fetchImpl: typeof fetch,
+  now: () => number,
+  budget?: { ms: number; operation: VertexOperation },
+): Promise<string> => {
   const cacheKey = `${sa.client_email}|${sa.private_key_id}|${sa.token_uri}`;
   const cached = tokenCache.get(cacheKey);
   if (cached && cached.expiresAtMs > now()) return cached.token;
   const existing = inflightMints.get(cacheKey);
-  if (existing) return existing;
+  if (existing) return budget ? awaitWithinBudget(existing, budget.ms, budget.operation) : existing;
   const mint = (async () => {
     const { token, expiresInS } = await mintAccessToken(sa, fetchImpl, now());
     tokenCache.set(cacheKey, { token, expiresAtMs: now() + (expiresInS - TOKEN_SAFETY_MARGIN_S) * 1000 });
     return token;
   })();
   inflightMints.set(cacheKey, mint);
-  try {
-    return await mint;
-  } finally {
+  // A limpeza trata os dois desfechos: com `.finally` a rejeição da mint
+  // sobreviveria na promise derivada e viraria unhandled rejection quando o
+  // caller já tivesse desistido por orçamento.
+  const cleanup = () => {
     inflightMints.delete(cacheKey);
-  }
+  };
+  mint.then(cleanup, cleanup);
+  return budget ? awaitWithinBudget(mint, budget.ms, budget.operation) : mint;
 };
 
 const isContent = (item: unknown): boolean =>
@@ -380,7 +406,22 @@ export class VertexGenAI {
     timeoutMs?: number,
   ): Promise<unknown> {
     const sa = parseServiceAccountKey(this.options.saKeyJson);
-    const token = await getAccessToken(sa, this.fetchImpl, this.now);
+    // O timeout do caller é orçamento da chamada INTEIRA (mint + requisição):
+    // com cache frio, gastar o orçamento na mint e ainda disparar a geração
+    // deixaria trabalho faturável correndo depois do prazo do handler.
+    const hasBudget = Number.isFinite(timeoutMs) && Number(timeoutMs) > 0;
+    const budgetMs = hasBudget ? Number(timeoutMs) : 0;
+    const startedAt = this.now();
+    const token = await getAccessToken(
+      sa,
+      this.fetchImpl,
+      this.now,
+      hasBudget ? { ms: budgetMs, operation: verb } : undefined,
+    );
+    const remainingMs = hasBudget ? budgetMs - (this.now() - startedAt) : 0;
+    if (hasBudget && remainingMs <= 0) {
+      throw new Error(`Vertex ${verb}: orçamento de ${budgetMs}ms esgotado antes da requisição.`);
+    }
     const { location } = this.options;
     // Deploys de terceiros (forks) configuram apenas VERTEX_SA_KEY: sem project
     // explícito, o correto é o projeto dono da própria service account.
@@ -395,9 +436,7 @@ export class VertexGenAI {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-      ...(Number.isFinite(timeoutMs) && Number(timeoutMs) > 0
-        ? { signal: AbortSignal.timeout(Number(timeoutMs)) }
-        : {}),
+      ...(hasBudget ? { signal: AbortSignal.timeout(remainingMs) } : {}),
     });
     if (!res.ok) {
       const detail = (await res.text()).slice(0, ERROR_BODY_EXCERPT);

--- a/admin-motor/src/handlers/oraculoModelos.test.ts
+++ b/admin-motor/src/handlers/oraculoModelos.test.ts
@@ -90,6 +90,19 @@ describe('handleOraculoModelosGet (catálogo via Vertex)', () => {
     });
   });
 
+  it('com location regional omite modelos preview/exp, que só existem no endpoint global', async () => {
+    runtime.listModels = [
+      { name: 'publishers/google/models/gemini-3.1-pro-preview' },
+      { name: 'publishers/google/models/gemini-2.0-flash-exp' },
+      { name: 'publishers/google/models/gemini-2.5-flash' },
+      { name: 'publishers/google/models/gemini-2.5-pro' },
+    ];
+    const res = await handleOraculoModelosGet(context({ VERTEX_SA_KEY: '{"sa":"x"}', VERTEX_LOCATION: 'us-central1' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { models: ModelPayload[]; total: number };
+    expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-pro', 'gemini-2.5-flash']);
+  });
+
   it('retorna 500 com a mensagem do erro quando a listagem falha', async () => {
     runtime.listError = new runtime.MockVertexHttpError(
       'Vertex listModels falhou (HTTP 403): sem permissão',

--- a/admin-motor/src/handlers/oraculoModelos.test.ts
+++ b/admin-motor/src/handlers/oraculoModelos.test.ts
@@ -85,7 +85,9 @@ describe('handleOraculoModelosGet (catálogo via Vertex)', () => {
     });
     expect(body.models[1]?.displayName).toBe('Gemini 3.1 Pro (Preview)');
     expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
-    expect(runtime.listRequests[0]).toEqual({ config: { pageSize: 1000 } });
+    expect(runtime.listRequests[0]).toEqual({
+      config: { pageSize: 1000, httpOptions: { timeout: 20_000 } },
+    });
   });
 
   it('retorna 500 com a mensagem do erro quando a listagem falha', async () => {

--- a/admin-motor/src/handlers/oraculoModelos.test.ts
+++ b/admin-motor/src/handlers/oraculoModelos.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    listRequests: [] as Record<string, unknown>[],
+    listModels: [] as { name?: string; displayName?: string }[],
+    listError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('./_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      list: (request: Record<string, unknown>) => {
+        runtime.listRequests.push(request);
+        return (async function* () {
+          if (runtime.listError) throw runtime.listError;
+          for (const m of runtime.listModels) {
+            yield m;
+          }
+        })();
+      },
+    };
+  },
+}));
+
+import { handleOraculoModelosGet } from './oraculoModelos';
+
+type ModelPayload = { id: string; displayName: string; api: string; vision: boolean };
+
+const context = (env: Record<string, unknown>) =>
+  ({
+    request: new Request('https://admin.example/api/oraculo/modelos'),
+    env,
+  }) as unknown as Parameters<typeof handleOraculoModelosGet>[0];
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.listRequests.length = 0;
+  runtime.listModels = [];
+  runtime.listError = null;
+});
+
+describe('handleOraculoModelosGet (catálogo via Vertex)', () => {
+  it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
+    const res = await handleOraculoModelosGet(context({}));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ ok: false, error: 'VERTEX_SA_KEY não configurada.' });
+  });
+
+  it('lista gemini flash/pro com id extraído de publishers/google/models/<id>', async () => {
+    runtime.listModels = [
+      { name: 'publishers/google/models/gemini-3.1-pro-preview' },
+      { name: 'publishers/google/models/gemini-2.5-flash', displayName: 'Gemini 2.5 Flash' },
+      { name: 'publishers/google/models/imagen-4.0-generate-001' },
+      { name: 'publishers/google/models/gemini-embedding-001' },
+    ];
+    const res = await handleOraculoModelosGet(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; models: ModelPayload[]; total: number };
+    expect(body.ok).toBe(true);
+    expect(body.total).toBe(2);
+    expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash', 'gemini-3.1-pro-preview']);
+    expect(body.models[0]).toEqual({
+      id: 'gemini-2.5-flash',
+      displayName: 'Gemini 2.5 Flash',
+      api: 'vertex',
+      vision: true,
+    });
+    expect(body.models[1]?.displayName).toBe('Gemini 3.1 Pro (Preview)');
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    expect(runtime.listRequests[0]).toEqual({ config: { pageSize: 1000 } });
+  });
+
+  it('retorna 500 com a mensagem do erro quando a listagem falha', async () => {
+    runtime.listError = new runtime.MockVertexHttpError(
+      'Vertex listModels falhou (HTTP 403): sem permissão',
+      403,
+      'listModels',
+    );
+    const res = await handleOraculoModelosGet(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('listModels');
+  });
+});

--- a/admin-motor/src/handlers/oraculoModelos.ts
+++ b/admin-motor/src/handlers/oraculoModelos.ts
@@ -44,7 +44,7 @@ export const handleOraculoModelosGet = async (context: Context) => {
     });
     const allModels = new Map<string, { id: string; displayName: string; api: string; vision: boolean }>();
 
-    const pager = await ai.models.list({ config: { pageSize: 1000 } });
+    const pager = await ai.models.list({ config: { pageSize: 1000, httpOptions: { timeout: 20_000 } } });
     for await (const m of pager) {
       if (!m.name) continue;
       // Vertex retorna "publishers/google/models/<id>" (AI Studio retornava "models/<id>").

--- a/admin-motor/src/handlers/oraculoModelos.ts
+++ b/admin-motor/src/handlers/oraculoModelos.ts
@@ -2,6 +2,13 @@ import { VertexGenAI } from './_shared/vertex';
 
 const DEFAULT_VERTEX_LOCATION = 'global';
 
+/** O catálogo só existe no host global e anuncia modelos que uma região pode
+ * não servir. Provado em 2026-08-09 no projeto lcv-ideas-and-software:
+ * `gemini-3.1-pro-preview` responde 200 em `global` e 404 em `us-central1`,
+ * enquanto `gemini-2.5-pro` responde 200 nos dois. Numa location regional,
+ * oferecer preview/exp na UI é oferecer uma escolha que falha na geração. */
+export const isGlobalOnlyModelId = (id: string): boolean => /preview|exp/i.test(id);
+
 type Env = {
   VERTEX_SA_KEY?: string;
   VERTEX_PROJECT?: string;
@@ -36,12 +43,11 @@ export const handleOraculoModelosGet = async (context: Context) => {
   const saKeyJson = env.VERTEX_SA_KEY;
   if (!saKeyJson) return json({ ok: false, error: 'VERTEX_SA_KEY não configurada.' }, 500);
 
+  const location = env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION;
+  const regional = location !== DEFAULT_VERTEX_LOCATION;
+
   try {
-    const ai = new VertexGenAI({
-      saKeyJson,
-      project: env.VERTEX_PROJECT,
-      location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
-    });
+    const ai = new VertexGenAI({ saKeyJson, project: env.VERTEX_PROJECT, location });
     const allModels = new Map<string, { id: string; displayName: string; api: string; vision: boolean }>();
 
     const pager = await ai.models.list({ config: { pageSize: 1000, httpOptions: { timeout: 20_000 } } });
@@ -53,6 +59,7 @@ export const handleOraculoModelosGet = async (context: Context) => {
       const isFlashOrPro = lower.includes('flash') || lower.includes('pro');
       const isGemini = lower.startsWith('gemini');
       if (!isGemini || !isFlashOrPro) continue;
+      if (regional && isGlobalOnlyModelId(id)) continue;
 
       const hasVision = lower.includes('vision') || lower.includes('pro') || lower.includes('flash');
       if (!allModels.has(id)) {

--- a/admin-motor/src/handlers/oraculoModelos.ts
+++ b/admin-motor/src/handlers/oraculoModelos.ts
@@ -1,7 +1,11 @@
-import { GoogleGenAI } from '@google/genai';
+import { VertexGenAI } from './_shared/vertex';
+
+const DEFAULT_VERTEX_LOCATION = 'global';
 
 type Env = {
-  GEMINI_API_KEY?: string;
+  VERTEX_SA_KEY?: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
 };
 
 type Context = {
@@ -29,17 +33,22 @@ const formatModelName = (id: string): string => {
 
 export const handleOraculoModelosGet = async (context: Context) => {
   const { env } = context;
-  const apiKey = env.GEMINI_API_KEY;
-  if (!apiKey) return json({ ok: false, error: 'GEMINI_API_KEY não configurada.' }, 500);
+  const saKeyJson = env.VERTEX_SA_KEY;
+  if (!saKeyJson) return json({ ok: false, error: 'VERTEX_SA_KEY não configurada.' }, 500);
 
   try {
-    const ai = new GoogleGenAI({ apiKey });
+    const ai = new VertexGenAI({
+      saKeyJson,
+      project: env.VERTEX_PROJECT,
+      location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+    });
     const allModels = new Map<string, { id: string; displayName: string; api: string; vision: boolean }>();
 
     const pager = await ai.models.list({ config: { pageSize: 1000 } });
     for await (const m of pager) {
       if (!m.name) continue;
-      const id = m.name.replace('models/', '');
+      // Vertex retorna "publishers/google/models/<id>" (AI Studio retornava "models/<id>").
+      const id = m.name.split('/').pop() ?? '';
       const lower = id.toLowerCase();
       const isFlashOrPro = lower.includes('flash') || lower.includes('pro');
       const isGemini = lower.startsWith('gemini');
@@ -50,7 +59,7 @@ export const handleOraculoModelosGet = async (context: Context) => {
         allModels.set(id, {
           id,
           displayName: m.displayName || formatModelName(id),
-          api: 'sdk',
+          api: 'vertex',
           vision: hasVision,
         });
       }

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2470,14 +2470,15 @@ async function callProvider(
   const timeoutMs = options?.timeoutMs ?? PROVIDER_TIMEOUT_MS;
   if (agent === 'gemini') {
     // Documented web deviation: this Vertex path keeps the deadline-coupled
-    // timeout but has no 429 retry or in-flight abort (the cooperative cancel
-    // checks around the call cover it).
+    // timeout — repassado ao cliente para virar AbortSignal na requisição — mas
+    // não tem o retry de 429 dos providers HTTP (os checks de cancelamento
+    // cooperativo em volta da chamada cobrem a interrupção da sessão).
     const ai = vertexClient(env);
     const response = await withTimeout(
       ai.models.generateContent({
         model,
         contents: `${system}\n\n${prompt}`,
-        config: { temperature: 0.2, topP: 0.9, maxOutputTokens },
+        config: { temperature: 0.2, topP: 0.9, maxOutputTokens, httpOptions: { timeout: timeoutMs } },
       }),
       timeoutMs,
       `${AGENT_LABELS[agent]} request`,

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2371,6 +2371,9 @@ const MODEL_RESOLUTION: Partial<
 const VERTEX_GEMINI_CANDIDATES = ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-2.5-pro'];
 const VERTEX_GEMINI_FALLBACK = 'gemini-2.5-pro';
 const DEFAULT_VERTEX_LOCATION = 'global';
+// Mesmo teto que o fetchWithTimeout dos demais providers usa no /models: a
+// resolução roda antes da geração e não pode consumir o prazo da sessão.
+const VERTEX_CATALOG_TIMEOUT_MS = 15_000;
 
 function vertexClient(env: MaestroAiEnv): VertexGenAI {
   return new VertexGenAI({
@@ -2385,7 +2388,10 @@ function vertexClient(env: MaestroAiEnv): VertexGenAI {
 async function resolveVertexModel(env: MaestroAiEnv): Promise<string> {
   try {
     const ids: string[] = [];
-    for await (const model of vertexClient(env).models.list({ config: { pageSize: 1000 } })) {
+    const catalog = vertexClient(env).models.list({
+      config: { pageSize: 1000, httpOptions: { timeout: VERTEX_CATALOG_TIMEOUT_MS } },
+    });
+    for await (const model of catalog) {
       const id = model.name?.split('/').pop();
       if (id?.toLowerCase().startsWith('gemini')) ids.push(id);
     }

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2386,6 +2386,12 @@ function vertexClient(env: MaestroAiEnv): VertexGenAI {
 /** Vertex publisher-model catalog (v1beta1 global) em vez do /models do AI
  *  Studio; qualquer falha cai no default canônico, como nos demais providers. */
 async function resolveVertexModel(env: MaestroAiEnv): Promise<string> {
+  // O catálogo só existe no host global e lista modelos que podem não estar
+  // publicados numa região específica (os previews, por exemplo). Se a geração
+  // vai para uma região, escolher por esse catálogo produziria um modelo que
+  // depois falha com 404 — melhor ficar no default, que é regionalmente amplo.
+  const location = env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION;
+  if (location !== DEFAULT_VERTEX_LOCATION) return VERTEX_GEMINI_FALLBACK;
   try {
     const ids: string[] = [];
     const catalog = vertexClient(env).models.list({
@@ -4359,22 +4365,23 @@ export async function handleMaestroAiSettingsPut(context: RequestContext): Promi
     const models = sanitizeModels(body.models ?? parseJson(current.models_json, DEFAULT_MODELS));
     const configuredSecrets = parseJson<Partial<Record<ProviderKey, boolean>>>(current.configured_secrets_json, {});
     const apiKeys = body.api_keys && typeof body.api_keys === 'object' ? body.api_keys : {};
+    // Validação ANTES de qualquer efeito colateral: rejeitar no meio do laço
+    // deixaria os secrets anteriores já rotacionados num request que responde
+    // 400. Gemini usa Vertex AI, cuja credencial é a service account JSON
+    // compartilhada pela frota, provisionada na infraestrutura.
+    if (typeof apiKeys.gemini === 'string' && apiKeys.gemini.trim()) {
+      return json(
+        {
+          ok: false,
+          error:
+            'Gemini usa Vertex AI: a credencial é a service account JSON compartilhada da frota (secret vertex-sa-key no Secrets Store, exposta pelo binding VERTEX_SA_KEY em admin-motor/wrangler.json) e não é gravável por este painel.',
+        },
+        400,
+      );
+    }
     for (const agent of PROVIDER_KEYS) {
       const value = apiKeys[agent];
       if (typeof value === 'string' && value.trim()) {
-        // Gemini usa Vertex AI: a credencial é a service account JSON
-        // compartilhada por toda a frota, provisionada na infraestrutura — não
-        // é uma API key digitável, e gravá-la aqui rotacionaria os outros apps.
-        if (agent === 'gemini') {
-          return json(
-            {
-              ok: false,
-              error:
-                'Gemini usa Vertex AI: a credencial é a service account JSON compartilhada da frota (secret vertex-sa-key no Secrets Store, exposta pelo binding VERTEX_SA_KEY em admin-motor/wrangler.json) e não é gravável por este painel.',
-            },
-            400,
-          );
-        }
         await upsertSecretStoreSecret(context.env, agent, value);
         configuredSecrets[agent] = true;
       }

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -1,5 +1,5 @@
-import { GoogleGenAI } from '@google/genai';
 import { toHeaders } from '../../../../../functions/api/_lib/mainsite-admin';
+import { VertexGenAI } from '../../_shared/vertex';
 import { formatBlockManifestForPrompt, validateRevisionContentLock } from './content-lock.ts';
 
 type D1Database = {
@@ -20,7 +20,9 @@ export type MaestroAiEnv = {
   MAESTRO_SECRET_STORE_ID?: string;
   MAESTRO_OPENAI_API_KEY?: string;
   MAESTRO_ANTHROPIC_API_KEY?: string;
-  MAESTRO_GEMINI_API_KEY?: string;
+  VERTEX_SA_KEY?: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
   MAESTRO_DEEPSEEK_API_KEY?: string;
   MAESTRO_GROK_API_KEY?: string;
   MAESTRO_PERPLEXITY_API_KEY?: string;
@@ -282,7 +284,9 @@ const API_TEST_PROMPT = 'Reply with exactly: OK';
 const SECRET_NAMES: Record<ProviderKey, string> = {
   claude: 'MAESTRO_ANTHROPIC_API_KEY',
   codex: 'MAESTRO_OPENAI_API_KEY',
-  gemini: 'MAESTRO_GEMINI_API_KEY',
+  // Gemini migra para Vertex AI: o "secret" é a service account JSON
+  // compartilhada da frota (Secrets Store `vertex-sa-key`) — ver README.
+  gemini: 'VERTEX_SA_KEY',
   deepseek: 'MAESTRO_DEEPSEEK_API_KEY',
   grok: 'MAESTRO_GROK_API_KEY',
   perplexity: 'MAESTRO_PERPLEXITY_API_KEY',
@@ -833,7 +837,7 @@ function secretForAgent(env: MaestroAiEnv, agent: ProviderKey): string | undefin
       : agent === 'codex'
         ? env.MAESTRO_OPENAI_API_KEY
         : agent === 'gemini'
-          ? env.MAESTRO_GEMINI_API_KEY
+          ? env.VERTEX_SA_KEY
           : agent === 'deepseek'
             ? env.MAESTRO_DEEPSEEK_API_KEY
             : agent === 'grok'
@@ -2349,12 +2353,6 @@ const MODEL_RESOLUTION: Partial<
     ],
     fallback: 'claude-fable-5',
   },
-  gemini: {
-    endpoint: 'https://generativelanguage.googleapis.com/v1beta/models',
-    auth: 'query-key',
-    candidates: ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-2.5-pro'],
-    fallback: 'gemini-2.5-pro',
-  },
   deepseek: {
     endpoint: 'https://api.deepseek.com/models',
     auth: 'bearer',
@@ -2369,6 +2367,33 @@ const MODEL_RESOLUTION: Partial<
     fallback: 'grok-4.5',
   },
 };
+
+const VERTEX_GEMINI_CANDIDATES = ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-2.5-pro'];
+const VERTEX_GEMINI_FALLBACK = 'gemini-2.5-pro';
+const DEFAULT_VERTEX_LOCATION = 'global';
+
+function vertexClient(env: MaestroAiEnv): VertexGenAI {
+  return new VertexGenAI({
+    saKeyJson: env.VERTEX_SA_KEY ?? '',
+    project: env.VERTEX_PROJECT,
+    location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+  });
+}
+
+/** Vertex publisher-model catalog (v1beta1 global) em vez do /models do AI
+ *  Studio; qualquer falha cai no default canônico, como nos demais providers. */
+async function resolveVertexModel(env: MaestroAiEnv): Promise<string> {
+  try {
+    const ids: string[] = [];
+    for await (const model of vertexClient(env).models.list({ config: { pageSize: 1000 } })) {
+      const id = model.name?.split('/').pop();
+      if (id?.toLowerCase().startsWith('gemini')) ids.push(id);
+    }
+    return choosePreferredModel(ids, VERTEX_GEMINI_CANDIDATES, VERTEX_GEMINI_FALLBACK);
+  } catch {
+    return VERTEX_GEMINI_FALLBACK;
+  }
+}
 
 /** Port of choose_preferred_model: first candidate present in the live list;
  *  else the first live model; else the fallback. */
@@ -2432,7 +2457,9 @@ async function callProvider(
   if (!model) {
     model = options?.modelCache?.get(agent) ?? '';
     if (!model) {
-      model = await resolveProviderModel(agent, apiKey);
+      // Gemini resolve pelo catálogo do Vertex (v1beta1 global), que precisa da
+      // service account; os demais providers usam seu próprio /models.
+      model = agent === 'gemini' ? await resolveVertexModel(env) : await resolveProviderModel(agent, apiKey);
       options?.modelCache?.set(agent, model);
     }
   }
@@ -2442,10 +2469,10 @@ async function callProvider(
 
   const timeoutMs = options?.timeoutMs ?? PROVIDER_TIMEOUT_MS;
   if (agent === 'gemini') {
-    // Documented web deviation: the Gemini SDK exposes no Response/AbortSignal,
-    // so this path keeps the deadline-coupled timeout but has no 429 retry or
-    // in-flight abort (the cooperative cancel checks around the call cover it).
-    const ai = new GoogleGenAI({ apiKey });
+    // Documented web deviation: this Vertex path keeps the deadline-coupled
+    // timeout but has no 429 retry or in-flight abort (the cooperative cancel
+    // checks around the call cover it).
+    const ai = vertexClient(env);
     const response = await withTimeout(
       ai.models.generateContent({
         model,
@@ -4328,6 +4355,19 @@ export async function handleMaestroAiSettingsPut(context: RequestContext): Promi
     for (const agent of PROVIDER_KEYS) {
       const value = apiKeys[agent];
       if (typeof value === 'string' && value.trim()) {
+        // Gemini usa Vertex AI: a credencial é a service account JSON
+        // compartilhada por toda a frota, provisionada na infraestrutura — não
+        // é uma API key digitável, e gravá-la aqui rotacionaria os outros apps.
+        if (agent === 'gemini') {
+          return json(
+            {
+              ok: false,
+              error:
+                'Gemini usa Vertex AI: a credencial é a service account JSON compartilhada da frota (secret vertex-sa-key no Secrets Store, exposta pelo binding VERTEX_SA_KEY em admin-motor/wrangler.json) e não é gravável por este painel.',
+            },
+            400,
+          );
+        }
         await upsertSecretStoreSecret(context.env, agent, value);
         configuredSecrets[agent] = true;
       }

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -1,5 +1,6 @@
 import { toHeaders } from '../../../../../functions/api/_lib/mainsite-admin';
 import { VertexGenAI } from '../../_shared/vertex';
+import { isGlobalOnlyModelId } from '../../oraculoModelos';
 import { formatBlockManifestForPrompt, validateRevisionContentLock } from './content-lock.ts';
 
 type D1Database = {
@@ -2375,6 +2376,9 @@ const DEFAULT_VERTEX_LOCATION = 'global';
 // resolução roda antes da geração e não pode consumir o prazo da sessão.
 const VERTEX_CATALOG_TIMEOUT_MS = 15_000;
 
+const vertexLocationIsRegional = (env: MaestroAiEnv): boolean =>
+  (env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION) !== DEFAULT_VERTEX_LOCATION;
+
 function vertexClient(env: MaestroAiEnv): VertexGenAI {
   return new VertexGenAI({
     saKeyJson: env.VERTEX_SA_KEY ?? '',
@@ -2390,8 +2394,7 @@ async function resolveVertexModel(env: MaestroAiEnv): Promise<string> {
   // publicados numa região específica (os previews, por exemplo). Se a geração
   // vai para uma região, escolher por esse catálogo produziria um modelo que
   // depois falha com 404 — melhor ficar no default, que é regionalmente amplo.
-  const location = env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION;
-  if (location !== DEFAULT_VERTEX_LOCATION) return VERTEX_GEMINI_FALLBACK;
+  if (vertexLocationIsRegional(env)) return VERTEX_GEMINI_FALLBACK;
   try {
     const ids: string[] = [];
     const catalog = vertexClient(env).models.list({
@@ -2465,7 +2468,13 @@ async function callProvider(
   // seeded default) wins; otherwise resolve live against the provider's
   // /models list (canonical), memoized per execution via options.modelCache.
   const configured = sanitizeText(models[agent], 120);
-  let model = configured && configured !== DEFAULT_MODELS[agent] ? configured : '';
+  // Uma escolha persistida vence a resolução ao vivo — mas o catálogo do Vertex
+  // é global e anuncia previews que uma região não serve. Sem esta checagem, um
+  // `gemini-3.1-pro-preview` salvo antes contornaria o fallback regional e toda
+  // chamada seguinte voltaria 404.
+  const configuredIsUnusableHere =
+    agent === 'gemini' && vertexLocationIsRegional(env) && isGlobalOnlyModelId(configured ?? '');
+  let model = configured && configured !== DEFAULT_MODELS[agent] && !configuredIsUnusableHere ? configured : '';
   if (!model) {
     model = options?.modelCache?.get(agent) ?? '';
     if (!model) {

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
@@ -101,10 +101,17 @@ describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
     expect(runtime.listRequests).toHaveLength(1);
     const gen = runtime.generateRequests[0] as {
       model: string;
-      config: { temperature: number; topP: number; maxOutputTokens: number };
+      config: { temperature: number; topP: number; maxOutputTokens: number; httpOptions?: { timeout?: number } };
     };
     expect(gen.model).toBe('gemini-3.1-pro-preview');
-    expect(gen.config).toEqual({ temperature: 0.2, topP: 0.9, maxOutputTokens: 256 });
+    // O timeout do provider vira AbortSignal na própria chamada, não só uma
+    // corrida de Promise — o Vertex agora aborta a requisição em voo.
+    expect(gen.config).toEqual({
+      temperature: 0.2,
+      topP: 0.9,
+      maxOutputTokens: 256,
+      httpOptions: { timeout: 120_000 },
+    });
 
     for (const other of body.results.filter((r) => r.agent !== 'gemini')) {
       expect(other.ok).toBe(false);

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
@@ -99,6 +99,11 @@ describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
 
     expect(runtime.constructorOptions.every((o) => o.saKeyJson === '{"sa":"x"}')).toBe(true);
     expect(runtime.listRequests).toHaveLength(1);
+    // O catálogo precisa de prazo próprio: ele roda antes da geração e um
+    // catálogo travado impediria o health check de chegar à chamada.
+    expect(runtime.listRequests[0]).toEqual({
+      config: { pageSize: 1000, httpOptions: { timeout: 15_000 } },
+    });
     const gen = runtime.generateRequests[0] as {
       model: string;
       config: { temperature: number; topP: number; maxOutputTokens: number; httpOptions?: { timeout?: number } };

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
@@ -62,27 +62,27 @@ const SECRET_STORE_ENV = {
   MAESTRO_SECRET_STORE_ID: 'store-1',
 };
 
-const createDb = () => {
-  const makeStmt = () => {
+const createDb = (settingsRow: Record<string, unknown> | null = null) => {
+  const makeStmt = (sql: string) => {
     const stmt = {
       bind: (..._args: unknown[]) => stmt,
       run: async () => ({}),
       all: async () => ({ results: [] as unknown[] }),
-      first: async () => null,
+      first: async () => (sql.includes('FROM maestro_ai_settings') ? settingsRow : null),
     };
     return stmt;
   };
   return { prepare: makeStmt };
 };
 
-const context = (env: Record<string, unknown>, body?: unknown) =>
+const context = (env: Record<string, unknown>, body?: unknown, settingsRow: Record<string, unknown> | null = null) =>
   ({
     request: new Request('https://admin.example/api/maestro-ai/settings', {
       method: body === undefined ? 'GET' : 'POST',
       ...(body === undefined ? {} : { body: JSON.stringify(body) }),
       headers: { 'Content-Type': 'application/json' },
     }),
-    env: { BIGDATA_DB: createDb(), ...env },
+    env: { BIGDATA_DB: createDb(settingsRow), ...env },
   }) as unknown as Parameters<typeof handleMaestroAiSettingsTestPost>[0];
 
 type TestResults = { ok: boolean; results: { agent: string; ok: boolean; message: string; model?: string }[] };
@@ -160,6 +160,39 @@ describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
     // Nada de consultar o catálogo global para escolher um modelo que será
     // chamado numa região onde ele pode não existir.
     expect(runtime.listRequests).toHaveLength(0);
+  });
+
+  it('test-api: modelo global-only já persistido não é usado numa location regional', async () => {
+    const settingsRow = {
+      id: 'default',
+      protocol_text: 'p'.repeat(120),
+      max_cost_usd: 10,
+      max_runtime_minutes: null,
+      max_cycles: 2,
+      configured_secrets_json: '{}',
+      rates_json: JSON.stringify(
+        Object.fromEntries(
+          ['claude', 'codex', 'gemini', 'deepseek', 'grok', 'perplexity'].map((k) => [
+            k,
+            { input_usd_per_million: 1, output_usd_per_million: 2 },
+          ]),
+        ),
+      ),
+      // O operador escolheu um preview: ele só existe no endpoint global.
+      models_json: JSON.stringify({ gemini: 'gemini-3.1-pro-preview' }),
+      updated_at: '2026-08-09T00:00:00Z',
+    };
+
+    const res = await handleMaestroAiSettingsTestPost(
+      context({ VERTEX_SA_KEY: '{"sa":"x"}', VERTEX_LOCATION: 'us-central1' }, undefined, settingsRow),
+    );
+    const body = (await res.json()) as TestResults;
+    const gemini = body.results.find((r) => r.agent === 'gemini');
+    expect(gemini?.ok).toBe(true);
+    // Sem essa checagem, a escolha persistida chegaria à região e devolveria 404.
+    expect(gemini?.model).toBe('gemini-2.5-pro');
+    const gen = runtime.generateRequests[0] as { model: string };
+    expect(gen.model).toBe('gemini-2.5-pro');
   });
 
   it('test-api: falha na listagem cai no fallback gemini-2.5-pro', async () => {

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    listRequests: [] as Record<string, unknown>[],
+    listModels: [{ name: 'publishers/google/models/gemini-3.1-pro-preview' }] as { name?: string }[],
+    listError: null as Error | null,
+    generateRequests: [] as Record<string, unknown>[],
+    generateText: 'OK',
+    generateError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('../../_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      list: (request: Record<string, unknown>) => {
+        runtime.listRequests.push(request);
+        return (async function* () {
+          if (runtime.listError) throw runtime.listError;
+          for (const m of runtime.listModels) {
+            yield m;
+          }
+        })();
+      },
+      generateContent: async (request: Record<string, unknown>) => {
+        runtime.generateRequests.push(request);
+        if (runtime.generateError) throw runtime.generateError;
+        return {
+          text: runtime.generateText,
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2 },
+        };
+      },
+    };
+  },
+}));
+
+import { handleMaestroAiSettingsGet, handleMaestroAiSettingsPut, handleMaestroAiSettingsTestPost } from './sessions';
+
+const createDb = () => {
+  const makeStmt = () => {
+    const stmt = {
+      bind: (..._args: unknown[]) => stmt,
+      run: async () => ({}),
+      all: async () => ({ results: [] as unknown[] }),
+      first: async () => null,
+    };
+    return stmt;
+  };
+  return { prepare: makeStmt };
+};
+
+const context = (env: Record<string, unknown>, body?: unknown) =>
+  ({
+    request: new Request('https://admin.example/api/maestro-ai/settings', {
+      method: body === undefined ? 'GET' : 'POST',
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+    env: { BIGDATA_DB: createDb(), ...env },
+  }) as unknown as Parameters<typeof handleMaestroAiSettingsTestPost>[0];
+
+type TestResults = { ok: boolean; results: { agent: string; ok: boolean; message: string; model?: string }[] };
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.listRequests.length = 0;
+  runtime.listModels = [{ name: 'publishers/google/models/gemini-3.1-pro-preview' }];
+  runtime.listError = null;
+  runtime.generateRequests.length = 0;
+  runtime.generateText = 'OK';
+  runtime.generateError = null;
+});
+
+describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
+  it('test-api: gemini resolve modelo via models.list e responde OK', async () => {
+    const res = await handleMaestroAiSettingsTestPost(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TestResults;
+    const gemini = body.results.find((r) => r.agent === 'gemini');
+    expect(gemini?.ok).toBe(true);
+    expect(gemini?.model).toBe('gemini-3.1-pro-preview');
+
+    expect(runtime.constructorOptions.every((o) => o.saKeyJson === '{"sa":"x"}')).toBe(true);
+    expect(runtime.listRequests).toHaveLength(1);
+    const gen = runtime.generateRequests[0] as {
+      model: string;
+      config: { temperature: number; topP: number; maxOutputTokens: number };
+    };
+    expect(gen.model).toBe('gemini-3.1-pro-preview');
+    expect(gen.config).toEqual({ temperature: 0.2, topP: 0.9, maxOutputTokens: 256 });
+
+    for (const other of body.results.filter((r) => r.agent !== 'gemini')) {
+      expect(other.ok).toBe(false);
+      expect(other.message).toBe('Chave nao configurada.');
+    }
+  });
+
+  it('test-api: falha na listagem cai no fallback gemini-2.5-pro', async () => {
+    runtime.listError = new runtime.MockVertexHttpError('Vertex listModels falhou (HTTP 403): x', 403, 'listModels');
+    const res = await handleMaestroAiSettingsTestPost(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
+    const body = (await res.json()) as TestResults;
+    const gemini = body.results.find((r) => r.agent === 'gemini');
+    expect(gemini?.ok).toBe(true);
+    expect(gemini?.model).toBe('gemini-2.5-pro');
+  });
+
+  it('test-api: sem VERTEX_SA_KEY o gemini reporta chave não configurada e não instancia cliente', async () => {
+    const res = await handleMaestroAiSettingsTestPost(context({}));
+    const body = (await res.json()) as TestResults;
+    const gemini = body.results.find((r) => r.agent === 'gemini');
+    expect(gemini?.ok).toBe(false);
+    expect(gemini?.message).toBe('Chave nao configurada.');
+    expect(runtime.constructorOptions).toHaveLength(0);
+  });
+
+  it('settings GET: painel expõe secret_name VERTEX_SA_KEY e runtime_ready', async () => {
+    const res = await handleMaestroAiSettingsGet(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      settings: { agents: { key: string; secret_name: string; runtime_ready: boolean }[] };
+    };
+    const gemini = body.settings.agents.find((a) => a.key === 'gemini');
+    expect(gemini?.secret_name).toBe('VERTEX_SA_KEY');
+    expect(gemini?.runtime_ready).toBe(true);
+  });
+
+  it('settings PUT: gravação de api_key do gemini via painel é rejeitada com diagnóstico', async () => {
+    const res = await handleMaestroAiSettingsPut(
+      context(
+        { VERTEX_SA_KEY: '{"sa":"x"}' },
+        {
+          protocol_text: 'p'.repeat(120),
+          max_cost_usd: 10,
+          max_cycles: 2,
+          api_keys: { gemini: 'alguma-coisa' },
+        },
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('VERTEX_SA_KEY');
+    expect(body.error).toContain('vertex-sa-key');
+  });
+});

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.vertex.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const runtime = vi.hoisted(() => {
   class MockVertexHttpError extends Error {
@@ -53,6 +53,15 @@ vi.mock('../../_shared/vertex', () => ({
 
 import { handleMaestroAiSettingsGet, handleMaestroAiSettingsPut, handleMaestroAiSettingsTestPost } from './sessions';
 
+/** Registra gravações no Secrets Store para provar atomicidade do PUT. */
+const upsertedSecrets: string[] = [];
+
+const SECRET_STORE_ENV = {
+  CLOUDFLARE_PW: 'token-cf',
+  CF_ACCOUNT_ID: 'acct-1',
+  MAESTRO_SECRET_STORE_ID: 'store-1',
+};
+
 const createDb = () => {
   const makeStmt = () => {
     const stmt = {
@@ -86,6 +95,22 @@ beforeEach(() => {
   runtime.generateRequests.length = 0;
   runtime.generateText = 'OK';
   runtime.generateError = null;
+  upsertedSecrets.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/secrets_store/') && init?.method && init.method !== 'GET') {
+        const body = String(init.body ?? '');
+        upsertedSecrets.push(body.slice(0, 200));
+      }
+      return new Response(JSON.stringify({ success: true, result: [] }), { status: 200 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
@@ -124,6 +149,19 @@ describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
     }
   });
 
+  it('test-api: com location regional não usa o catálogo global (modelos global-only não existem lá)', async () => {
+    const res = await handleMaestroAiSettingsTestPost(
+      context({ VERTEX_SA_KEY: '{"sa":"x"}', VERTEX_LOCATION: 'us-central1' }),
+    );
+    const body = (await res.json()) as TestResults;
+    const gemini = body.results.find((r) => r.agent === 'gemini');
+    expect(gemini?.ok).toBe(true);
+    expect(gemini?.model).toBe('gemini-2.5-pro');
+    // Nada de consultar o catálogo global para escolher um modelo que será
+    // chamado numa região onde ele pode não existir.
+    expect(runtime.listRequests).toHaveLength(0);
+  });
+
   it('test-api: falha na listagem cai no fallback gemini-2.5-pro', async () => {
     runtime.listError = new runtime.MockVertexHttpError('Vertex listModels falhou (HTTP 403): x', 403, 'listModels');
     const res = await handleMaestroAiSettingsTestPost(context({ VERTEX_SA_KEY: '{"sa":"x"}' }));
@@ -152,6 +190,24 @@ describe('Maestro AI provider gemini via Vertex (SA OAuth)', () => {
     const gemini = body.settings.agents.find((a) => a.key === 'gemini');
     expect(gemini?.secret_name).toBe('VERTEX_SA_KEY');
     expect(gemini?.runtime_ready).toBe(true);
+  });
+
+  it('settings PUT: rejeita o gemini ANTES de gravar qualquer outro secret (atomicidade)', async () => {
+    const res = await handleMaestroAiSettingsPut(
+      context(
+        { VERTEX_SA_KEY: '{"sa":"x"}', ...SECRET_STORE_ENV },
+        {
+          protocol_text: 'p'.repeat(120),
+          max_cost_usd: 10,
+          max_cycles: 2,
+          // claude vem antes de gemini na ordem de PROVIDER_KEYS: sem validação
+          // prévia, ele seria rotacionado e só então o gemini falharia.
+          api_keys: { claude: 'chave-claude', gemini: 'alguma-coisa' },
+        },
+      ),
+    );
+    expect(res.status).toBe(400);
+    expect(upsertedSecrets).toEqual([]);
   });
 
   it('settings PUT: gravação de api_key do gemini via painel é rejeitada com diagnóstico', async () => {

--- a/admin-motor/src/handlers/routes/mainsite/ai/transform.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/ai/transform.test.ts
@@ -18,6 +18,7 @@ const runtime = vi.hoisted(() => {
     totalTokens: 10,
     generateText: 'texto transformado',
     generateError: null as Error | null,
+    onGenerate: null as (() => void) | null,
     MockVertexHttpError,
   };
 });
@@ -35,6 +36,7 @@ vi.mock('../../../_shared/vertex', () => ({
       },
       generateContent: async (request: Record<string, unknown>) => {
         runtime.generateRequests.push(request);
+        runtime.onGenerate?.();
         if (runtime.generateError) throw runtime.generateError;
         return {
           text: runtime.generateText,
@@ -65,6 +67,7 @@ beforeEach(() => {
   runtime.totalTokens = 10;
   runtime.generateText = 'texto transformado';
   runtime.generateError = null;
+  runtime.onGenerate = null;
 });
 
 describe('POST /api/mainsite/ai/transform (Vertex)', () => {
@@ -93,7 +96,10 @@ describe('POST /api/mainsite/ai/transform (Vertex)', () => {
       };
     };
     expect(gen.model).toBe('gemini-2.5-pro');
-    expect(gen.config.httpOptions?.timeout).toBe(80_000);
+    // Teto da etapa dentro do orçamento do request (95s), não um valor fixo.
+    const genTimeout = gen.config.httpOptions?.timeout ?? 0;
+    expect(genTimeout).toBeGreaterThan(0);
+    expect(genTimeout).toBeLessThanOrEqual(80_000);
     expect(gen.config.temperature).toBe(0.3);
     expect(gen.config.safetySettings).toEqual([
       { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
@@ -113,6 +119,32 @@ describe('POST /api/mainsite/ai/transform (Vertex)', () => {
     const res = await onRequestPost(context({ action: 'grammar', text: 'ola' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
     expect(res.status).toBe(413);
     expect(runtime.generateRequests).toHaveLength(0);
+  });
+
+  it('as tentativas dividem um único prazo em vez de reiniciar 80s cada', async () => {
+    // Relógio controlado: cada tentativa "gasta" 50s, como numa geração lenta.
+    let clock = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    runtime.onGenerate = () => {
+      clock += 50_000;
+    };
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+
+    await onRequestPost(context({ action: 'grammar', text: 'ola' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+
+    expect(runtime.generateRequests).toHaveLength(2);
+    const [primeira, segunda] = runtime.generateRequests as Array<{ config: { httpOptions?: { timeout?: number } } }>;
+    const t1 = primeira?.config.httpOptions?.timeout ?? 0;
+    const t2 = segunda?.config.httpOptions?.timeout ?? 0;
+    // Orçamento de 95s: a 1a tentativa pega o teto de 80s; gastos 50s, a 2a
+    // recebe exatamente os 45s que restam — nunca um 80s novo em folha.
+    expect(t1).toBe(80_000);
+    expect(t2).toBe(45_000);
+    vi.restoreAllMocks();
   });
 
   it('retorna 500 após esgotar retries quando a geração falha', async () => {

--- a/admin-motor/src/handlers/routes/mainsite/ai/transform.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/ai/transform.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    countRequests: [] as Record<string, unknown>[],
+    generateRequests: [] as Record<string, unknown>[],
+    totalTokens: 10,
+    generateText: 'texto transformado',
+    generateError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('../../../_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      countTokens: async (request: Record<string, unknown>) => {
+        runtime.countRequests.push(request);
+        return { totalTokens: runtime.totalTokens };
+      },
+      generateContent: async (request: Record<string, unknown>) => {
+        runtime.generateRequests.push(request);
+        if (runtime.generateError) throw runtime.generateError;
+        return {
+          text: runtime.generateText,
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 },
+        };
+      },
+    };
+  },
+}));
+
+import { onRequestPost } from './transform';
+
+const context = (body: unknown, env: Record<string, unknown>) =>
+  ({
+    request: new Request('https://admin.example/api/mainsite/ai/transform', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+    env,
+    data: {},
+  }) as unknown as Parameters<typeof onRequestPost>[0];
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.countRequests.length = 0;
+  runtime.generateRequests.length = 0;
+  runtime.totalTokens = 10;
+  runtime.generateText = 'texto transformado';
+  runtime.generateError = null;
+});
+
+describe('POST /api/mainsite/ai/transform (Vertex)', () => {
+  it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
+    const res = await onRequestPost(context({ action: 'grammar', text: 'ola' }, {}));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'VERTEX_SA_KEY não configurada.' });
+  });
+
+  it('transforma texto com safety settings REST e timeouts por chamada', async () => {
+    const res = await onRequestPost(context({ action: 'grammar', text: 'ola mundo' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ text: 'texto transformado' });
+
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    const count = runtime.countRequests[0] as { model: string; config?: { httpOptions?: { timeout?: number } } };
+    expect(count.model).toBe('gemini-2.5-pro');
+    expect(count.config?.httpOptions?.timeout).toBe(20_000);
+
+    const gen = runtime.generateRequests[0] as {
+      model: string;
+      config: {
+        safetySettings: { category: string; threshold: string }[];
+        httpOptions?: { timeout?: number };
+        temperature: number;
+      };
+    };
+    expect(gen.model).toBe('gemini-2.5-pro');
+    expect(gen.config.httpOptions?.timeout).toBe(80_000);
+    expect(gen.config.temperature).toBe(0.3);
+    expect(gen.config.safetySettings).toEqual([
+      { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+    ]);
+  });
+
+  it('retorna 400 sem texto ou ação', async () => {
+    const res = await onRequestPost(context({ action: 'grammar' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('retorna 413 quando a contagem de tokens excede o limite', async () => {
+    runtime.totalTokens = 200_000;
+    const res = await onRequestPost(context({ action: 'grammar', text: 'ola' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(413);
+    expect(runtime.generateRequests).toHaveLength(0);
+  });
+
+  it('retorna 500 após esgotar retries quando a geração falha', async () => {
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+    const res = await onRequestPost(context({ action: 'grammar', text: 'ola' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(500);
+    expect(runtime.generateRequests).toHaveLength(2);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('generateContent');
+  });
+});

--- a/admin-motor/src/handlers/routes/mainsite/ai/transform.ts
+++ b/admin-motor/src/handlers/routes/mainsite/ai/transform.ts
@@ -1,17 +1,21 @@
 /// <reference types="@cloudflare/workers-types" />
 
 /**
- * POST /api/mainsite/ai/transform — Transformação de texto via Gemini SDK.
- * Migrado de REST fetch direto para @google/genai SDK oficial.
+ * POST /api/mainsite/ai/transform — Transformação de texto via Vertex AI
+ * (service account OAuth), cliente compartilhado _shared/vertex.
  */
 
-import { GoogleGenAI, HarmBlockThreshold, HarmCategory } from '@google/genai';
+import { VertexGenAI } from '../../../_shared/vertex';
 import { logAiUsage } from '../../_lib/ai-telemetry';
 
 export interface Env {
-  GEMINI_API_KEY: string;
+  VERTEX_SA_KEY: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
   BIGDATA_DB?: D1Database;
 }
+
+const DEFAULT_VERTEX_LOCATION = 'global';
 
 /** Fallback usado quando BIGDATA_DB não retorna modelo configurado para 'chat'. */
 const FALLBACK_MODEL = 'gemini-2.5-pro';
@@ -74,11 +78,12 @@ async function resolveModel(db: D1Database | undefined): Promise<string> {
 /**
  * Estima contagem de tokens via SDK countTokens
  */
-async function estimateTokenCount(ai: GoogleGenAI, text: string, model: string): Promise<number> {
+async function estimateTokenCount(ai: VertexGenAI, text: string, model: string): Promise<number> {
   try {
     const resp = await ai.models.countTokens({
       model,
       contents: text,
+      config: { httpOptions: { timeout: 20_000 } },
     });
     return resp.totalTokens ?? 0;
   } catch (error) {
@@ -103,20 +108,20 @@ function validateInputTokens(
   return { shouldReject: false };
 }
 
-// Safety settings via SDK enums
+// Safety settings como literais REST v1 (mesmos valores dos enums do SDK).
 const TRANSFORM_SAFETY_SETTINGS = [
-  { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
+  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
 ];
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   const resolvedEnv = ((context as { data?: { env?: Env } }).data?.env ?? context.env) as Env;
 
-  if (!resolvedEnv.GEMINI_API_KEY) {
-    structuredLog('error', 'GEMINI_API_KEY missing');
-    return new Response(JSON.stringify({ error: 'GEMINI_API_KEY não configurada.' }), { status: 500 });
+  if (!resolvedEnv.VERTEX_SA_KEY) {
+    structuredLog('error', 'VERTEX_SA_KEY missing');
+    return new Response(JSON.stringify({ error: 'VERTEX_SA_KEY não configurada.' }), { status: 500 });
   }
 
   const _telemetryStart = Date.now();
@@ -130,7 +135,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     );
   }
 
-  const ai = new GoogleGenAI({ apiKey: resolvedEnv.GEMINI_API_KEY });
+  const ai = new VertexGenAI({
+    saKeyJson: resolvedEnv.VERTEX_SA_KEY,
+    project: resolvedEnv.VERTEX_PROJECT,
+    location: resolvedEnv.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+  });
 
   try {
     const body = (await context.request.json()) as { action: string; text: string; instruction?: string };
@@ -196,6 +205,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
             temperature: GEMINI_CONFIG.endpoints.transform.temperature,
             topP: GEMINI_CONFIG.endpoints.transform.topP,
             maxOutputTokens: GEMINI_CONFIG.endpoints.transform.maxOutputTokens,
+            httpOptions: { timeout: 80_000 },
           },
         });
 

--- a/admin-motor/src/handlers/routes/mainsite/ai/transform.ts
+++ b/admin-motor/src/handlers/routes/mainsite/ai/transform.ts
@@ -5,6 +5,7 @@
  * (service account OAuth), cliente compartilhado _shared/vertex.
  */
 
+import { PROXY_REQUEST_BUDGET_MS, stageBudget } from '../../../_shared/deadlines';
 import { VertexGenAI } from '../../../_shared/vertex';
 import { logAiUsage } from '../../_lib/ai-telemetry';
 
@@ -16,6 +17,8 @@ export interface Env {
 }
 
 const DEFAULT_VERTEX_LOCATION = 'global';
+const COUNT_TOKENS_TIMEOUT_MS = 20_000;
+const GENERATE_TIMEOUT_MS = 80_000;
 
 /** Fallback usado quando BIGDATA_DB não retorna modelo configurado para 'chat'. */
 const FALLBACK_MODEL = 'gemini-2.5-pro';
@@ -78,12 +81,12 @@ async function resolveModel(db: D1Database | undefined): Promise<string> {
 /**
  * Estima contagem de tokens via SDK countTokens
  */
-async function estimateTokenCount(ai: VertexGenAI, text: string, model: string): Promise<number> {
+async function estimateTokenCount(ai: VertexGenAI, text: string, model: string, timeoutMs: number): Promise<number> {
   try {
     const resp = await ai.models.countTokens({
       model,
       contents: text,
-      config: { httpOptions: { timeout: 20_000 } },
+      config: { httpOptions: { timeout: timeoutMs } },
     });
     return resp.totalTokens ?? 0;
   } catch (error) {
@@ -117,6 +120,9 @@ const TRANSFORM_SAFETY_SETTINGS = [
 ];
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
+  // Um instante-limite para o request inteiro: a contagem de tokens e as duas
+  // tentativas de geração dividem esse relógio, senão a soma passa do 524.
+  const requestDeadlineAt = Date.now() + PROXY_REQUEST_BUDGET_MS;
   const resolvedEnv = ((context as { data?: { env?: Env } }).data?.env ?? context.env) as Env;
 
   if (!resolvedEnv.VERTEX_SA_KEY) {
@@ -179,7 +185,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const fullPrompt = `${promptInfo}\n\nTexto:\n${text}`;
 
     // Token Counting via SDK
-    const inputTokens = await estimateTokenCount(ai, fullPrompt, activeModel);
+    const inputTokens = await estimateTokenCount(
+      ai,
+      fullPrompt,
+      activeModel,
+      stageBudget(requestDeadlineAt, COUNT_TOKENS_TIMEOUT_MS),
+    );
     const validation = validateInputTokens(inputTokens);
     if (validation.shouldReject) {
       structuredLog('warn', 'Input rejected due to token count', { tokens: inputTokens });
@@ -190,6 +201,10 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     // Retry loop
     for (let tentativa = 0; tentativa < GEMINI_CONFIG.maxRetries; tentativa++) {
+      const generateTimeout = stageBudget(requestDeadlineAt, GENERATE_TIMEOUT_MS);
+      if (generateTimeout <= 0) {
+        throw new Error('Tempo do request esgotado antes de concluir a transformação por IA.');
+      }
       try {
         structuredLog('info', `Gemini request attempt ${tentativa + 1}`, {
           endpoint: 'transform',
@@ -205,7 +220,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
             temperature: GEMINI_CONFIG.endpoints.transform.temperature,
             topP: GEMINI_CONFIG.endpoints.transform.topP,
             maxOutputTokens: GEMINI_CONFIG.endpoints.transform.maxOutputTokens,
-            httpOptions: { timeout: 80_000 },
+            httpOptions: { timeout: generateTimeout },
           },
         });
 

--- a/admin-motor/src/handlers/routes/mainsite/gemini-import.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/gemini-import.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    generateRequests: [] as Record<string, unknown>[],
+    generateText: JSON.stringify({ title: 'Conversa', markdown: 'Olá **mundo**' }),
+    generateError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('../../_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      generateContent: async (request: Record<string, unknown>) => {
+        runtime.generateRequests.push(request);
+        if (runtime.generateError) throw runtime.generateError;
+        return {
+          text: runtime.generateText,
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 },
+        };
+      },
+    };
+  },
+}));
+
+import { onRequestPost } from './gemini-import';
+
+const SHARE_URL = 'https://gemini.google.com/share/abc123';
+const JINA_MARKDOWN = `# Conversa exportada\n${'conteúdo da conversa compartilhada. '.repeat(5)}`;
+
+const context = (body: unknown, env: Record<string, unknown>) =>
+  ({
+    request: new Request('https://admin.example/api/mainsite/gemini-import', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+    env,
+  }) as unknown as Parameters<typeof onRequestPost>[0];
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.generateRequests.length = 0;
+  runtime.generateText = JSON.stringify({ title: 'Conversa', markdown: 'Olá **mundo**' });
+  runtime.generateError = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL) => {
+      if (String(url).startsWith('https://r.jina.ai/')) {
+        return new Response(JINA_MARKDOWN, { status: 200 });
+      }
+      throw new Error(`fetch inesperado no teste: ${String(url)}`);
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('POST /api/mainsite/gemini-import (Vertex)', () => {
+  it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
+    const res = await onRequestPost(context({ url: SHARE_URL }, {}));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Falta variável VERTEX_SA_KEY no deploy.' });
+  });
+
+  it('mantém 422 para URL que não é share do Gemini', async () => {
+    const res = await onRequestPost(context({ url: 'https://example.com/x' }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(422);
+  });
+
+  it('importa conversa com responseSchema OpenAPI e timeout de 80s', async () => {
+    const res = await onRequestPost(context({ url: SHARE_URL }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { html: string; title?: string };
+    expect(body.title).toBe('Conversa');
+    expect(body.html).toContain('<strong>mundo</strong>');
+
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    const gen = runtime.generateRequests[0] as {
+      model: string;
+      config: {
+        responseSchema?: { type: string; required: string[] };
+        responseMimeType?: string;
+        systemInstruction?: string;
+        temperature?: number;
+        httpOptions?: { timeout?: number };
+      };
+    };
+    expect(gen.model).toBe('gemini-2.5-flash');
+    expect(gen.config.responseMimeType).toBe('application/json');
+    expect(gen.config.responseSchema?.type).toBe('OBJECT');
+    expect(gen.config.responseSchema?.required).toEqual(['title', 'markdown']);
+    expect(gen.config.temperature).toBe(0.1);
+    expect(gen.config.httpOptions?.timeout).toBe(80_000);
+    expect(gen.config.systemInstruction).toContain('FIDELIDADE');
+  });
+
+  it('retorna 500 com detalhe após esgotar retries quando a geração falha', async () => {
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+    const res = await onRequestPost(context({ url: SHARE_URL }, { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(500);
+    expect(runtime.generateRequests).toHaveLength(2);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('Falha na importação Gemini.');
+    expect(body.error).toContain('generateContent');
+  });
+});

--- a/admin-motor/src/handlers/routes/mainsite/gemini-import.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/gemini-import.test.ts
@@ -109,7 +109,11 @@ describe('POST /api/mainsite/gemini-import (Vertex)', () => {
     expect(gen.config.responseSchema?.type).toBe('OBJECT');
     expect(gen.config.responseSchema?.required).toEqual(['title', 'markdown']);
     expect(gen.config.temperature).toBe(0.1);
-    expect(gen.config.httpOptions?.timeout).toBe(80_000);
+    // O prazo é o que resta do orçamento do request (95s): a busca via Jina
+    // divide o mesmo relógio, então a geração nunca leva 80s fixos por cima.
+    const genTimeout = gen.config.httpOptions?.timeout ?? 0;
+    expect(genTimeout).toBeGreaterThan(0);
+    expect(genTimeout).toBeLessThanOrEqual(95_000);
     expect(gen.config.systemInstruction).toContain('FIDELIDADE');
   });
 

--- a/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
+++ b/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
@@ -1,4 +1,5 @@
 import { marked } from 'marked';
+import { msUntil, PROXY_REQUEST_BUDGET_MS, stageBudget } from '../../_shared/deadlines';
 import { VertexGenAI } from '../../_shared/vertex';
 import { logAiUsage } from '../_lib/ai-telemetry';
 
@@ -70,16 +71,13 @@ async function resolveModel(db: D1Database | undefined): Promise<string> {
 //   entrega qualidade equivalente com metade da latência e zero 503s.
 const JINA_BASE_URL = 'https://r.jina.ai/';
 
-// ── Orçamento de tempo (deadline)
-// Cloudflare Pages proxy retorna 524 se a Pages Function demorar > 100s.
-// Reservamos 15s para Gemini API + overhead → 85s de budget para Jina.
-const JINA_TOTAL_BUDGET_MS = 85_000;
-
 // ── Orçamento do request inteiro
-// O proxy do Pages devolve 524 além de ~100s. Jina e geração dividem o mesmo
-// relógio: o que a busca consumir sai do que resta para a IA, e as tentativas
-// de geração nunca podem, somadas, empurrar o request além desse teto.
-const REQUEST_TOTAL_BUDGET_MS = 95_000;
+// O proxy do Pages devolve 524 além de ~100s. Busca e geração dividem o mesmo
+// relógio: o que a Jina consumir sai do que resta para a IA, e nenhuma etapa
+// reinicia o teto. O instante-limite é fixado no início do handler.
+const REQUEST_TOTAL_BUDGET_MS = PROXY_REQUEST_BUDGET_MS;
+// Fatia máxima da busca; o que vale é sempre o menor entre ela e o restante.
+const JINA_STAGE_CEILING_MS = 85_000;
 
 // ── Timeouts ideais para browser-only
 // browser engine renderiza via Chromium headless (~15-25s para SPAs como Gemini)
@@ -106,13 +104,22 @@ const JINA_RETRY_BASE_DELAY_MS = 1_500;
  *  - Com API key: 500 RPM por key
  * Solução: JINA_API_KEY sempre presente via Cloudflare Secrets.
  */
-async function fetchSharePageContent(url: string, jinaApiKey?: string): Promise<string> {
-  const deadline = Date.now() + JINA_TOTAL_BUDGET_MS;
+async function fetchSharePageContent(
+  url: string,
+  jinaApiKey: string | undefined,
+  requestDeadlineAt: number,
+): Promise<string> {
+  // A busca não tem relógio próprio: ela recebe a menor fatia entre seu teto e
+  // o que resta do request, de modo que o tempo já gasto (resolveModel, por
+  // exemplo) saia do orçamento dela e sobre prazo para a extração por IA.
+  const stageMs = stageBudget(requestDeadlineAt, JINA_STAGE_CEILING_MS);
+  const deadline = Date.now() + stageMs;
 
   structuredLog('info', 'Jina fetch iniciado (browser-only)', {
     hasApiKey: Boolean(jinaApiKey && jinaApiKey.length > 0),
     url: url.substring(0, 80),
-    budgetMs: JINA_TOTAL_BUDGET_MS,
+    budgetMs: stageMs,
+    requestRemainingMs: msUntil(requestDeadlineAt),
   });
 
   // Headers base para browser-only (X-Timeout atualizado dinamicamente por tentativa)
@@ -130,7 +137,8 @@ async function fetchSharePageContent(url: string, jinaApiKey?: string): Promise<
 
     // ── Recalcula timeout DINAMICAMENTE a cada tentativa baseado no budget restante ──
     // (Fix: usar valor stale pre-loop causava overshoot do deadline de 100s do CF proxy → 524)
-    const remainingMs = deadline - Date.now();
+    // Duplo limite: o da etapa e o do request, o que vencer primeiro.
+    const remainingMs = Math.min(deadline - Date.now(), msUntil(requestDeadlineAt));
     const clientTimeoutMs = Math.min(JINA_IDEAL_CLIENT_MS, remainingMs - 2_000);
     const serverTimeoutS = Math.min(JINA_IDEAL_SERVER_S, Math.floor((clientTimeoutMs - 5_000) / 1000));
 
@@ -206,7 +214,7 @@ async function fetchSharePageContent(url: string, jinaApiKey?: string): Promise<
         attempt,
         url: url.substring(0, 80),
         contentLength: content.length,
-        elapsedMs: Date.now() - (deadline - JINA_TOTAL_BUDGET_MS),
+        elapsedMs: Date.now() - (deadline - stageMs),
       });
       return content;
     } catch (err) {
@@ -367,7 +375,7 @@ async function handleGeminiImport(
 
   try {
     // 1. Fetch page content as clean markdown via Jina Reader
-    const pageContent = await fetchSharePageContent(url, env?.JINA_API_KEY);
+    const pageContent = await fetchSharePageContent(url, env?.JINA_API_KEY, requestDeadlineAt);
 
     // 2. Prompt Gemini Flash to extract structured conversation from markdown
     const systemInstructionConfig = `Você é um sistema de extração inteligente. Analise o conteúdo markdown de uma página de compartilhamento do Gemini.
@@ -386,7 +394,7 @@ Regras:
     for (let tentativa = 0; tentativa < GEMINI_CONFIG.maxRetries; tentativa++) {
       // O que a Jina consumiu já saiu do relógio: cada tentativa recebe apenas
       // o que ainda cabe antes do 524, nunca 80s fixos.
-      const generateTimeout = requestDeadlineAt - Date.now();
+      const generateTimeout = msUntil(requestDeadlineAt);
       if (generateTimeout <= 0) {
         throw new Error('Tempo do request esgotado após a busca da página; a extração não foi tentada.');
       }

--- a/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
+++ b/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
@@ -75,6 +75,12 @@ const JINA_BASE_URL = 'https://r.jina.ai/';
 // Reservamos 15s para Gemini API + overhead → 85s de budget para Jina.
 const JINA_TOTAL_BUDGET_MS = 85_000;
 
+// ── Orçamento do request inteiro
+// O proxy do Pages devolve 524 além de ~100s. Jina e geração dividem o mesmo
+// relógio: o que a busca consumir sai do que resta para a IA, e as tentativas
+// de geração nunca podem, somadas, empurrar o request além desse teto.
+const REQUEST_TOTAL_BUDGET_MS = 95_000;
+
 // ── Timeouts ideais para browser-only
 // browser engine renderiza via Chromium headless (~15-25s para SPAs como Gemini)
 const JINA_IDEAL_SERVER_S = 45; // X-Timeout para Jina server
@@ -352,6 +358,7 @@ async function handleGeminiImport(
     });
   }
 
+  const requestDeadlineAt = Date.now() + REQUEST_TOTAL_BUDGET_MS;
   const activeModel = await resolveModel(env?.BIGDATA_DB);
 
   const _telemetryStart = Date.now();
@@ -377,6 +384,12 @@ Regras:
     });
 
     for (let tentativa = 0; tentativa < GEMINI_CONFIG.maxRetries; tentativa++) {
+      // O que a Jina consumiu já saiu do relógio: cada tentativa recebe apenas
+      // o que ainda cabe antes do 524, nunca 80s fixos.
+      const generateTimeout = requestDeadlineAt - Date.now();
+      if (generateTimeout <= 0) {
+        throw new Error('Tempo do request esgotado após a busca da página; a extração não foi tentada.');
+      }
       try {
         const response = await ai.models.generateContent({
           model: activeModel,
@@ -393,7 +406,7 @@ Regras:
               },
               required: ['title', 'markdown'],
             },
-            httpOptions: { timeout: 80_000 },
+            httpOptions: { timeout: generateTimeout },
           },
         });
 

--- a/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
+++ b/admin-motor/src/handlers/routes/mainsite/gemini-import.ts
@@ -1,18 +1,22 @@
-import { GoogleGenAI } from '@google/genai';
 import { marked } from 'marked';
+import { VertexGenAI } from '../../_shared/vertex';
 import { logAiUsage } from '../_lib/ai-telemetry';
 
 /**
  * gemini-import.ts — Cloudflare Pages Function
  * POST /api/mainsite/gemini-import
- * Fetches a Gemini share URL directly and utilizes Gemini SDK to cleanly parse its conversation.
+ * Fetches a Gemini share URL directly and uses Vertex AI (SA OAuth) to cleanly parse its conversation.
  */
 
 interface Env {
-  GEMINI_API_KEY: string;
+  VERTEX_SA_KEY: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
   JINA_API_KEY?: string;
   BIGDATA_DB?: D1Database;
 }
+
+const DEFAULT_VERTEX_LOCATION = 'global';
 
 interface PagesContext<E = Env> {
   request: Request;
@@ -341,8 +345,8 @@ async function handleGeminiImport(
     );
   }
 
-  if (!env?.GEMINI_API_KEY) {
-    return new Response(JSON.stringify({ error: 'Falta variável GEMINI_API_KEY no deploy.' }), {
+  if (!env?.VERTEX_SA_KEY) {
+    return new Response(JSON.stringify({ error: 'Falta variável VERTEX_SA_KEY no deploy.' }), {
       status: 500,
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
@@ -366,7 +370,11 @@ Regras:
 3. LIMPEZA: Descarte elementos de UI (Sign in, Settings, botões de menu).
 4. TÍTULO: Infira o título principal da conversa.`;
 
-    const ai = new GoogleGenAI({ apiKey: env.GEMINI_API_KEY });
+    const ai = new VertexGenAI({
+      saKeyJson: env.VERTEX_SA_KEY,
+      project: env.VERTEX_PROJECT,
+      location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+    });
 
     for (let tentativa = 0; tentativa < GEMINI_CONFIG.maxRetries; tentativa++) {
       try {
@@ -385,6 +393,7 @@ Regras:
               },
               required: ['title', 'markdown'],
             },
+            httpOptions: { timeout: 80_000 },
           },
         });
 

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    countRequests: [] as Record<string, unknown>[],
+    generateRequests: [] as Record<string, unknown>[],
+    generateParts: [{ text: JSON.stringify({ summary_og: 'resumo curto', summary_ld: 'resumo longo' }) }] as {
+      text?: string;
+      thought?: boolean;
+    }[],
+    generateError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('../../_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      countTokens: async (request: Record<string, unknown>) => {
+        runtime.countRequests.push(request);
+        return { totalTokens: 42 };
+      },
+      generateContent: async (request: Record<string, unknown>) => {
+        runtime.generateRequests.push(request);
+        if (runtime.generateError) throw runtime.generateError;
+        return {
+          candidates: [{ content: { parts: runtime.generateParts } }],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 },
+          text: runtime.generateParts[0]?.text ?? '',
+        };
+      },
+    };
+  },
+}));
+
+import { onRequestPost } from './post-summaries';
+
+const POST_ROW = {
+  id: 7,
+  title: 'Título do post',
+  content: `<p>${'Conteúdo relevante do post para resumo. '.repeat(4)}</p>`,
+};
+
+const createDb = () => {
+  const makeStmt = (sql: string) => {
+    const stmt = {
+      bind: (..._args: unknown[]) => stmt,
+      run: async () => ({}),
+      all: async () => ({ results: [] as unknown[] }),
+      first: async () => (sql.includes('FROM mainsite_posts WHERE id') ? POST_ROW : null),
+    };
+    return stmt;
+  };
+  return { prepare: makeStmt };
+};
+
+const context = (body: unknown, env: Record<string, unknown>) =>
+  ({
+    request: new Request('https://admin.example/api/mainsite/post-summaries', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'Content-Type': 'application/json' },
+    }),
+    env: { BIGDATA_DB: createDb(), ...env },
+  }) as unknown as Parameters<typeof onRequestPost>[0];
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.countRequests.length = 0;
+  runtime.generateRequests.length = 0;
+  runtime.generateParts = [{ text: JSON.stringify({ summary_og: 'resumo curto', summary_ld: 'resumo longo' }) }];
+  runtime.generateError = null;
+});
+
+describe('POST /api/mainsite/post-summaries action=regenerate (Vertex)', () => {
+  it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
+    const res = await onRequestPost(context({ action: 'regenerate', postId: 7 }, {}));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('VERTEX_SA_KEY não configurada.');
+  });
+
+  it('gera resumos com safety settings REST (5 categorias) e timeouts por chamada', async () => {
+    const res = await onRequestPost(
+      context({ action: 'regenerate', postId: 7, model: 'gemini-2.5-flash' }, { VERTEX_SA_KEY: '{"sa":"x"}' }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; summary_og: string; summary_ld: string };
+    expect(body.ok).toBe(true);
+    expect(body.summary_og).toBe('resumo curto');
+    expect(body.summary_ld).toBe('resumo longo');
+
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    const count = runtime.countRequests[0] as { config?: { httpOptions?: { timeout?: number } } };
+    expect(count.config?.httpOptions?.timeout).toBe(20_000);
+
+    const gen = runtime.generateRequests[0] as {
+      model: string;
+      config: {
+        safetySettings: { category: string; threshold: string }[];
+        responseMimeType?: string;
+        httpOptions?: { timeout?: number };
+      };
+    };
+    expect(gen.model).toBe('gemini-2.5-flash');
+    expect(gen.config.responseMimeType).toBe('application/json');
+    expect(gen.config.httpOptions?.timeout).toBe(80_000);
+    expect(gen.config.safetySettings).toEqual([
+      { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+      { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_ONLY_HIGH' },
+    ]);
+  });
+
+  it('retorna 500 com "AI falhou." após esgotar retries', async () => {
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+    const res = await onRequestPost(
+      context({ action: 'regenerate', postId: 7, model: 'gemini-2.5-flash' }, { VERTEX_SA_KEY: '{"sa":"x"}' }),
+    );
+    expect(res.status).toBe(500);
+    expect(runtime.generateRequests).toHaveLength(2);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.error).toContain('AI falhou.');
+  });
+});

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
@@ -56,12 +56,12 @@ const POST_ROW = {
   content: `<p>${'Conteúdo relevante do post para resumo. '.repeat(4)}</p>`,
 };
 
-const createDb = () => {
+const createDb = (posts: (typeof POST_ROW)[] = []) => {
   const makeStmt = (sql: string) => {
     const stmt = {
       bind: (..._args: unknown[]) => stmt,
       run: async () => ({}),
-      all: async () => ({ results: [] as unknown[] }),
+      all: async () => ({ results: sql.includes('SELECT id, title, content FROM mainsite_posts') ? posts : [] }),
       first: async () => (sql.includes('FROM mainsite_posts WHERE id') ? POST_ROW : null),
     };
     return stmt;
@@ -69,14 +69,14 @@ const createDb = () => {
   return { prepare: makeStmt };
 };
 
-const context = (body: unknown, env: Record<string, unknown>) =>
+const context = (body: unknown, env: Record<string, unknown>, posts: (typeof POST_ROW)[] = []) =>
   ({
     request: new Request('https://admin.example/api/mainsite/post-summaries', {
       method: 'POST',
       body: JSON.stringify(body),
       headers: { 'Content-Type': 'application/json' },
     }),
-    env: { BIGDATA_DB: createDb(), ...env },
+    env: { BIGDATA_DB: createDb(posts), ...env },
   }) as unknown as Parameters<typeof onRequestPost>[0];
 
 beforeEach(() => {
@@ -128,6 +128,26 @@ describe('POST /api/mainsite/post-summaries action=regenerate (Vertex)', () => {
       { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
       { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_ONLY_HIGH' },
     ]);
+  });
+
+  it('generate-all limita cada chamada ao tempo que resta do teto do lote', async () => {
+    const res = await onRequestPost(
+      context({ action: 'generate-all', mode: 'all', model: 'gemini-2.5-flash' }, { VERTEX_SA_KEY: '{"sa":"x"}' }, [
+        POST_ROW,
+      ]),
+    );
+    expect(res.status).toBe(200);
+
+    const count = runtime.countRequests[0] as { config?: { httpOptions?: { timeout?: number } } };
+    const gen = runtime.generateRequests[0] as { config?: { httpOptions?: { timeout?: number } } };
+    const countTimeout = count.config?.httpOptions?.timeout ?? 0;
+    const genTimeout = gen.config?.httpOptions?.timeout ?? 0;
+    // O lote inteiro tem 40s antes do 524 do proxy; nenhuma chamada individual
+    // pode pedir mais do que resta dele (o single-post segue com 20s/80s).
+    expect(countTimeout).toBeGreaterThan(0);
+    expect(countTimeout).toBeLessThanOrEqual(40_000);
+    expect(genTimeout).toBeGreaterThan(0);
+    expect(genTimeout).toBeLessThanOrEqual(40_000);
   });
 
   it('retorna 500 com "AI falhou." após esgotar retries', async () => {

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.test.ts
@@ -20,6 +20,7 @@ const runtime = vi.hoisted(() => {
       thought?: boolean;
     }[],
     generateError: null as Error | null,
+    onGenerate: null as (() => void) | null,
     MockVertexHttpError,
   };
 });
@@ -37,6 +38,7 @@ vi.mock('../../_shared/vertex', () => ({
       },
       generateContent: async (request: Record<string, unknown>) => {
         runtime.generateRequests.push(request);
+        runtime.onGenerate?.();
         if (runtime.generateError) throw runtime.generateError;
         return {
           candidates: [{ content: { parts: runtime.generateParts } }],
@@ -85,6 +87,7 @@ beforeEach(() => {
   runtime.generateRequests.length = 0;
   runtime.generateParts = [{ text: JSON.stringify({ summary_og: 'resumo curto', summary_ld: 'resumo longo' }) }];
   runtime.generateError = null;
+  runtime.onGenerate = null;
 });
 
 describe('POST /api/mainsite/post-summaries action=regenerate (Vertex)', () => {
@@ -148,6 +151,33 @@ describe('POST /api/mainsite/post-summaries action=regenerate (Vertex)', () => {
     expect(countTimeout).toBeLessThanOrEqual(40_000);
     expect(genTimeout).toBeGreaterThan(0);
     expect(genTimeout).toBeLessThanOrEqual(40_000);
+  });
+
+  it('regenerate (post único) também tem prazo total: a 2a tentativa recebe o que resta', async () => {
+    let clock = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    runtime.onGenerate = () => {
+      clock += 50_000;
+    };
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+
+    await onRequestPost(
+      context({ action: 'regenerate', postId: 7, model: 'gemini-2.5-flash' }, { VERTEX_SA_KEY: '{"sa":"x"}' }),
+    );
+
+    expect(runtime.generateRequests).toHaveLength(2);
+    const [primeira, segunda] = runtime.generateRequests as Array<{ config?: { httpOptions?: { timeout?: number } } }>;
+    const t1 = primeira?.config?.httpOptions?.timeout ?? 0;
+    const t2 = segunda?.config?.httpOptions?.timeout ?? 0;
+    // Sem prazo total, cada tentativa pediria 80s novos e o request passaria
+    // dos 100s do proxy, virando 524 no lugar do JSON de erro do handler.
+    expect(t1).toBe(80_000);
+    expect(t2).toBe(45_000);
+    vi.restoreAllMocks();
   });
 
   it('retorna 500 com "AI falhou." após esgotar retries', async () => {

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
@@ -6,6 +6,7 @@
  * Usa D1 direto (BIGDATA_DB) — padrão admin-app.
  */
 
+import { PROXY_REQUEST_BUDGET_MS, stageBudget } from '../../_shared/deadlines';
 import { VertexGenAI } from '../../_shared/vertex';
 import { logAiUsage } from '../_lib/ai-telemetry';
 import { toHeaders } from '../_lib/mainsite-admin';
@@ -145,9 +146,10 @@ async function generateShareSummary(
   env: SummaryEnv,
   model: string,
   db?: D1Database,
-  /** Teto opcional para esta chamada: no generate-all é o que resta do lote,
-   * de modo que nenhum post sozinho estoure o limite que evita o 524. */
-  budgetMs?: number,
+  /** Teto desta chamada: no generate-all é o que resta do lote; no post único
+   * é o orçamento do request. Em ambos os casos as tentativas dividem o mesmo
+   * relógio, senão dois retries de 80s já estouram o 524 do proxy. */
+  budgetMs: number = PROXY_REQUEST_BUDGET_MS,
 ): Promise<{ summary_og: string; summary_ld: string } | { error: string }> {
   const telStart = Date.now();
   const cleanContent = stripHtml(htmlContent);
@@ -177,10 +179,8 @@ REGRAS:
   const userPrompt = `TÍTULO: ${title}\nCONTEÚDO: ${cleanContent}`;
   const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
 
-  // Sem orçamento (ação de post único) valem os tetos padrão; no lote, cada
-  // chamada recebe o que ainda resta antes do 524.
-  const remaining = () => (budgetMs === undefined ? undefined : Math.max(0, budgetMs - (Date.now() - telStart)));
-  const countTimeout = Math.min(COUNT_TOKENS_TIMEOUT_MS, remaining() ?? COUNT_TOKENS_TIMEOUT_MS);
+  const deadlineAt = telStart + budgetMs;
+  const countTimeout = stageBudget(deadlineAt, COUNT_TOKENS_TIMEOUT_MS);
   if (countTimeout <= 0) return { error: 'Tempo do lote esgotado antes de processar este post.' };
 
   // 1. Validation de Contexto API e Pre-req Token Counting
@@ -197,7 +197,7 @@ REGRAS:
   let parsedResponse: Awaited<ReturnType<typeof ai.models.generateContent>> | undefined;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    const generateTimeout = Math.min(GENERATE_TIMEOUT_MS, remaining() ?? GENERATE_TIMEOUT_MS);
+    const generateTimeout = stageBudget(deadlineAt, GENERATE_TIMEOUT_MS);
     if (generateTimeout <= 0) {
       lastErrorMsg = 'Tempo do lote esgotado durante a geração.';
       break;

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
@@ -6,7 +6,7 @@
  * Usa D1 direto (BIGDATA_DB) — padrão admin-app.
  */
 
-import { GoogleGenAI, HarmBlockThreshold, HarmCategory } from '@google/genai';
+import { VertexGenAI } from '../../_shared/vertex';
 import { logAiUsage } from '../_lib/ai-telemetry';
 import { toHeaders } from '../_lib/mainsite-admin';
 import { logModuleOperationalEvent } from '../_lib/operational';
@@ -19,8 +19,12 @@ interface SummaryEnv {
   AI?: {
     run?: (model: string, payload: unknown, options?: unknown) => Promise<unknown>;
   };
-  GEMINI_API_KEY?: string;
+  VERTEX_SA_KEY?: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
 }
+
+const DEFAULT_VERTEX_LOCATION = 'global';
 
 interface SummaryContext {
   request: Request;
@@ -63,18 +67,17 @@ function structuredLog(level: 'INFO' | 'WARN' | 'ERROR', message: string, contex
 
 const GEMINI_CONFIG = {
   model: 'gemini-2.5-flash',
-  apiVersion: 'v1beta',
   maxOutputTokens: 8192,
   temperature: 0.3,
 };
 
-// ── v1beta: Safety Settings (BLOCK_ONLY_HIGH) ──
+// ── Safety Settings como literais REST v1 (BLOCK_ONLY_HIGH) ──
 const SUMMARY_SAFETY_SETTINGS = [
-  { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
-  { category: HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY, threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH },
+  { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+  { category: 'HARM_CATEGORY_CIVIC_INTEGRITY', threshold: 'BLOCK_ONLY_HIGH' },
 ];
 
 function stripHtml(html: string): string {
@@ -113,11 +116,12 @@ function extractJsonFromText(rawText: string): string {
   return str;
 }
 
-async function estimateTokenCount(ai: GoogleGenAI, prompt: string, model: string): Promise<number> {
+async function estimateTokenCount(ai: VertexGenAI, prompt: string, model: string): Promise<number> {
   try {
     const resp = await ai.models.countTokens({
       model,
       contents: prompt,
+      config: { httpOptions: { timeout: 20_000 } },
     });
     return resp.totalTokens ?? -1;
   } catch (err) {
@@ -135,13 +139,17 @@ async function generateShareSummary(
 ): Promise<{ summary_og: string; summary_ld: string } | { error: string }> {
   const telStart = Date.now();
   const cleanContent = stripHtml(htmlContent);
-  const apiKey = env.GEMINI_API_KEY;
-  if (!apiKey) {
-    structuredLog('ERROR', 'GEMINI_API_KEY não configurada');
-    return { error: 'GEMINI_API_KEY não configurada.' };
+  const saKeyJson = env.VERTEX_SA_KEY;
+  if (!saKeyJson) {
+    structuredLog('ERROR', 'VERTEX_SA_KEY não configurada');
+    return { error: 'VERTEX_SA_KEY não configurada.' };
   }
 
-  const ai = new GoogleGenAI({ apiKey });
+  const ai = new VertexGenAI({
+    saKeyJson,
+    project: env.VERTEX_PROJECT,
+    location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+  });
   const targetModel = model || GEMINI_CONFIG.model;
 
   const systemPrompt = `Você é um editor especializado em SEO e compartilhamento social.
@@ -181,6 +189,7 @@ REGRAS:
           temperature: GEMINI_CONFIG.temperature,
           maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
           responseMimeType: 'application/json',
+          httpOptions: { timeout: 80_000 },
         },
       });
       break;

--- a/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
+++ b/admin-motor/src/handlers/routes/mainsite/post-summaries.ts
@@ -25,6 +25,10 @@ interface SummaryEnv {
 }
 
 const DEFAULT_VERTEX_LOCATION = 'global';
+const COUNT_TOKENS_TIMEOUT_MS = 20_000;
+const GENERATE_TIMEOUT_MS = 80_000;
+// Teto do lote em generate-all: o proxy do Pages devolve 524 além disso.
+const BATCH_TIMEOUT_LIMIT_MS = 40_000;
 
 interface SummaryContext {
   request: Request;
@@ -116,12 +120,17 @@ function extractJsonFromText(rawText: string): string {
   return str;
 }
 
-async function estimateTokenCount(ai: VertexGenAI, prompt: string, model: string): Promise<number> {
+async function estimateTokenCount(
+  ai: VertexGenAI,
+  prompt: string,
+  model: string,
+  timeoutMs = COUNT_TOKENS_TIMEOUT_MS,
+): Promise<number> {
   try {
     const resp = await ai.models.countTokens({
       model,
       contents: prompt,
-      config: { httpOptions: { timeout: 20_000 } },
+      config: { httpOptions: { timeout: timeoutMs } },
     });
     return resp.totalTokens ?? -1;
   } catch (err) {
@@ -136,6 +145,9 @@ async function generateShareSummary(
   env: SummaryEnv,
   model: string,
   db?: D1Database,
+  /** Teto opcional para esta chamada: no generate-all é o que resta do lote,
+   * de modo que nenhum post sozinho estoure o limite que evita o 524. */
+  budgetMs?: number,
 ): Promise<{ summary_og: string; summary_ld: string } | { error: string }> {
   const telStart = Date.now();
   const cleanContent = stripHtml(htmlContent);
@@ -165,8 +177,14 @@ REGRAS:
   const userPrompt = `TÍTULO: ${title}\nCONTEÚDO: ${cleanContent}`;
   const fullPrompt = `${systemPrompt}\n\n${userPrompt}`;
 
+  // Sem orçamento (ação de post único) valem os tetos padrão; no lote, cada
+  // chamada recebe o que ainda resta antes do 524.
+  const remaining = () => (budgetMs === undefined ? undefined : Math.max(0, budgetMs - (Date.now() - telStart)));
+  const countTimeout = Math.min(COUNT_TOKENS_TIMEOUT_MS, remaining() ?? COUNT_TOKENS_TIMEOUT_MS);
+  if (countTimeout <= 0) return { error: 'Tempo do lote esgotado antes de processar este post.' };
+
   // 1. Validation de Contexto API e Pre-req Token Counting
-  const tokenCount = await estimateTokenCount(ai, fullPrompt, targetModel);
+  const tokenCount = await estimateTokenCount(ai, fullPrompt, targetModel, countTimeout);
   if (tokenCount > 120000) {
     structuredLog('ERROR', 'Conteúdo muito extenso para processar', { tokens: tokenCount });
     return { error: 'Dados muito extensos para geração do resumo.' };
@@ -179,6 +197,11 @@ REGRAS:
   let parsedResponse: Awaited<ReturnType<typeof ai.models.generateContent>> | undefined;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const generateTimeout = Math.min(GENERATE_TIMEOUT_MS, remaining() ?? GENERATE_TIMEOUT_MS);
+    if (generateTimeout <= 0) {
+      lastErrorMsg = 'Tempo do lote esgotado durante a geração.';
+      break;
+    }
     try {
       parsedResponse = await ai.models.generateContent({
         model: targetModel,
@@ -189,7 +212,7 @@ REGRAS:
           temperature: GEMINI_CONFIG.temperature,
           maxOutputTokens: GEMINI_CONFIG.maxOutputTokens,
           responseMimeType: 'application/json',
-          httpOptions: { timeout: 80_000 },
+          httpOptions: { timeout: generateTimeout },
         },
       });
       break;
@@ -439,7 +462,7 @@ export async function onRequestPost(context: SummaryContext) {
       const details: Array<{ postId: number; title: string; status: string }> = [];
       const resolvedModel = await resolveSummaryModel(db, body.model);
 
-      const TIMEOUT_LIMIT = 40000; // 40 seconds max to prevent 524 Timeout
+      const TIMEOUT_LIMIT = BATCH_TIMEOUT_LIMIT_MS;
       const startTime = Date.now();
 
       for (const post of allPosts) {
@@ -472,7 +495,17 @@ export async function onRequestPost(context: SummaryContext) {
         }
 
         try {
-          const result = await generateShareSummary(post.title, post.content, runtimeEnv, resolvedModel, db);
+          // O teto do lote é verificado entre posts; sem repassar o que resta,
+          // um único post poderia consumir 20s de contagem + 2x80s de geração
+          // e estourar justamente o 524 que essa proteção evita.
+          const result = await generateShareSummary(
+            post.title,
+            post.content,
+            runtimeEnv,
+            resolvedModel,
+            db,
+            Math.max(0, TIMEOUT_LIMIT - (Date.now() - startTime)),
+          );
           if ('error' in result) {
             failed++;
             details.push({ postId: post.id, title: post.title, status: result.error });

--- a/admin-motor/src/handlers/routes/news/discover.test.ts
+++ b/admin-motor/src/handlers/routes/news/discover.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    generateRequests: [] as Record<string, unknown>[],
+    generateText: JSON.stringify([{ name: 'Portal Exemplo', url: 'https://exemplo.com/rss', category: 'Brasil' }]),
+    generateError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('../../_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      generateContent: async (request: Record<string, unknown>) => {
+        runtime.generateRequests.push(request);
+        if (runtime.generateError) throw runtime.generateError;
+        return {
+          text: runtime.generateText,
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 7 },
+        };
+      },
+    };
+  },
+}));
+
+import { onRequestGet } from './discover';
+
+type DiscoverPayload = {
+  ok: boolean;
+  suggestions: { id: string; url: string; source: string }[];
+  layers?: { geminiAi: boolean };
+};
+
+const context = (query: string, env: Record<string, unknown>) =>
+  ({
+    request: new Request(`https://admin.example/api/news/discover?q=${encodeURIComponent(query)}`),
+    env,
+  }) as unknown as Parameters<typeof onRequestGet>[0];
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.generateRequests.length = 0;
+  runtime.generateText = JSON.stringify([
+    { name: 'Portal Exemplo', url: 'https://exemplo.com/rss', category: 'Brasil' },
+  ]);
+  runtime.generateError = null;
+});
+
+describe('GET /api/news/discover (camada Vertex opcional)', () => {
+  it('sem VERTEX_SA_KEY: responde ok com layers.geminiAi=false e não instancia o cliente', async () => {
+    const res = await onRequestGet(context('tecnologia', {}));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverPayload;
+    expect(body.ok).toBe(true);
+    expect(body.layers?.geminiAi).toBe(false);
+    expect(runtime.constructorOptions).toHaveLength(0);
+  });
+
+  it('com VERTEX_SA_KEY: agrega sugestões da IA com source gemini-ai', async () => {
+    const res = await onRequestGet(context('tecnologia', { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverPayload;
+    expect(body.ok).toBe(true);
+    expect(body.layers?.geminiAi).toBe(true);
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    const aiItems = body.suggestions.filter((s) => s.source === 'gemini-ai');
+    expect(aiItems.map((s) => s.url)).toContain('https://exemplo.com/rss');
+    const gen = runtime.generateRequests[0] as { model: string };
+    expect(gen.model).toBe('gemini-2.5-flash');
+  });
+
+  it('falha da IA é silenciosa: responde ok sem itens gemini-ai', async () => {
+    runtime.generateError = new runtime.MockVertexHttpError(
+      'Vertex generateContent falhou (HTTP 500): interno',
+      500,
+      'generateContent',
+    );
+    const res = await onRequestGet(context('tecnologia', { VERTEX_SA_KEY: '{"sa":"x"}' }));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverPayload;
+    expect(body.ok).toBe(true);
+    expect(body.suggestions.filter((s) => s.source === 'gemini-ai')).toHaveLength(0);
+  });
+});

--- a/admin-motor/src/handlers/routes/news/discover.test.ts
+++ b/admin-motor/src/handlers/routes/news/discover.test.ts
@@ -81,8 +81,14 @@ describe('GET /api/news/discover (camada Vertex opcional)', () => {
     expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
     const aiItems = body.suggestions.filter((s) => s.source === 'gemini-ai');
     expect(aiItems.map((s) => s.url)).toContain('https://exemplo.com/rss');
-    const gen = runtime.generateRequests[0] as { model: string };
+    const gen = runtime.generateRequests[0] as {
+      model: string;
+      config?: { httpOptions?: { timeout?: number } };
+    };
     expect(gen.model).toBe('gemini-2.5-flash');
+    // A camada descarta o resultado após 6s; abortar a requisição no mesmo
+    // prazo evita deixá-la pendurada no isolate depois de já ser inútil.
+    expect(gen.config?.httpOptions?.timeout).toBe(6_000);
   });
 
   it('falha da IA é silenciosa: responde ok sem itens gemini-ai', async () => {

--- a/admin-motor/src/handlers/routes/news/discover.test.ts
+++ b/admin-motor/src/handlers/routes/news/discover.test.ts
@@ -86,9 +86,11 @@ describe('GET /api/news/discover (camada Vertex opcional)', () => {
       config?: { httpOptions?: { timeout?: number } };
     };
     expect(gen.model).toBe('gemini-2.5-flash');
-    // A camada descarta o resultado após 6s; abortar a requisição no mesmo
-    // prazo evita deixá-la pendurada no isolate depois de já ser inútil.
-    expect(gen.config?.httpOptions?.timeout).toBe(6_000);
+    // A camada descarta o resultado após 6s; a requisição é abortada no mesmo
+    // instante-limite, descontado o que a resolução de modelo já consumiu.
+    const genTimeout = gen.config?.httpOptions?.timeout ?? 0;
+    expect(genTimeout).toBeGreaterThan(0);
+    expect(genTimeout).toBeLessThanOrEqual(6_000);
   });
 
   it('falha da IA é silenciosa: responde ok sem itens gemini-ai', async () => {

--- a/admin-motor/src/handlers/routes/news/discover.ts
+++ b/admin-motor/src/handlers/routes/news/discover.ts
@@ -25,6 +25,10 @@ interface Env {
 
 const DEFAULT_VERTEX_LOCATION = 'global';
 
+// Orçamento da camada de IA: passado o prazo, a sugestão deixa de ser útil para
+// a resposta. O mesmo valor aborta a requisição e corta a corrida no handler.
+const AI_LAYER_BUDGET_MS = 6_000;
+
 interface D1Binding {
   prepare(query: string): {
     bind(...values: unknown[]): { run(): Promise<unknown>; first<T>(): Promise<T | null> };
@@ -1295,7 +1299,7 @@ REGRAS:
         temperature: 0.2,
         maxOutputTokens: 8192,
         responseMimeType: 'application/json',
-        httpOptions: { timeout: 80_000 },
+        httpOptions: { timeout: AI_LAYER_BUDGET_MS },
       },
     });
 
@@ -1547,7 +1551,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     try {
       const geminiResults = await Promise.race([
         discoverWithGemini(query, runtimeEnv, runtimeEnv.BIGDATA_DB as unknown as D1Binding),
-        new Promise<RssSuggestion[]>((resolve) => setTimeout(() => resolve([]), 6000)),
+        new Promise<RssSuggestion[]>((resolve) => setTimeout(() => resolve([]), AI_LAYER_BUDGET_MS)),
       ]);
       addUnique(geminiResults);
     } catch {

--- a/admin-motor/src/handlers/routes/news/discover.ts
+++ b/admin-motor/src/handlers/routes/news/discover.ts
@@ -1,5 +1,5 @@
 /// <reference types="@cloudflare/workers-types" />
-import { GoogleGenAI } from '@google/genai';
+import { VertexGenAI } from '../../_shared/vertex';
 
 /**
  * /api/news/discover — Pages Function
@@ -13,13 +13,17 @@ import { GoogleGenAI } from '@google/genai';
  * - q (string): Termo de busca
  * - field (name|url|category): Qual campo originou a busca
  *
- * A camada Gemini é opcional — funciona apenas se GEMINI_API_KEY estiver configurada.
+ * A camada de IA é opcional — funciona apenas se VERTEX_SA_KEY estiver configurada.
  */
 
 interface Env {
   BIGDATA_DB: D1Database;
-  GEMINI_API_KEY?: string;
+  VERTEX_SA_KEY?: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
 }
+
+const DEFAULT_VERTEX_LOCATION = 'global';
 
 interface D1Binding {
   prepare(query: string): {
@@ -1261,10 +1265,14 @@ function buildGoogleNewsSuggestion(query: string): RssSuggestion | null {
 // Layer 3: Gemini AI — descoberta inteligente de feeds
 // ══════════════════════════════════════════════════════════
 
-async function discoverWithGemini(query: string, apiKey: string, db?: D1Binding): Promise<RssSuggestion[]> {
+async function discoverWithGemini(query: string, env: Env, db?: D1Binding): Promise<RssSuggestion[]> {
   const _telStart = Date.now();
   const activeModel = await resolveModel(db);
-  const ai = new GoogleGenAI({ apiKey });
+  const ai = new VertexGenAI({
+    saKeyJson: env.VERTEX_SA_KEY ?? '',
+    project: env.VERTEX_PROJECT,
+    location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+  });
   try {
     const prompt = `Você é um especialista em feeds RSS de notícias.
 O usuário está buscando fontes de notícias para o termo: "${query}"
@@ -1287,6 +1295,7 @@ REGRAS:
         temperature: 0.2,
         maxOutputTokens: 8192,
         responseMimeType: 'application/json',
+        httpOptions: { timeout: 80_000 },
       },
     });
 
@@ -1531,13 +1540,13 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     if (gnews) addUnique([gnews]);
   }
 
-  // Layer 3: Gemini AI (se API key disponível e query ≥3 chars)
+  // Layer 3: IA via Vertex (se service account disponível e query ≥3 chars)
   const runtimeEnv = (context as unknown as { data?: { env?: Env } }).data?.env || context.env;
-  const apiKey = runtimeEnv.GEMINI_API_KEY;
-  if (apiKey && query.length >= 3) {
+  const saKeyJson = runtimeEnv.VERTEX_SA_KEY;
+  if (saKeyJson && query.length >= 3) {
     try {
       const geminiResults = await Promise.race([
-        discoverWithGemini(query, apiKey, runtimeEnv.BIGDATA_DB as unknown as D1Binding),
+        discoverWithGemini(query, runtimeEnv, runtimeEnv.BIGDATA_DB as unknown as D1Binding),
         new Promise<RssSuggestion[]>((resolve) => setTimeout(() => resolve([]), 6000)),
       ]);
       addUnique(geminiResults);
@@ -1555,7 +1564,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       layers: {
         curated: true,
         googleNews: !isUrl,
-        geminiAi: Boolean(apiKey),
+        geminiAi: Boolean(saKeyJson),
         autoDetect: field === 'url' && isUrl,
       },
     }),

--- a/admin-motor/src/handlers/routes/news/discover.ts
+++ b/admin-motor/src/handlers/routes/news/discover.ts
@@ -1269,9 +1269,19 @@ function buildGoogleNewsSuggestion(query: string): RssSuggestion | null {
 // Layer 3: Gemini AI — descoberta inteligente de feeds
 // ══════════════════════════════════════════════════════════
 
-async function discoverWithGemini(query: string, env: Env, db?: D1Binding): Promise<RssSuggestion[]> {
+async function discoverWithGemini(
+  query: string,
+  env: Env,
+  db?: D1Binding,
+  /** Instante-limite absoluto da camada; tudo que sobrar dele é o que a IA tem. */
+  deadlineAt = Date.now() + AI_LAYER_BUDGET_MS,
+): Promise<RssSuggestion[]> {
   const _telStart = Date.now();
   const activeModel = await resolveModel(db);
+  // resolveModel consulta o D1 antes da IA: sem descontar esse tempo, o abort
+  // começaria a contar depois que a corrida do handler já tivesse terminado.
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) return [];
   const ai = new VertexGenAI({
     saKeyJson: env.VERTEX_SA_KEY ?? '',
     project: env.VERTEX_PROJECT,
@@ -1299,7 +1309,7 @@ REGRAS:
         temperature: 0.2,
         maxOutputTokens: 8192,
         responseMimeType: 'application/json',
-        httpOptions: { timeout: AI_LAYER_BUDGET_MS },
+        httpOptions: { timeout: remainingMs },
       },
     });
 
@@ -1549,8 +1559,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   const saKeyJson = runtimeEnv.VERTEX_SA_KEY;
   if (saKeyJson && query.length >= 3) {
     try {
+      // Um único instante-limite governa a corrida e o abort da chamada.
+      const deadlineAt = Date.now() + AI_LAYER_BUDGET_MS;
       const geminiResults = await Promise.race([
-        discoverWithGemini(query, runtimeEnv, runtimeEnv.BIGDATA_DB as unknown as D1Binding),
+        discoverWithGemini(query, runtimeEnv, runtimeEnv.BIGDATA_DB as unknown as D1Binding, deadlineAt),
         new Promise<RssSuggestion[]>((resolve) => setTimeout(() => resolve([]), AI_LAYER_BUDGET_MS)),
       ]);
       addUnique(geminiResults);

--- a/admin-motor/src/index.test.ts
+++ b/admin-motor/src/index.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => {
+  class MockVertexHttpError extends Error {
+    constructor(
+      message: string,
+      readonly status: number,
+      readonly operation: string,
+    ) {
+      super(message);
+      this.name = 'VertexHttpError';
+    }
+  }
+  return {
+    constructorOptions: [] as Record<string, unknown>[],
+    listRequests: [] as Record<string, unknown>[],
+    listModels: [] as { name?: string; displayName?: string }[],
+    listError: null as Error | null,
+    MockVertexHttpError,
+  };
+});
+
+vi.mock('./handlers/_shared/vertex', () => ({
+  VertexHttpError: runtime.MockVertexHttpError,
+  VertexGenAI: class {
+    constructor(options: Record<string, unknown>) {
+      runtime.constructorOptions.push(options);
+    }
+    readonly models = {
+      list: (request: Record<string, unknown>) => {
+        runtime.listRequests.push(request);
+        return (async function* () {
+          if (runtime.listError) throw runtime.listError;
+          for (const m of runtime.listModels) {
+            yield m;
+          }
+        })();
+      },
+    };
+  },
+}));
+
+import worker from './index';
+
+type ModelPayload = { id: string; displayName: string; api: string; vision: boolean };
+
+const TOKEN = 'admin-token-teste';
+
+const dispatch = (path: string, env: Record<string, unknown>) =>
+  (worker as unknown as { fetch: (r: Request, e: unknown, c: unknown) => Promise<Response> }).fetch(
+    new Request(`https://admin.example${path}`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    }),
+    env,
+    { waitUntil: () => {} },
+  );
+
+beforeEach(() => {
+  runtime.constructorOptions.length = 0;
+  runtime.listRequests.length = 0;
+  runtime.listModels = [];
+  runtime.listError = null;
+});
+
+describe('GET /api/mainsite/modelos e /api/calculadora/modelos (catálogo via Vertex)', () => {
+  it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
+    const res = await dispatch('/api/mainsite/modelos', { ADMIN_BEARER_TOKEN: TOKEN });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('VERTEX_SA_KEY não configurada.');
+  });
+
+  it('lista gemini flash/pro na rota mainsite com id de publishers/google/models/<id>', async () => {
+    runtime.listModels = [
+      { name: 'publishers/google/models/gemini-3.1-pro-preview' },
+      { name: 'publishers/google/models/gemini-2.5-flash', displayName: 'Gemini 2.5 Flash' },
+      { name: 'publishers/google/models/imagen-4.0-generate-001' },
+    ];
+    const res = await dispatch('/api/mainsite/modelos', {
+      ADMIN_BEARER_TOKEN: TOKEN,
+      VERTEX_SA_KEY: '{"sa":"x"}',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; models: ModelPayload[]; total: number };
+    expect(body.ok).toBe(true);
+    expect(body.total).toBe(2);
+    expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash', 'gemini-3.1-pro-preview']);
+    expect(body.models[0]?.api).toBe('vertex');
+    expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
+    expect(runtime.listRequests[0]).toEqual({ config: { pageSize: 1000 } });
+  });
+
+  it('serve o mesmo catálogo na rota calculadora', async () => {
+    runtime.listModels = [{ name: 'publishers/google/models/gemini-2.5-flash' }];
+    const res = await dispatch('/api/calculadora/modelos', {
+      ADMIN_BEARER_TOKEN: TOKEN,
+      VERTEX_SA_KEY: '{"sa":"x"}',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; models: ModelPayload[] };
+    expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+  });
+});

--- a/admin-motor/src/index.test.ts
+++ b/admin-motor/src/index.test.ts
@@ -88,7 +88,9 @@ describe('GET /api/mainsite/modelos e /api/calculadora/modelos (catálogo via Ve
     expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash', 'gemini-3.1-pro-preview']);
     expect(body.models[0]?.api).toBe('vertex');
     expect(runtime.constructorOptions[0]?.saKeyJson).toBe('{"sa":"x"}');
-    expect(runtime.listRequests[0]).toEqual({ config: { pageSize: 1000 } });
+    expect(runtime.listRequests[0]).toEqual({
+      config: { pageSize: 1000, httpOptions: { timeout: 20_000 } },
+    });
   });
 
   it('serve o mesmo catálogo na rota calculadora', async () => {

--- a/admin-motor/src/index.test.ts
+++ b/admin-motor/src/index.test.ts
@@ -93,6 +93,21 @@ describe('GET /api/mainsite/modelos e /api/calculadora/modelos (catálogo via Ve
     });
   });
 
+  it('com location regional omite modelos preview/exp (global-only) também aqui', async () => {
+    runtime.listModels = [
+      { name: 'publishers/google/models/gemini-3.1-pro-preview' },
+      { name: 'publishers/google/models/gemini-2.5-flash' },
+    ];
+    const res = await dispatch('/api/mainsite/modelos', {
+      ADMIN_BEARER_TOKEN: TOKEN,
+      VERTEX_SA_KEY: '{"sa":"x"}',
+      VERTEX_LOCATION: 'us-central1',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { models: ModelPayload[] };
+    expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+  });
+
   it('serve o mesmo catálogo na rota calculadora', async () => {
     runtime.listModels = [{ name: 'publishers/google/models/gemini-2.5-flash' }];
     const res = await dispatch('/api/calculadora/modelos', {

--- a/admin-motor/src/index.ts
+++ b/admin-motor/src/index.ts
@@ -421,7 +421,7 @@ const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMo
 
   const allModels = new Map<string, ModelOption>();
 
-  const pager = await ai.models.list({ config: { pageSize: 1000 } });
+  const pager = await ai.models.list({ config: { pageSize: 1000, httpOptions: { timeout: 20_000 } } });
   for await (const m of pager) {
     if (!m.name) continue;
 

--- a/admin-motor/src/index.ts
+++ b/admin-motor/src/index.ts
@@ -1,7 +1,7 @@
-import { GoogleGenAI } from '@google/genai';
 import type { Context } from 'hono';
 import { Hono } from 'hono';
 import { toHeaders } from '../../functions/api/_lib/mainsite-admin';
+import { VertexGenAI } from './handlers/_shared/vertex';
 import { handleAstrologoEnviarEmailPost } from './handlers/astrologoEmail';
 import { handleCfdnsZonesGet } from './handlers/cfdnsZones';
 import { handleCleanupDeploymentsGet, handleCleanupDeploymentsPost } from './handlers/cfpwCleanup';
@@ -259,6 +259,9 @@ type AdminMotorEnv = {
   MAESTRO_GROK_API_KEY?: unknown;
   MAESTRO_PERPLEXITY_API_KEY?: unknown;
   GEMINI_API_KEY?: unknown;
+  VERTEX_SA_KEY?: unknown;
+  VERTEX_PROJECT?: unknown;
+  VERTEX_LOCATION?: unknown;
   CLOUDFLARE_PW?: unknown;
   CF_ACCOUNT_ID?: unknown;
   RESEND_API_KEY?: unknown;
@@ -286,6 +289,9 @@ type ResolvedAdminMotorEnv = {
   MAESTRO_GROK_API_KEY?: string;
   MAESTRO_PERPLEXITY_API_KEY?: string;
   GEMINI_API_KEY?: string;
+  VERTEX_SA_KEY?: string;
+  VERTEX_PROJECT?: string;
+  VERTEX_LOCATION?: string;
   CLOUDFLARE_PW?: string;
   CF_ACCOUNT_ID?: string;
   RESEND_API_KEY?: string;
@@ -381,6 +387,9 @@ const resolveRuntimeEnv = async (env: AdminMotorEnv): Promise<ResolvedAdminMotor
   MAESTRO_GROK_API_KEY: await readSecretString(env.MAESTRO_GROK_API_KEY),
   MAESTRO_PERPLEXITY_API_KEY: await readSecretString(env.MAESTRO_PERPLEXITY_API_KEY),
   GEMINI_API_KEY: await readSecretString(env.GEMINI_API_KEY),
+  VERTEX_SA_KEY: await readSecretString(env.VERTEX_SA_KEY),
+  VERTEX_PROJECT: await readSecretString(env.VERTEX_PROJECT),
+  VERTEX_LOCATION: await readSecretString(env.VERTEX_LOCATION),
   CLOUDFLARE_PW: await readSecretString(env.CLOUDFLARE_PW),
   CF_ACCOUNT_ID: await readSecretString(env.CF_ACCOUNT_ID),
   RESEND_API_KEY: await readSecretString(env.RESEND_API_KEY),
@@ -396,13 +405,19 @@ const resolveRuntimeEnv = async (env: AdminMotorEnv): Promise<ResolvedAdminMotor
   ADMIN_BEARER_TOKEN: await readSecretString(env.ADMIN_BEARER_TOKEN),
 });
 
+const DEFAULT_VERTEX_LOCATION = 'global';
+
 const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMotorEnv): Promise<ModelOption[]> => {
-  const apiKey = env.GEMINI_API_KEY;
-  if (!apiKey) {
-    throw new Error('GEMINI_API_KEY não configurada.');
+  const saKeyJson = env.VERTEX_SA_KEY;
+  if (!saKeyJson) {
+    throw new Error('VERTEX_SA_KEY não configurada.');
   }
 
-  const ai = new GoogleGenAI({ apiKey });
+  const ai = new VertexGenAI({
+    saKeyJson,
+    project: env.VERTEX_PROJECT,
+    location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
+  });
 
   const allModels = new Map<string, ModelOption>();
 
@@ -410,7 +425,8 @@ const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMo
   for await (const m of pager) {
     if (!m.name) continue;
 
-    const id = m.name.replace('models/', '');
+    // Vertex retorna "publishers/google/models/<id>" (AI Studio retornava "models/<id>").
+    const id = m.name.split('/').pop() ?? '';
     const lower = id.toLowerCase();
     const isFlashOrPro = lower.includes('flash') || lower.includes('pro');
     const isGemini = lower.startsWith('gemini');
@@ -422,7 +438,7 @@ const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMo
       allModels.set(id, {
         id,
         displayName: m.displayName || formatModelName(id),
-        api: 'sdk',
+        api: 'vertex',
         vision: hasVision,
       });
     }

--- a/admin-motor/src/index.ts
+++ b/admin-motor/src/index.ts
@@ -6,7 +6,7 @@ import { handleAstrologoEnviarEmailPost } from './handlers/astrologoEmail';
 import { handleCfdnsZonesGet } from './handlers/cfdnsZones';
 import { handleCleanupDeploymentsGet, handleCleanupDeploymentsPost } from './handlers/cfpwCleanup';
 import { handleOraculoCronGet, handleOraculoCronPut } from './handlers/oraculoCron';
-import { handleOraculoModelosGet } from './handlers/oraculoModelos';
+import { handleOraculoModelosGet, isGlobalOnlyModelId } from './handlers/oraculoModelos';
 import { resolveAdminBearerToken, validatePutAuth } from './handlers/routes/_lib/auth';
 import {
   onRequestGet as handleAdminhubConfigGet,
@@ -413,11 +413,9 @@ const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMo
     throw new Error('VERTEX_SA_KEY não configurada.');
   }
 
-  const ai = new VertexGenAI({
-    saKeyJson,
-    project: env.VERTEX_PROJECT,
-    location: env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION,
-  });
+  const location = env.VERTEX_LOCATION || DEFAULT_VERTEX_LOCATION;
+  const regional = location !== DEFAULT_VERTEX_LOCATION;
+  const ai = new VertexGenAI({ saKeyJson, project: env.VERTEX_PROJECT, location });
 
   const allModels = new Map<string, ModelOption>();
 
@@ -431,6 +429,9 @@ const fetchMainsiteGeminiModels = async (_request: Request, env: ResolvedAdminMo
     const isFlashOrPro = lower.includes('flash') || lower.includes('pro');
     const isGemini = lower.startsWith('gemini');
     if (!isGemini || !isFlashOrPro) continue;
+    // O modelo escolhido aqui é persistido e depois chamado na location
+    // configurada: numa região, preview/exp do catálogo global dariam 404.
+    if (regional && isGlobalOnlyModelId(id)) continue;
 
     const hasVision = lower.includes('vision') || lower.includes('pro') || lower.includes('flash');
 

--- a/admin-motor/wrangler.json
+++ b/admin-motor/wrangler.json
@@ -44,6 +44,11 @@
       "secret_name": "gemini-api-key"
     },
     {
+      "binding": "VERTEX_SA_KEY",
+      "store_id": "df90c0935ba1460899c3c2c457548a90",
+      "secret_name": "vertex-sa-key"
+    },
+    {
       "binding": "MAESTRO_DEEPSEEK_API_KEY",
       "store_id": "df90c0935ba1460899c3c2c457548a90",
       "secret_name": "MAESTRO_DEEPSEEK_API_KEY"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "admin-app",
-  "version": "2.15.15",
+  "version": "2.15.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-app",
-      "version": "2.15.15",
+      "version": "2.15.16",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
-        "@google/genai": "^2.15.0",
         "@radix-ui/react-dialog": "^1.1.23",
         "@tanstack/react-query": "^5.101.4",
         "@tiptap/core": "^3.29.2",
@@ -1432,30 +1431,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
-    },
-    "node_modules/@google/genai": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.15.0.tgz",
-      "integrity": "sha512-Q41TvqwBQ9NcmWdh6qxY5qrpg+0FaVHD7febQoH007pykxzco4ohScBUP4BBBy+Q8j5D8euIBSRIBDfWuNVCKA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2978,63 +2953,6 @@
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
-      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
-      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.7",
@@ -4747,6 +4665,7 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -4771,12 +4690,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
     },
     "node_modules/@types/sanitize-html": {
       "version": "2.16.1",
@@ -5319,15 +5232,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -5467,15 +5371,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -5535,12 +5430,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-image-size": {
       "version": "0.6.4",
@@ -5770,15 +5659,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -5789,6 +5669,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6000,15 +5881,6 @@
       "license": "BSD",
       "dependencies": {
         "underscore": "^1.13.1"
-      }
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -6340,12 +6212,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6402,29 +6268,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -6501,18 +6344,6 @@
         "node": ">=18.3.0"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -6526,34 +6357,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/gaxios": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
-      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/gcp-metadata": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
-      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -6635,32 +6438,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/google-auth-library": {
-      "version": "10.6.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
-      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^7.1.4",
-        "gcp-metadata": "8.1.2",
-        "google-logging-utils": "1.1.3",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/google-logging-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
-      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/happy-dom": {
@@ -6752,19 +6529,6 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "entities": "^7.0.1"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -7022,15 +6786,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -7075,27 +6830,6 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/jwa": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-equal-constant-time": "^1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/jws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-      "license": "MIT",
-      "dependencies": {
-        "jwa": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7548,12 +7282,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/lop": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/lop/-/lop-0.4.2.tgz",
@@ -7811,6 +7539,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -7837,44 +7566,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -8044,19 +7735,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pako": {
@@ -8426,29 +8104,6 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.1",
-        "@protobufjs/fetch": "^1.1.1",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.1",
-        "@types/node": ">=13.7.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8610,15 +8265,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
@@ -8702,26 +8348,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/sanitize-html": {
       "version": "2.17.6",
@@ -9330,6 +8956,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -9640,15 +9267,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -9820,6 +9438,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-app",
   "private": true,
-  "version": "2.15.15",
+  "version": "2.15.16",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.5",
-    "@google/genai": "^2.15.0",
     "@radix-ui/react-dialog": "^1.1.23",
     "@tanstack/react-query": "^5.101.4",
     "@tiptap/core": "^3.29.2",
@@ -136,7 +135,6 @@
     "@xmldom/xmldom": "^0.9.10",
     "ws": "8.21.0",
     "esbuild": "0.28.1",
-    "protobufjs": "7.6.5",
     "@babel/core": "7.29.6",
     "linkify-it": "5.0.2",
     "sharp": "0.35.3"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.15.15';
+const APP_VERSION = 'APP v02.15.16';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',

--- a/src/modules/maestro-ai/MaestroAiModule.test.tsx
+++ b/src/modules/maestro-ai/MaestroAiModule.test.tsx
@@ -92,6 +92,15 @@ describe('MaestroAiModule — credencial do Gemini é gerida pela infraestrutura
     });
     expect(campo.disabled).toBe(true);
     expect(campo.placeholder).toContain('VERTEX_SA_KEY');
+
+    // O aviso não pode viver só no placeholder: campo desabilitado não recebe
+    // foco de teclado e o texto fica visualmente cortado. Precisa ser texto
+    // visível e associado ao campo para leitores de tela.
+    const aviso = screen.getByText(/credencial de infraestrutura/i);
+    expect(aviso).toBeVisible();
+    expect(aviso.textContent).toContain('VERTEX_SA_KEY');
+    expect(campo.getAttribute('aria-describedby')).toBe(aviso.id);
+    expect(aviso.id).toBeTruthy();
   });
 
   it('salvar continua funcionando com os demais ajustes, sem chave do Gemini no payload', async () => {

--- a/src/modules/maestro-ai/MaestroAiModule.test.tsx
+++ b/src/modules/maestro-ai/MaestroAiModule.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2026 LCV Ideas & Software
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationProvider } from '../../components/Notification';
+import { MaestroAiModule } from './MaestroAiModule';
+
+const AGENT_KEYS = ['claude', 'codex', 'gemini', 'deepseek', 'grok', 'perplexity'] as const;
+
+const rate = { input_usd_per_million: 1, output_usd_per_million: 2 };
+
+const settingsPayload = {
+  ok: true,
+  settings: {
+    protocol_text:
+      'Protocolo editorial de teste com mais de cem caracteres para satisfazer o backend em cenários reais de gravação.',
+    max_cost_usd: 5,
+    max_runtime_minutes: null,
+    max_cycles: 2,
+    rates: Object.fromEntries(AGENT_KEYS.map((key) => [key, rate])),
+    models: Object.fromEntries(AGENT_KEYS.map((key) => [key, `${key}-model`])),
+    agents: AGENT_KEYS.map((key) => ({
+      key,
+      label: key,
+      secret_name: key === 'gemini' ? 'VERTEX_SA_KEY' : `MAESTRO_${key.toUpperCase()}_API_KEY`,
+      configured: true,
+      runtime_ready: true,
+      financially_ready: true,
+      model: `${key}-model`,
+      rates: rate,
+    })),
+    updated_at: '2026-08-09T00:00:00Z',
+  },
+};
+
+const putBodies: unknown[] = [];
+
+const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = String(input);
+  if (url.includes('/api/maestro-ai/settings')) {
+    if (init?.method === 'PUT') {
+      putBodies.push(JSON.parse(String(init.body)));
+    }
+    return new Response(JSON.stringify(settingsPayload), { status: 200 });
+  }
+  if (url.includes('/api/maestro-ai/sessions')) {
+    return new Response(JSON.stringify({ ok: true, sessions: [] }), { status: 200 });
+  }
+  return new Response(JSON.stringify({ ok: true }), { status: 200 });
+});
+
+const renderModule = () =>
+  render(
+    <NotificationProvider>
+      <MaestroAiModule />
+    </NotificationProvider>,
+  );
+
+const settingsSection = () => within(screen.getByRole('region', { name: /Configurações/i }));
+
+const geminiKeyField = (): HTMLInputElement | undefined => {
+  const inputs = Array.from(document.querySelectorAll('input[type="password"]'));
+  return inputs.find((element) => /VERTEX_SA_KEY/i.test(element.getAttribute('placeholder') ?? '')) as
+    | HTMLInputElement
+    | undefined;
+};
+
+beforeEach(() => {
+  putBodies.length = 0;
+  fetchMock.mockClear();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('MaestroAiModule — credencial do Gemini é gerida pela infraestrutura', () => {
+  it('desabilita o campo de chave do Gemini e explica onde a credencial vive', async () => {
+    renderModule();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const campo = await waitFor(() => {
+      const found = geminiKeyField();
+      expect(found).toBeDefined();
+      return found as HTMLInputElement;
+    });
+    expect(campo.disabled).toBe(true);
+    expect(campo.placeholder).toContain('VERTEX_SA_KEY');
+  });
+
+  it('salvar continua funcionando com os demais ajustes, sem chave do Gemini no payload', async () => {
+    renderModule();
+    await waitFor(() => expect(settingsSection().getByRole('button', { name: 'Salvar' })).toBeEnabled());
+
+    await userEvent.click(settingsSection().getByRole('button', { name: 'Salvar' }));
+
+    await waitFor(() => expect(putBodies).toHaveLength(1));
+    const body = putBodies[0] as { api_keys?: Record<string, string>; protocol_text?: string };
+    expect(Object.keys(body.api_keys ?? {})).not.toContain('gemini');
+    expect(body.protocol_text).toContain('Protocolo editorial de teste');
+  });
+});

--- a/src/modules/maestro-ai/MaestroAiModule.tsx
+++ b/src/modules/maestro-ai/MaestroAiModule.tsx
@@ -535,7 +535,9 @@ export function MaestroAiModule() {
     setSavingSettings(true);
     try {
       const api_keys = Object.fromEntries(
-        AGENTS.map((agent) => [agent.key, apiKeys[agent.key].trim()]).filter(([, value]) => Boolean(value)),
+        AGENTS.filter((agent) => agent.key !== 'gemini')
+          .map((agent) => [agent.key, apiKeys[agent.key].trim()])
+          .filter(([, value]) => Boolean(value)),
       );
       const data = await readJson<{ ok: true; settings: MaestroSettings }>(
         await fetch('/api/maestro-ai/settings', {
@@ -1206,6 +1208,11 @@ export function MaestroAiModule() {
               <div style={{ display: 'grid', gap: 10 }}>
                 {AGENTS.map((agent) => {
                   const saved = settings?.agents.find((item) => item.key === agent.key);
+                  // O Gemini roda no Vertex AI: a credencial é a service account
+                  // compartilhada da frota, provisionada na infraestrutura. Editá-la
+                  // aqui rotacionaria a chave dos demais apps, então o campo fica
+                  // apenas informativo.
+                  const infraManaged = agent.key === 'gemini';
                   return (
                     <div
                       key={agent.key}
@@ -1215,12 +1222,15 @@ export function MaestroAiModule() {
                       <strong>{agent.label}</strong>
                       <input
                         type="password"
-                        value={apiKeys[agent.key]}
+                        value={infraManaged ? '' : apiKeys[agent.key]}
                         onChange={(event) => setApiKeys((current) => ({ ...current, [agent.key]: event.target.value }))}
+                        disabled={infraManaged}
                         placeholder={
-                          saved?.configured
-                            ? 'Chave já configurada; preencha apenas para substituir'
-                            : 'Informe a chave'
+                          infraManaged
+                            ? `Credencial de infraestrutura (${saved?.secret_name ?? 'VERTEX_SA_KEY'}): service account do Vertex AI, compartilhada pela frota`
+                            : saved?.configured
+                              ? 'Chave já configurada; preencha apenas para substituir'
+                              : 'Informe a chave'
                         }
                         autoComplete="off"
                       />

--- a/src/modules/maestro-ai/MaestroAiModule.tsx
+++ b/src/modules/maestro-ai/MaestroAiModule.tsx
@@ -1213,6 +1213,7 @@ export function MaestroAiModule() {
                   // aqui rotacionaria a chave dos demais apps, então o campo fica
                   // apenas informativo.
                   const infraManaged = agent.key === 'gemini';
+                  const infraNoteId = `maestro-key-note-${agent.key}`;
                   return (
                     <div
                       key={agent.key}
@@ -1225,9 +1226,10 @@ export function MaestroAiModule() {
                         value={infraManaged ? '' : apiKeys[agent.key]}
                         onChange={(event) => setApiKeys((current) => ({ ...current, [agent.key]: event.target.value }))}
                         disabled={infraManaged}
+                        {...(infraManaged ? { 'aria-describedby': infraNoteId } : {})}
                         placeholder={
                           infraManaged
-                            ? `Credencial de infraestrutura (${saved?.secret_name ?? 'VERTEX_SA_KEY'}): service account do Vertex AI, compartilhada pela frota`
+                            ? `Credencial de infraestrutura (${saved?.secret_name ?? 'VERTEX_SA_KEY'})`
                             : saved?.configured
                               ? 'Chave já configurada; preencha apenas para substituir'
                               : 'Informe a chave'
@@ -1237,6 +1239,13 @@ export function MaestroAiModule() {
                       <span className="status-pill">
                         {saved?.runtime_ready ? 'ativa' : saved?.configured ? 'salva' : 'pendente'}
                       </span>
+                      {infraManaged ? (
+                        <p id={infraNoteId} style={{ gridColumn: '2 / -1', margin: 0, color: '#64748b', fontSize: 13 }}>
+                          Credencial de infraestrutura: a service account do Vertex AI (
+                          {saved?.secret_name ?? 'VERTEX_SA_KEY'}) é compartilhada por todos os apps da frota e
+                          provisionada fora deste painel.
+                        </p>
+                      ) : null}
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Escopo

Onda 4 do programa Gemini AI Studio → Vertex AI (ondas 0–3 já em produção: calculadora, mainsite, astrologo, oraculo). Todo consumo de IA do `admin-motor` passa a autenticar por **service account** (JWT RS256 → OAuth2, escopo `cloud-platform`) contra `aiplatform.googleapis.com`, sem API key.

Consumidores migrados (6 handlers + o roteador):

| Superfície | Rota / uso |
| --- | --- |
| `oraculoModelos.ts` | `GET /api/oraculo/modelos`, `GET /api/astrologo/modelos` |
| `index.ts` (`fetchMainsiteGeminiModels`) | `GET /api/mainsite/modelos`, `GET /api/calculadora/modelos` |
| `routes/mainsite/ai/transform.ts` | transform de texto do editor MainSite |
| `routes/mainsite/gemini-import.ts` | import de conversas do Gemini Share |
| `routes/mainsite/post-summaries.ts` | resumos OG/JSON-LD dos posts |
| `routes/news/discover.ts` | camada opcional de descoberta de feeds |
| `routes/maestro-ai/sessions.ts` | provider `gemini` do Maestro AI |

Prompts, contratos de rota, códigos de status e mensagens de negócio permanecem inalterados — só a autenticação, o transporte e o nome do secret exigido mudam.

## Decisões técnicas

- **Cliente compartilhado** `admin-motor/src/handlers/_shared/vertex.ts`, portado do que está em produção nas ondas 1–3: cache de token por identidade de chave com margem de 300s, single-flight na mint, timeout próprio de 20s na mint, `VertexHttpError` com status + operação de origem, `fetch` desacoplado de `this` (workerd), project derivado do `project_id` da SA quando `VERTEX_PROJECT` não está configurado.
- **`models.list` novo neste PR**: o catálogo de publisher models existe **apenas** no host global `v1beta1` (`GET https://aiplatform.googleapis.com/v1beta1/publishers/google/models`) — o `v1` e os hosts regionais respondem 404. Verificado empiricamente com token da própria SA antes de escrever o código. A geração continua no `v1`. Os `name` vêm como `publishers/google/models/<id>`, daí a mudança na extração do id.
- **`responseSchema` (OpenAPI) transportado no `generationConfig`** para o import de conversas — os dois campos (`responseSchema` e `responseJsonSchema`) foram sondados no `v1` e ambos retornam 200; mantive o `responseSchema` que o handler já usava.
- **Enums `HarmCategory`/`HarmBlockThreshold` → literais REST** equivalentes.
- **Timeouts por chamada**: 20s `countTokens`, 80s `generateContent` (paridade com a frota).
- **Credencial**: novo binding `VERTEX_SA_KEY` no `admin-motor/wrangler.json` apontando para o secret `vertex-sa-key` do Secrets Store — **a mesma SA que o `mainsite-motor` já consome em produção**, então nada precisa ser provisionado. Por isso o painel do Maestro AI passa a recusar gravação de chave Gemini pela UI (gravar ali rotacionaria a credencial dos outros apps) e exibe `VERTEX_SA_KEY` como secret do provider. `VERTEX_PROJECT` e `VERTEX_LOCATION` são opcionais (defaults: `project_id` da SA e `global`).
- **`resolveProviderModel` manteve a assinatura original** `(agent, apiKey)`; o gemini resolve pelo catálogo do Vertex numa função à parte, chamada de `callProvider`, onde o `env` está disponível. Assim os testes pré-existentes do hook seguem intactos.
- **Removidos**: dependência direta `@google/genai` e o override órfão de `protobufjs` (só existia para essa árvore).

## O que NÃO está neste PR

Os bindings legados `GEMINI_API_KEY`/`MAESTRO_GEMINI_API_KEY` e sua resolução em `index.ts` continuam declarados, sem consumidor. Eles saem na fase de descomissionamento, junto com a remoção dos secrets equivalentes em toda a frota — remover só as declarações agora deixaria o secret órfão no store sem ganho.

## Testes

TDD handler a handler (RED observado antes de cada implementação): 60 arquivos / **602 testes** no `admin-motor` e 54 / **363** na raiz, todos verdes. Novos: suíte do cliente Vertex (41, incluindo paginação de `models.list`, host global com location regional e `VertexHttpError` com `operation: 'listModels'`) e um arquivo por handler migrado.

A derivação de project a partir da SA com `project` vazio (o resolver de secrets do `admin-motor` devolve `''`, não `undefined`) ganhou teste dedicado, validado por mutação: trocando `||` por `??` no cliente o teste falha; restaurado, passa.

## Portões

`typecheck:admin-motor`, `lint`, `biome`, `test`, `test:admin-motor`, `build` e `git diff --check` — todos com exit code 0 no HEAD deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)