### PR TITLE
ci: use official Linear Release action

### DIFF
--- a/.github/workflows/actions.lock
+++ b/.github/workflows/actions.lock
@@ -18,6 +18,7 @@ workflows:
         - 'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020'
     '.github/workflows/linear-release.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
+        - 'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205'
     '.github/workflows/pages.yml':
         - 'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'
         - 'actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d'
@@ -89,6 +90,11 @@ dependencies:
         commit: 'sha1-ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd'
         owner_id: 9919
         repo_id: 259445878
+    'linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205':
+        ref: 'v0.16.0'
+        commit: 'sha1-0a25abab892a91062ebf42260dbb2ce6277aa205'
+        owner_id: 46686594
+        repo_id: 1150447766
     'ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc':
         ref: 'v2.4.4'
         commit: 'sha1-2d1146689b8cda280b9bc96326124645441f03bc'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -53,28 +53,21 @@ jobs:
           fetch-depth: 0 # histórico completo: o CLI varre commits desde a última release
           persist-credentials: false
 
-      # Download verificado por digest — sem wrapper de terceiro: o binário oficial
-      # do CLI só executa se o SHA-256 conferir com o valor gravado abaixo
-      # (recomputado localmente e conferido contra o digest declarado pela API do
-      # GitHub em 17/08/2026). Troca de versão exige atualizar URL e digest juntos,
-      # por desenho. Inventário e fronteira de confiança em THIRDPARTY.md do
-      # repositório de governança.
+      # Integração oficial da Linear, pinada no commit da release v0.16.0 e com a
+      # versão do CLI também explícita. O pin protege o código da action contra
+      # deslocamento de tag; o instalador upstream ainda não verifica o digest do
+      # asset do CLI, risco residual registrado em ADMIAPP-12 e
+      # linear/linear-release-action#59.
       #
       # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (digest divergente, indisponibilidade, segredo expirado) NUNCA pode
+      # falha (indisponibilidade, segredo expirado ou erro upstream) NUNCA pode
       # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
       # falha fica visível na anotação do passo; commits não sincronizados embarcam
       # na release seguinte.
-      - name: Create Linear release (CLI verificado por digest)
+      - name: Create Linear release (action oficial)
         id: linear_release
         continue-on-error: true
-        env:
-          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-          CLI_URL: https://github.com/linear/linear-release/releases/download/v0.15.0/linear-release-linux-x64
-          CLI_SHA256: 06eddce3f0d306fcdfed634105a57b02695b5c4fb40c42eb56d13feced729c99
-        run: |
-          bin="$RUNNER_TEMP/linear-release"
-          curl -fsSL "$CLI_URL" -o "$bin"
-          echo "$CLI_SHA256  $bin" | sha256sum -c -
-          chmod +x "$bin"
-          "$bin" sync
+        uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          cli_version: v0.16.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Infraestrutura
+
+- **Linear Release usa a action oficial da Linear.** O workflow pós-Deploy
+  substitui o download manual pelo `linear/linear-release-action` v0.16.0,
+  fixado por SHA completo e com a versão do CLI explícita. Permanecem o
+  checkout do SHA efetivamente implantado, o histórico completo, o environment
+  dedicado, as permissões mínimas, a concorrência e o comportamento
+  best-effort. O instalador upstream ainda não valida o digest do binário; o
+  risco residual está registrado em ADMIAPP-12 e em
+  `linear/linear-release-action#59`.
+
 ### Removido
 
 - **Duas tabelas D1 legadas da Calculadora.** A migração nativa `0002` e a


### PR DESCRIPTION
## Resumo

- substitui o download manual do Linear Release CLI pela action oficial `linear/linear-release-action`;
- fixa a action no commit `0a25abab892a91062ebf42260dbb2ce6277aa205` da release v0.16.0 e mantém `cli_version: v0.16.0` explícita;
- preserva o gatilho após Deploy bem-sucedido em `main`, o checkout do SHA implantado, histórico completo, environment protegido, permissões mínimas, concorrência e comportamento best-effort;
- atualiza e valida `actions.lock`.

## Risco conhecido

O `install.sh` da action oficial baixa o binário do CLI sem verificar o digest publicado. Isso reduz a garantia de supply chain em relação ao fluxo manual anterior. O risco foi aceito para este canário, está documentado em ADMIAPP-12/#529 e é acompanhado em https://github.com/linear/linear-release-action/issues/59. Nenhum segundo repositório será migrado antes da prova runtime pós-merge.

## Validação

- `git diff --check`
- `actionlint .github/workflows/linear-release.yml`
- `zizmor --persona auditor --offline .github/workflows/linear-release.yml` — zero achados, um ignore preexistente e justificado
- `gh actions-lock --verify-local --json=valid,findings` — `valid=true`
- `gh actions-lock --no-fix --json=valid,findings` — `valid=true`
- 14 assertions direcionadas dos invariantes do workflow
- commit assinado e verificado

## Gate pós-merge

Após o merge, um novo Deploy de `main` deve provar: mesmo SHA implantado e checkoutado, outcome real da action igual a `success` e exatamente uma Linear Release concluída para o SHA completo.

Linear: https://linear.app/lcv-ideas-software/issue/ADMIAPP-12/ci-migrar-linear-release-para-a-action-oficial-da-linear-v0160

Closes #529