### PR TITLE
fix(email-sanitizer): strip tags in DOM-less fallback, keep line breaks, harden scheme check

### DIFF
--- a/src/lib/astrological-report.sanitizer.test.ts
+++ b/src/lib/astrological-report.sanitizer.test.ts
@@ -1,0 +1,60 @@
+// Regression tests for the e-mail sanitizer findings from the review threads
+// on PRs #1/#2/#3: DOMParser-less fallback must strip tags, structural tags
+// must keep their line breaks in the text output, and scheme checks must not
+// be bypassable with embedded control characters.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { astrologicalReportTestHooks } from './astrological-report';
+
+const { htmlToPlainText, sanitizeForEmail } = astrologicalReportTestHooks;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('htmlToPlainText', () => {
+  it('preserves line breaks from <br>, <p> and <li> in the DOM path', () => {
+    const text = htmlToPlainText(
+      '<p>Primeira linha</p><p>Segunda linha<br>terceira</p><ul><li>item um</li><li>item dois</li></ul>',
+    );
+    const lines = text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    expect(lines).toEqual(['Primeira linha', 'Segunda linha', 'terceira', 'item um', 'item dois']);
+  });
+
+  it('strips tags in the DOMParser-less fallback instead of leaking them', () => {
+    vi.stubGlobal('DOMParser', undefined);
+    const text = htmlToPlainText('<p>Texto &amp; s&iacute;ntese</p><script>alert(1)</script>');
+    expect(text).not.toMatch(/[<>]/);
+    expect(text).toContain('Texto & s');
+    // Break-producing tags still separate lines in the fallback.
+    const broken = htmlToPlainText('<p>um</p><p>dois</p>');
+    expect(
+      broken
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ).toEqual(['um', 'dois']);
+  });
+});
+
+describe('sanitizeForEmail', () => {
+  it('returns tag-free plain text when DOMParser is unavailable', () => {
+    vi.stubGlobal('DOMParser', undefined);
+    const out = sanitizeForEmail('<p>ola</p><iframe src="https://exemplo.com"></iframe>');
+    expect(out).not.toMatch(/[<>]/);
+    expect(out).toContain('ola');
+  });
+
+  it('removes attributes whose scheme hides behind embedded control characters', () => {
+    // DOMParser decodes &#x0d; into a raw CR inside the attribute value, so a
+    // plain startsWith('javascript:') check would miss it.
+    const out = sanitizeForEmail(
+      '<p data-x="java&#x0d;script:alert(1)">seguro</p><a href="https://exemplo.com/ok">link</a>',
+    );
+    expect(out).not.toContain('script:alert');
+    expect(out).toContain('seguro');
+    expect(out).toContain('https://exemplo.com/ok');
+  });
+});

--- a/src/lib/astrological-report.ts
+++ b/src/lib/astrological-report.ts
@@ -120,11 +120,26 @@ const formatPosicaoLabel = (pos: string): string => {
   return p;
 };
 
-/** Sanitiza HTML para uso em e-mail (tags seguras apenas) */
+/** Troca tags estruturais por quebras de linha antes da extração de texto,
+ *  para que `<br>`, `<p>`, `<li>` etc. não achatem o relatório texto. */
+const structuralTagsToLineBreaks = (html: string): string =>
+  html.replace(/<br\s*\/?>/gi, '\n').replace(/<\/(?:p|div|li|h[1-6]|tr|blockquote)>/gi, '\n');
+
+/** Converte HTML em texto puro (sem tags), preservando quebras de linha
+ *  estruturais; adequado para e-mail texto e canais apenas-texto. */
 const htmlToPlainText = (html: string): string => {
-  const safeHtml = stripInternalAnalysisMarkers(html);
+  const safeHtml = structuralTagsToLineBreaks(stripInternalAnalysisMarkers(html));
   if (typeof DOMParser === 'undefined') {
-    return safeHtml
+    // Fallback sem DOM: remove tags até estabilizar (uma passada única
+    // deixaria `<scr<script>ipt>` recompor uma tag) e decodifica as
+    // entidades básicas já tratadas antes.
+    let text = safeHtml;
+    let previous: string;
+    do {
+      previous = text;
+      text = text.replace(/<[^>]*>/g, '');
+    } while (text !== previous);
+    return text
       .split('&nbsp;')
       .join(' ')
       .split('&amp;')
@@ -140,6 +155,7 @@ const htmlToPlainText = (html: string): string => {
   return stripInternalAnalysisMarkers(parsed.body.textContent || '').trim();
 };
 
+/** Sanitiza HTML para uso em e-mail (tags seguras apenas). */
 const sanitizeForEmail = (html: string): string => {
   const safeHtml = stripInternalAnalysisMarkers(html);
   if (typeof DOMParser === 'undefined') {
@@ -161,13 +177,18 @@ const sanitizeForEmail = (html: string): string => {
     Array.from(node.attributes).forEach((attr) => {
       const name = attr.name.toLowerCase();
       const rawValue = attr.value.trim();
-      const lowerValue = rawValue.toLowerCase();
+      // Controles/espaços embutidos não podem esconder o esquema: o DOMParser
+      // decodifica `java&#x0d;script:` para um CR literal dentro do valor, que
+      // um startsWith direto deixaria passar.
+      const schemeProbe = Array.from(rawValue.toLowerCase())
+        .filter((ch) => ch.charCodeAt(0) > 0x20)
+        .join('');
 
       if (
         name.startsWith('on') ||
-        lowerValue.startsWith('javascript:') ||
-        lowerValue.startsWith('data:') ||
-        lowerValue.startsWith('vbscript:')
+        schemeProbe.startsWith('javascript:') ||
+        schemeProbe.startsWith('data:') ||
+        schemeProbe.startsWith('vbscript:')
       ) {
         node.removeAttribute(attr.name);
         return;
@@ -838,3 +859,8 @@ export function generateAstrologicalReport(mapa: MapaDetalhado): GeneratedReport
 
   return { html: htmlContent, text: textContent, summary };
 }
+
+export const astrologicalReportTestHooks = {
+  htmlToPlainText,
+  sanitizeForEmail,
+};


### PR DESCRIPTION
## O que muda

Três achados ainda vivos das threads de review dos PRs #1/#2/#3, todos em `src/lib/astrological-report.ts`:

1. **Fallback sem DOMParser vazava tags** — `htmlToPlainText` só decodificava entidades; como `sanitizeForEmail` delega para ele nesse runtime, o corpo do e-mail podia sair com tags cruas. Agora remove tags até estabilizar (evita `<scr<script>ipt>` recompor) antes da decodificação. Origem: thread no PR #3 (linha 75).
2. **Quebras de linha estruturais preservadas** — `<br>`, `</p>`, `</li>` etc. viram `\n` antes da extração de texto (novo helper `structuralTagsToLineBreaks`), em vez de achatar o relatório texto. Origem: thread no PR #3 (linha 69). O docstring deslocado apontado na linha 57 também foi corrigido.
3. **Check de esquema não é mais contornável por controles embutidos** — o DOMParser decodifica `java&#x0d;script:` para CR literal dentro do valor do atributo, que escapava do `startsWith`; a sonda de esquema agora ignora chars ≤ 0x20. Origem: thread no PR #2 (linha 81).

Expõe `astrologicalReportTestHooks` (mesmo padrão do `maestroAiTestHooks`) para testar os helpers privados.

## Testes

4 testes novos em `astrological-report.sanitizer.test.ts`, escritos vermelhos antes do fix. Suíte frontend completa 363/363; lint, biome, build e format:public:check verdes; admin-motor inalterado (622/622).

## Versão

Bump para APP v02.15.26 será adicionado a esta branch após o merge do #514 (evita conflito nas superfícies de versão).

> Rastreio segue a exceção de segurança do G4 (AGENTS.md): sem issue pública; a origem são threads de review já públicas nos PRs #1/#2/#3, que serão resolvidas com disposição após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)