### PR TITLE
fix: aposenta o modelo Anthropic datado da sondagem do Maestro AI (v02.15.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [APP v02.15.24] — 17/08/2026
+
+### Removido
+
+- **Modelo Anthropic datado aposentado da sondagem do Maestro AI.** Sai
+  `claude-opus-4-1-20250805` da lista de candidatos Claude em
+  `admin-motor/src/handlers/routes/maestro-ai/sessions.ts` — o próprio
+  comentário do código agendava a remoção para a aposentadoria upstream de
+  05/08/2026. Efeito prático: a seleção por sonda deixa de gastar uma tentativa
+  num id morto; o fallback (`claude-fable-5`) e os demais candidatos ficam
+  inalterados. Fecha a issue #472.
+
 ## [APP v02.15.23] — 15/08/2026
 
 ### Alterado

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **Operator admin dashboard** for a multi-app Cloudflare workspace. Single-tenant by design: it's the operator's control plane for moderation, configuration, AI model selection, DNS, Pages/Workers ops, and operational telemetry across a fleet of public apps that share a single Cloudflare D1 database.
 
-**Status.** Stable. Current internal source version: **APP v02.15.23**. The last
+**Status.** Stable. Current internal source version: **APP v02.15.24**. The last
 historical tagged release is `v02.15.22`; web deployments after that point keep
 their visible version and changelog without creating package, tag, or GitHub
 Release artifacts. See [CHANGELOG.md](./CHANGELOG.md) for the full history.
@@ -24,6 +24,7 @@ The version history at a glance:
 
 | Release         | Scope                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`APP v02.15.24`** | **Aposenta o modelo Anthropic datado da lista de sondagem do Maestro AI.** Remove `claude-opus-4-1-20250805` (aposentado upstream em 05/08/2026) dos candidatos Claude em `sessions.ts`; a seleção por sonda deixa de tentar um id morto. Versão interna de fonte, sem tag ou GitHub Release. |
 | **`APP v02.15.23`** | **Automação e deploy official-only.** Substitui controladores e validadores próprios por recursos nativos do GitHub e Actions oficiais, reduz permissões, preserva a fila nativa com checks reais e passa os três deploys Cloudflare para a Wrangler Action oficial. É uma versão interna de fonte, sem tag ou GitHub Release. |
 | **`v02.15.22`** | **Corrige a atribuição da baseline de segurança no `SECURITY.md`.** O parágrafo de _Supported status_ acompanhava o número da release corrente e passava a atribuir a ela as correções de Hono, `brace-expansion`, Undici e PostCSS entregues na v02.15.15. |
 | **`v02.15.21`** | **Descomissiona os bindings legados do AI Studio.** Saem `GEMINI_API_KEY` e `MAESTRO_GEMINI_API_KEY` do `admin-motor/wrangler.json`, os tipos e a resolução em `index.ts` e o alias no resolver de secrets das Pages Functions. Nenhum código lia essas chaves desde a migração para o Vertex AI. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported status
 
-Latest supported source target: APP v02.15.23 on the current `main` branch. The
+Latest supported source target: APP v02.15.24 on the current `main` branch. The
 last historical tagged release is v02.15.22; this web application no longer
 creates package, tag, or GitHub Release artifacts for source-only revisions.
 The current dependency security baseline was

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2352,13 +2352,7 @@ const MODEL_RESOLUTION: Partial<
   claude: {
     endpoint: 'https://api.anthropic.com/v1/models',
     auth: 'x-api-key',
-    candidates: [
-      'claude-fable-5',
-      'claude-opus-5',
-      'claude-opus-4-8',
-      'claude-opus-4-7',
-      'claude-sonnet-5',
-    ],
+    candidates: ['claude-fable-5', 'claude-opus-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-5'],
     fallback: 'claude-fable-5',
   },
   deepseek: {

--- a/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
+++ b/admin-motor/src/handlers/routes/maestro-ai/sessions.ts
@@ -2358,8 +2358,6 @@ const MODEL_RESOLUTION: Partial<
       'claude-opus-4-8',
       'claude-opus-4-7',
       'claude-sonnet-5',
-      // Retires 2026-08-05; scheduled for removal with the retirement.
-      'claude-opus-4-1-20250805',
     ],
     fallback: 'claude-fable-5',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-app",
-  "version": "2.15.23",
+  "version": "2.15.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-app",
-      "version": "2.15.23",
+      "version": "2.15.24",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.5",
         "@radix-ui/react-dialog": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-app",
   "private": true,
-  "version": "2.15.23",
+  "version": "2.15.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ import { useNavigate, useParams } from './router-context';
 
 export type { ModuleId };
 
-const APP_VERSION = 'APP v02.15.23';
+const APP_VERSION = 'APP v02.15.24';
 
 const MODULE_LABELS: Record<Exclude<ModuleId, 'overview'>, string> = {
   astrologo: 'Astrólogo',


### PR DESCRIPTION
Remove `claude-opus-4-1-20250805` dos candidatos Claude em `admin-motor/src/handlers/routes/maestro-ai/sessions.ts` — o comentário do próprio código agendava a remoção para a aposentadoria upstream de 05/08/2026 (verificação de 17/08 na issue: 12 dias vencida). A seleção por sonda deixa de gastar uma tentativa num id morto; o fallback (`claude-fable-5`) e os demais candidatos ficam inalterados.

Superfícies de versão sincronizadas em **v02.15.24**: package.json, package-lock.json, README (status + tabela), SECURITY.md e CHANGELOG.

Portões locais todos verdes: `test:admin-motor` 620/620, `npm test` 359/359, lint, biome, `typecheck:admin-motor` 0/0, build, `format:public:check`.

Closes #472
Fixes ADMIAPP-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)