### PR TITLE
fix(storage): restore least-privilege Secrets Store binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## [Unreleased]
 
+### Corrigido
+
+- **Fallback do token dedicado de armazenamento.** O ambiente bruto do
+  `admin-motor` tipa `CLOUDFLARE_STORAGE` como `SecretsStoreSecret`, lê o valor
+  pela chamada assíncrona `get()` e, se a leitura do binding opcional falhar,
+  preserva o fallback explícito para `CLOUDFLARE_PW` sem registrar valor ou
+  erro bruto. O binding versionado aponta para o secret ativo
+  `cloudflare-storage`, de escopo Workers, e mantém o token amplo apenas como
+  compatibilidade degradada. A credencial do environment de produção foi
+  verificada com `Secrets Store Write`, `D1 Write`, `Pages Write` e
+  `Workers Scripts Write`, cobrindo a validação do binding no deploy por CI.
+
+### Decidido
+
+- **Resend permanece como provedor do Astrólogo.** Os planos documentais de
+  migração para o Cloudflare Email Service foram revogados; o handler e o
+  binding `RESEND_API_KEY` continuam sendo o contrato vigente.
+
 ## [APP v02.15.26] — 20/08/2026
 
 ### Segurança

--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ npx wrangler secret put ENFORCE_JWT_VALIDATION --config admin-motor/wrangler.jso
 
 ### 6. Configure additional secrets
 
-Per `admin-motor/wrangler.json`'s `secrets_store_secrets` list, set values for the keys you intend to use (Vertex AI, Resend, JINA, Cloudflare DNS/Cache/Account-ID tokens, etc.). `VERTEX_SA_KEY` (Secret Store `vertex-sa-key`, the same Service Account the other LCV apps use) is required by every AI endpoint: `/api/{oraculo,astrologo,mainsite,calculadora}/modelos`, the MainSite editor transform, Gemini share import, post summaries, the optional news-discovery layer and the Maestro AI Gemini provider. Optional companions: `VERTEX_PROJECT` (defaults to the `project_id` inside the Service Account JSON) and `VERTEX_LOCATION` (defaults to `global`).
+Per `admin-motor/wrangler.json`'s `secrets_store_secrets` list, set values for the keys you intend to use (Vertex AI, Resend, JINA, Cloudflare DNS/Cache/Account-ID tokens, etc.). Resend is the canonical e-mail provider for the Astrólogo flow; configure `RESEND_API_KEY` when e-mail dispatch is enabled. There is no planned Cloudflare Email Service binding for this flow. `VERTEX_SA_KEY` (Secret Store `vertex-sa-key`, the same Service Account the other LCV apps use) is required by every AI endpoint: `/api/{oraculo,astrologo,mainsite,calculadora}/modelos`, the MainSite editor transform, Gemini share import, post summaries, the optional news-discovery layer and the Maestro AI Gemini provider. Optional companions: `VERTEX_PROJECT` (defaults to the `project_id` inside the Service Account JSON) and `VERTEX_LOCATION` (defaults to `global`).
+
+The storage routes use the least-privilege Secrets Store binding `CLOUDFLARE_STORAGE`, backed by the active Workers-scoped secret `cloudflare-storage`, and retain `CLOUDFLARE_PW` only as a degraded compatibility fallback.
 
 `GCP_SA_KEY` (Cloud Monitoring Service Account) is provisioned as a native Worker secret instead:
 

--- a/admin-motor/src/index.test.ts
+++ b/admin-motor/src/index.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import adminMotorConfig from '../wrangler.json';
 
 const runtime = vi.hoisted(() => {
   class MockVertexHttpError extends Error {
@@ -62,6 +64,11 @@ beforeEach(() => {
   runtime.listError = null;
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
 describe('GET /api/mainsite/modelos e /api/calculadora/modelos (catálogo via Vertex)', () => {
   it('retorna 500 quando VERTEX_SA_KEY está ausente', async () => {
     const res = await dispatch('/api/mainsite/modelos', { ADMIN_BEARER_TOKEN: TOKEN });
@@ -117,5 +124,71 @@ describe('GET /api/mainsite/modelos e /api/calculadora/modelos (catálogo via Ve
     expect(res.status).toBe(200);
     const body = (await res.json()) as { ok: boolean; models: ModelPayload[] };
     expect(body.models.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+  });
+});
+
+describe('Secrets Store de armazenamento no limite do Worker', () => {
+  const stubKvNamespaces = () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({
+        success: true,
+        errors: [],
+        messages: [],
+        result: [],
+        result_info: { page: 1, per_page: 20, total_count: 0, total_pages: 1 },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  it('declara o binding dedicado para o secret ativo cloudflare-storage', () => {
+    expect(adminMotorConfig.secrets_store_secrets).toContainEqual({
+      binding: 'CLOUDFLARE_STORAGE',
+      store_id: 'df90c0935ba1460899c3c2c457548a90',
+      secret_name: 'cloudflare-storage',
+    });
+  });
+
+  it('lê o binding assíncrono e faz o token dedicado prevalecer sobre CLOUDFLARE_PW', async () => {
+    const fetchMock = stubKvNamespaces();
+    const storageGet = vi.fn().mockResolvedValue(' storage-token ');
+    const fallbackGet = vi.fn().mockResolvedValue(' pw-token ');
+
+    const res = await dispatch('/api/cfpw/storage/kv/namespaces', {
+      ADMIN_BEARER_TOKEN: TOKEN,
+      CF_ACCOUNT_ID: 'acct-1',
+      CLOUDFLARE_STORAGE: { get: storageGet },
+      CLOUDFLARE_PW: { get: fallbackGet },
+    });
+
+    expect(res.status).toBe(200);
+    expect(storageGet).toHaveBeenCalledTimes(1);
+    expect(fallbackGet).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer storage-token');
+  });
+
+  it('usa CLOUDFLARE_PW quando get() do binding opcional de armazenamento rejeita', async () => {
+    const fetchMock = stubKvNamespaces();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const storageGet = vi.fn().mockRejectedValue(new Error('binding indisponível'));
+    const fallbackGet = vi.fn().mockResolvedValue('pw-token');
+
+    const res = await dispatch('/api/cfpw/storage/kv/namespaces', {
+      ADMIN_BEARER_TOKEN: TOKEN,
+      CF_ACCOUNT_ID: 'acct-1',
+      CLOUDFLARE_STORAGE: { get: storageGet },
+      CLOUDFLARE_PW: { get: fallbackGet },
+    });
+
+    expect(res.status).toBe(200);
+    expect(storageGet).toHaveBeenCalledTimes(1);
+    expect(fallbackGet).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('[admin-motor] secret:read-failed', {
+      binding: 'CLOUDFLARE_STORAGE',
+    });
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer pw-token');
   });
 });

--- a/admin-motor/src/index.ts
+++ b/admin-motor/src/index.ts
@@ -265,7 +265,7 @@ type AdminMotorEnv = {
   RESEND_API_KEY?: unknown;
   CLOUDFLARE_DNS?: unknown;
   CLOUDFLARE_CACHE?: unknown;
-  CLOUDFLARE_STORAGE?: unknown;
+  CLOUDFLARE_STORAGE: SecretsStoreSecret;
   GCP_SA_KEY?: unknown;
   GCP_PROJECT_ID?: unknown;
   JINA_API_KEY?: unknown;
@@ -371,6 +371,20 @@ const readSecretString = async (value: unknown): Promise<string> => {
   return '';
 };
 
+/**
+ * A API oficial do Secrets Store faz `get()` rejeitar em falhas de leitura.
+ * Nesse caso deixamos o valor vazio para que o núcleo de API use o fallback
+ * explícito CLOUDFLARE_PW, sem registrar valor nem erro bruto.
+ */
+const readStorageSecretString = async (value: SecretsStoreSecret, binding: string): Promise<string> => {
+  try {
+    return await readSecretString(value);
+  } catch {
+    console.warn('[admin-motor] secret:read-failed', { binding });
+    return '';
+  }
+};
+
 const resolveRuntimeEnv = async (env: AdminMotorEnv): Promise<ResolvedAdminMotorEnv> => ({
   ...(env.BIGDATA_DB !== undefined ? { BIGDATA_DB: env.BIGDATA_DB } : {}),
   MEDIA_BUCKET: env.MEDIA_BUCKET,
@@ -389,7 +403,7 @@ const resolveRuntimeEnv = async (env: AdminMotorEnv): Promise<ResolvedAdminMotor
   RESEND_API_KEY: await readSecretString(env.RESEND_API_KEY),
   CLOUDFLARE_DNS: await readSecretString(env.CLOUDFLARE_DNS),
   CLOUDFLARE_CACHE: await readSecretString(env.CLOUDFLARE_CACHE),
-  CLOUDFLARE_STORAGE: await readSecretString(env.CLOUDFLARE_STORAGE),
+  CLOUDFLARE_STORAGE: await readStorageSecretString(env.CLOUDFLARE_STORAGE, 'CLOUDFLARE_STORAGE'),
   GCP_SA_KEY: await readSecretString(env.GCP_SA_KEY),
   GCP_PROJECT_ID: await readSecretString(env.GCP_PROJECT_ID),
   JINA_API_KEY: await readSecretString(env.JINA_API_KEY),

--- a/admin-motor/wrangler.json
+++ b/admin-motor/wrangler.json
@@ -59,6 +59,11 @@
       "secret_name": "admin-cloudflare-api-token"
     },
     {
+      "binding": "CLOUDFLARE_STORAGE",
+      "store_id": "df90c0935ba1460899c3c2c457548a90",
+      "secret_name": "cloudflare-storage"
+    },
+    {
       "binding": "ADMIN_BEARER_TOKEN",
       "store_id": "df90c0935ba1460899c3c2c457548a90",
       "secret_name": "admin-motor-bearer-token"

--- a/src/modules/cfpw/tabs/storage/StorageTab.tsx
+++ b/src/modules/cfpw/tabs/storage/StorageTab.tsx
@@ -31,24 +31,24 @@ type StorageSubTab = 'kv' | 'd1' | 'r2';
 
 const KV_DISABLED_INSTRUCTIONS: Record<'sem-permissao' | 'indisponivel' | 'erro', string> = {
   'sem-permissao':
-    'Sem permissão para Workers KV: crie o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
-    'no Secrets Store ou amplie as permissões do token CLOUDFLARE_PW.',
+    'Sem permissão para Workers KV: verifique o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
+    'e o binding CLOUDFLARE_STORAGE, ou amplie as permissões do token CLOUDFLARE_PW.',
   indisponivel: 'Workers KV indisponível nesta conta Cloudflare — verifique se o produto está ativo no dashboard.',
   erro: 'Falha ao sondar o Workers KV na API Cloudflare — tente atualizar; se persistir, verifique o motor.',
 };
 
 const D1_DISABLED_INSTRUCTIONS: Record<'sem-permissao' | 'indisponivel' | 'erro', string> = {
   'sem-permissao':
-    'Sem permissão para D1: crie o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
-    'no Secrets Store ou amplie as permissões do token CLOUDFLARE_PW.',
+    'Sem permissão para D1: verifique o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
+    'e o binding CLOUDFLARE_STORAGE, ou amplie as permissões do token CLOUDFLARE_PW.',
   indisponivel: 'D1 indisponível nesta conta Cloudflare — verifique se o produto está ativo no dashboard.',
   erro: 'Falha ao sondar o D1 na API Cloudflare — tente atualizar; se persistir, verifique o motor.',
 };
 
 const R2_DISABLED_INSTRUCTIONS: Record<'sem-permissao' | 'indisponivel' | 'erro', string> = {
   'sem-permissao':
-    'Sem permissão para R2: crie o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
-    'no Secrets Store ou amplie as permissões do token CLOUDFLARE_PW.',
+    'Sem permissão para R2: verifique o token cloudflare-storage (Workers KV Storage Edit + D1 Edit + R2 Edit) ' +
+    'e o binding CLOUDFLARE_STORAGE, ou amplie as permissões do token CLOUDFLARE_PW.',
   indisponivel: 'R2 indisponível nesta conta Cloudflare — verifique se o produto está ativo no dashboard.',
   erro: 'Falha ao sondar o R2 na API Cloudflare — tente atualizar; se persistir, verifique o motor.',
 };


### PR DESCRIPTION
## Summary

- restore the Workers-scoped `CLOUDFLARE_STORAGE` Secrets Store binding for the active `cloudflare-storage` secret
- resolve the binding asynchronously and fall back to `CLOUDFLARE_PW` only when the dedicated binding is unavailable
- document Resend as the retained mail provider and cover precedence/fallback behavior with tests

Closes #470

## Validation

- [x] Relevant local checks were run or the change is documentation/configuration only.
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs.
- [x] Dependabot automation remains non-blocking for routine patch/minor updates.

Passed locally before commit: `npm test`, `npm run test:admin-motor`, `npm run lint`, `npm run biome`, `npm run typecheck:admin-motor`, `npm run build`, `npm run format:public:check`, Wrangler dry-run, and `npm audit --audit-level=high`.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] New deployment or cloud access uses short-lived credentials or OIDC where practical.

The credential value is held only in Cloudflare Secrets Store. The versioned configuration contains the binding metadata required by Wrangler; no token value is present.