### PR TITLE
fix: restore dedicated Cloudflare admin credentials

### DIFF
--- a/admin-motor/wrangler.json
+++ b/admin-motor/wrangler.json
@@ -56,7 +56,12 @@
     {
       "binding": "CLOUDFLARE_PW",
       "store_id": "df90c0935ba1460899c3c2c457548a90",
-      "secret_name": "cloudflare-pw"
+      "secret_name": "admin-cloudflare-api-token"
+    },
+    {
+      "binding": "ADMIN_BEARER_TOKEN",
+      "store_id": "df90c0935ba1460899c3c2c457548a90",
+      "secret_name": "admin-motor-bearer-token"
     },
     {
       "binding": "CLOUDFLARE_DNS",


### PR DESCRIPTION
## O que mudou

- desacopla `admin-motor` do segredo compartilhado `cloudflare-pw`;
- vincula `CLOUDFLARE_PW` ao token operacional dedicado `admin-cloudflare-api-token`;
- adiciona `ADMIN_BEARER_TOKEN` em segredo próprio, evitando usar o token Cloudflare como bearer da aplicação.

## Causa

A revogação do token compartilhado interrompeu os módulos Cloudflare P&W e Purge de Deployments. O mesmo segredo também era consumido por `mainsite-motor`, portanto uma rotação cega teria ampliado o impacto.

## Evidência

- token operacional user-owned validado em 15/15 probes Cloudflare;
- preflight: 620 testes do motor, 359 testes gerais, typecheck, lint, Biome, formatação, build e Wrangler dry-run;
- canário da versão exata e pós-promoção: health verde, 6/6 capacidades, Pages cleanup GET read-only; nenhum deployment apagado;
- produção `admin-motor` v454 em 100%; `mainsite-motor` e `cloudflare-pw` permanecem intactos.