### PR TITLE
docs(security): use canonical reporting address (GIT-134)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ Please do not open a public issue for suspected vulnerabilities, credential leak
 
 Report privately by email:
 
-- lcv@lcv.dev
+- security@lcv.dev
 
 If GitHub private vulnerability reporting is enabled for this repository, that channel is also acceptable.
 


### PR DESCRIPTION
Padroniza o canal de reporte de segurança de lcv@lcv.dev para security@lcv.dev somente no SECURITY.md.

Mudança mecânica: 1 linha; nenhum código alterado. Contatos de conduta, suporte e privacidade permanecem inalterados.

Tracking Linear: https://linear.app/lcv-ideas-software/issue/GIT-134/maintenance-padronizar-contato-de-seguranca-como-securitylcvdev-na
Tracking GitHub: https://github.com/LCV-Ideas-Software/github-operations/issues/149