### PR TITLE
fix(d1): retire unused calculator legacy tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Removido
+
+- **Duas tabelas D1 legadas da Calculadora.** A migração nativa `0002` e a
+  etapa de bootstrap `019` aposentam `calc_email_rate_limit` e
+  `calc_parametros_calculo`, ambas sem consumidor runtime e vazias no inventário
+  pré-operação. Um guard transacional recusa a remoção caso qualquer tabela
+  ganhe linhas ou se `calc_parametros_auditoria` — ainda usada pelo
+  `admin-motor` — estiver ausente. Testes cobrem sucesso, repetição idempotente e
+  rollback dos três desvios.
+
 ### Corrigido
 
 - **Fallback do token dedicado de armazenamento.** O ambiente bruto do

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ for your own database in:
 For a new, empty database, apply the versioned SQL files exactly once in lexical
 order. This includes migration `014a`, which materializes
 `astrologo_mapas.email` before migration 015, and migrations 017/018, which add
-saved-map ownership and durable AI-analysis jobs.
+saved-map ownership and durable AI-analysis jobs. Migration 019 retires the
+empty Calculadora legacy tables `calc_email_rate_limit` and
+`calc_parametros_calculo` while preserving `calc_parametros_auditoria`.
 
 ```bash
 for f in $(git ls-files 'db/migrations/*.sql' | sort); do
@@ -226,8 +228,10 @@ compatible database—apply the pending production migrations through Wrangler:
 npx wrangler d1 migrations apply BIGDATA_DB --remote --config wrangler.json
 ```
 
-Each new production change must be a backward-compatible, data-preserving
-migration because the previous Worker revision remains live until deploy.
+Each new production change must remain compatible with the previous Worker
+revision while it is live. A deliberate legacy-table retirement must be
+fail-closed on non-empty data, have a pre-apply export and Time Travel bookmark,
+and preserve every table still consumed by a deployed Worker.
 
 The canonical Astrólogo schema, rollout order, verification queries, and the
 `astrologo-config/modeloSintese` contract are documented in

--- a/db/admin-app-migrations/0002_remove_calc_legacy_tables.sql
+++ b/db/admin-app-migrations/0002_remove_calc_legacy_tables.sql
@@ -1,0 +1,37 @@
+-- Retire two empty Calculadora legacy tables after the runtime-consumer inventory.
+-- Wrangler applies D1 migrations transactionally: the CHECK guard aborts and
+-- rolls back the whole migration if either candidate gained data or if the
+-- active audit table is missing.
+
+CREATE TABLE IF NOT EXISTS calc_email_rate_limit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ip TEXT NOT NULL,
+    timestamp INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS calc_parametros_calculo (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chave TEXT NOT NULL,
+    valor TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE __admin_app_0002_calc_legacy_guard (
+    legacy_row_count INTEGER NOT NULL CHECK (legacy_row_count = 0),
+    active_audit_table_count INTEGER NOT NULL CHECK (active_audit_table_count = 1)
+);
+
+INSERT INTO __admin_app_0002_calc_legacy_guard (
+    legacy_row_count,
+    active_audit_table_count
+)
+SELECT
+    (SELECT COUNT(*) FROM calc_email_rate_limit)
+        + (SELECT COUNT(*) FROM calc_parametros_calculo),
+    (SELECT COUNT(*)
+     FROM sqlite_master
+     WHERE type = 'table' AND name = 'calc_parametros_auditoria');
+
+DROP TABLE calc_email_rate_limit;
+DROP TABLE calc_parametros_calculo;
+DROP TABLE __admin_app_0002_calc_legacy_guard;

--- a/db/migrations/007_bigdata_calc_tabelas_complementares.sql
+++ b/db/migrations/007_bigdata_calc_tabelas_complementares.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS calc_parametros_auditoria (
 -- ============================================================================
 -- TABELAS LEGADO (prefixo obrigatório: calc_)
 -- Existentes em calculadora-calc-db mas sem uso no código atual.
--- Mantidas para preservar histórico de dados antes do cutover.
+-- Preservadas nesta etapa histórica; a migration 019 só as remove se vazias.
 -- ============================================================================
 
 -- Legacy: rate-limit de e-mail gerenciado inline (antes do módulo rate-limit.mjs)
@@ -64,5 +64,5 @@ CREATE INDEX IF NOT EXISTS idx_calc_email_rate_limit_ip_timestamp
 -- As tabelas ativas (parametros_customizados e parametros_auditoria) são criadas
 -- inline no código via "CREATE TABLE IF NOT EXISTS" — esta migration garante que
 -- existam na bigdata_db antes do primeiro acesso.
--- As tabelas legado (email_rate_limit, parametros_calculo) devem ser populadas
--- via sync manual antes do cutover definitivo do calculadora-calc-db.
+-- As tabelas legado (email_rate_limit, parametros_calculo) não devem receber
+-- novos dados. A migration 019 encerra o contrato após um guard fail-closed.

--- a/db/migrations/019_bigdata_calc_remove_legacy_tables.sql
+++ b/db/migrations/019_bigdata_calc_remove_legacy_tables.sql
@@ -1,0 +1,37 @@
+-- admin-app / bigdata_db
+-- Migration 019: retire two empty legacy tables from the Calculadora domain.
+-- The guard makes bootstrap replay idempotent and refuses destructive cleanup
+-- if either candidate contains data or the active audit table is absent.
+
+CREATE TABLE IF NOT EXISTS calc_email_rate_limit (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ip TEXT NOT NULL,
+    timestamp INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS calc_parametros_calculo (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    chave TEXT NOT NULL,
+    valor TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE __admin_app_0002_calc_legacy_guard (
+    legacy_row_count INTEGER NOT NULL CHECK (legacy_row_count = 0),
+    active_audit_table_count INTEGER NOT NULL CHECK (active_audit_table_count = 1)
+);
+
+INSERT INTO __admin_app_0002_calc_legacy_guard (
+    legacy_row_count,
+    active_audit_table_count
+)
+SELECT
+    (SELECT COUNT(*) FROM calc_email_rate_limit)
+        + (SELECT COUNT(*) FROM calc_parametros_calculo),
+    (SELECT COUNT(*)
+     FROM sqlite_master
+     WHERE type = 'table' AND name = 'calc_parametros_auditoria');
+
+DROP TABLE calc_email_rate_limit;
+DROP TABLE calc_parametros_calculo;
+DROP TABLE __admin_app_0002_calc_legacy_guard;

--- a/src/lib/calculadora-legacy-migrations.test.mjs
+++ b/src/lib/calculadora-legacy-migrations.test.mjs
@@ -1,0 +1,116 @@
+import { readFileSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const migrationPaths = [
+  'db/migrations/019_bigdata_calc_remove_legacy_tables.sql',
+  'db/admin-app-migrations/0002_remove_calc_legacy_tables.sql',
+];
+
+const readMigration = (path) => readFileSync(`${root}/${path}`, 'utf8');
+const tableExists = (db, table) =>
+  db.prepare("SELECT 1 AS present FROM sqlite_master WHERE type = 'table' AND name = ?").get(table)?.present === 1;
+
+const prepareDatabase = ({ includeAudit = true } = {}) => {
+  const db = new DatabaseSync(':memory:');
+  if (includeAudit) {
+    db.exec(`
+      CREATE TABLE calc_parametros_auditoria (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at INTEGER NOT NULL,
+        admin_email TEXT NOT NULL,
+        chave TEXT NOT NULL,
+        valor_anterior TEXT,
+        valor_novo TEXT NOT NULL,
+        origem TEXT NOT NULL
+      );
+    `);
+    db.prepare(
+      `INSERT INTO calc_parametros_auditoria
+       (created_at, admin_email, chave, valor_anterior, valor_novo, origem)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(1, 'operator@example.com', 'taxa', '1', '2', 'teste');
+  }
+  db.exec(`
+    CREATE TABLE calc_email_rate_limit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ip TEXT NOT NULL,
+      timestamp INTEGER NOT NULL
+    );
+    CREATE TABLE calc_parametros_calculo (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      chave TEXT NOT NULL,
+      valor TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    );
+  `);
+  return db;
+};
+
+const applyMigration = (db, sql) => {
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.exec(sql);
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+};
+
+describe.each(migrationPaths)('%s', (path) => {
+  it('removes only empty legacy tables and preserves the active audit table', () => {
+    const db = prepareDatabase();
+
+    applyMigration(db, readMigration(path));
+
+    expect(tableExists(db, 'calc_email_rate_limit')).toBe(false);
+    expect(tableExists(db, 'calc_parametros_calculo')).toBe(false);
+    expect(tableExists(db, 'calc_parametros_auditoria')).toBe(true);
+    expect(db.prepare('SELECT COUNT(*) AS count FROM calc_parametros_auditoria').get().count).toBe(1);
+  });
+
+  it('is idempotent after the legacy tables are absent', () => {
+    const db = prepareDatabase();
+    const sql = readMigration(path);
+
+    applyMigration(db, sql);
+    applyMigration(db, sql);
+
+    expect(tableExists(db, 'calc_email_rate_limit')).toBe(false);
+    expect(tableExists(db, 'calc_parametros_calculo')).toBe(false);
+    expect(tableExists(db, 'calc_parametros_auditoria')).toBe(true);
+  });
+
+  it.each(['calc_email_rate_limit', 'calc_parametros_calculo'])(
+    'rolls back without dropping either table when %s contains data',
+    (table) => {
+      const db = prepareDatabase();
+      if (table === 'calc_email_rate_limit') {
+        db.prepare('INSERT INTO calc_email_rate_limit (ip, timestamp) VALUES (?, ?)').run('192.0.2.1', 1);
+      } else {
+        db.prepare('INSERT INTO calc_parametros_calculo (chave, valor, created_at) VALUES (?, ?, ?)').run(
+          'taxa',
+          '1',
+          1,
+        );
+      }
+
+      expect(() => applyMigration(db, readMigration(path))).toThrow(/CHECK constraint failed/);
+      expect(tableExists(db, 'calc_email_rate_limit')).toBe(true);
+      expect(tableExists(db, 'calc_parametros_calculo')).toBe(true);
+      expect(db.prepare(`SELECT COUNT(*) AS count FROM ${table}`).get().count).toBe(1);
+      expect(db.prepare('SELECT COUNT(*) AS count FROM calc_parametros_auditoria').get().count).toBe(1);
+    },
+  );
+
+  it('rolls back when the active audit table is missing', () => {
+    const db = prepareDatabase({ includeAudit: false });
+
+    expect(() => applyMigration(db, readMigration(path))).toThrow(/CHECK constraint failed/);
+    expect(tableExists(db, 'calc_email_rate_limit')).toBe(true);
+    expect(tableExists(db, 'calc_parametros_calculo')).toBe(true);
+    expect(tableExists(db, 'calc_parametros_auditoria')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Resultado

- adiciona a migração D1 nativa `0002` e a etapa de bootstrap `019`;
- remove somente `calc_email_rate_limit` e `calc_parametros_calculo`;
- preserva `calc_parametros_auditoria`, que continua com consumidor runtime;
- falha antes dos `DROP` se qualquer candidata contiver linhas ou se a tabela ativa estiver ausente.

## Segurança operacional

- inventário dos 13 repositórios ativos concluído;
- as duas candidatas estavam vazias no preflight remoto;
- exports individuais e bookmark de Time Travel foram registrados fora do repositório;
- a migração será aplicada somente pelo workflow protegido após o merge;
- nenhum identificador real de infraestrutura foi publicado.

## Verificação

- RED focado: 10/10 falhas com as migrações ausentes;
- GREEN focado: 10/10;
- `npm test`: 374/374;
- `npm run test:admin-motor`: 625/625;
- lint, Biome, typecheck, build e formato público: aprovados;
- Ultrabrain estrito: válido;
- revisão local independente: READY, sem finding.

Closes #519
Related: LCV-Ideas-Software/calculadora-app#183