### PR TITLE
fix(ci): preserve Dependabot cooldown and release queue (ADMIAPP-13)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     cooldown:
       default-days: 7
       exclude:
-        - '*'
+        - 'actions/*'
+        - 'github/*'
     labels:
       - 'dependencies'
       - 'github-actions'

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -17,19 +17,12 @@ on:
 # Política enterprise (Discussion #150): sem write-all. Conjunto vazio no escopo do
 # workflow e grant mínimo declarado no job.
 permissions: {}
-# Agrupamento intencional: o CLI varre todos os commits desde a última release
-# (fetch-depth: 0). Se um run pendente for substituído por um mais novo, os
-# commits dele embarcam na release do run seguinte — nada se perde; releases
-# agrupam deploys em rajada por desenho, e o grupo evita corrida entre duas
-# criações de release simultâneas.
-# O grupo inclui a CONCLUSÃO do Deploy: o filtro do job (if) só age depois do
-# enfileiramento, então um run de Deploy falhado entraria no mesmo grupo e
-# poderia substituir na fila um run de sucesso pendente — deixando o SHA
-# publicado sem release até o próximo deploy. Com a conclusão na chave, runs de
-# falha (que o if pula) nunca deslocam runs de sucesso.
+# Cada Deploy bem-sucedido precisa gerar sua própria release. `queue: max`
+# preserva todos os runs pendentes do grupo, e a conclusão na chave mantém runs
+# falhados (que o job ignora) separados dos runs de sucesso.
 concurrency:
   group: linear-release-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.conclusion }}
-  cancel-in-progress: false
+  queue: max
 jobs:
   linear_release:
     name: Linear Release
@@ -59,14 +52,11 @@ jobs:
       # asset do CLI, risco residual registrado em ADMIAPP-12 e
       # linear/linear-release-action#59.
       #
-      # Best-effort por desenho: esta sincronização é um espelho opcional e sua
-      # falha (indisponibilidade, segredo expirado ou erro upstream) NUNCA pode
-      # bloquear portões que varrem todos os runs do SHA. O run conclui verde e a
-      # falha fica visível na anotação do passo; commits não sincronizados embarcam
-      # na release seguinte.
+      # A sincronização falha de forma visível: indisponibilidade, segredo
+      # expirado ou erro upstream deixam o workflow vermelho, evitando perder
+      # silenciosamente a release do SHA publicado.
       - name: Create Linear release (action oficial)
         id: linear_release
-        continue-on-error: true
         uses: linear/linear-release-action@0a25abab892a91062ebf42260dbb2ce6277aa205 # v0.16.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   substitui o download manual pelo `linear/linear-release-action` v0.16.0,
   fixado por SHA completo e com a versão do CLI explícita. Permanecem o
   checkout do SHA efetivamente implantado, o histórico completo, o environment
-  dedicado, as permissões mínimas, a concorrência e o comportamento
-  best-effort. O instalador upstream ainda não valida o digest do binário; o
+  dedicado e as permissões mínimas. A concorrência usa `queue: max` para
+  preservar os runs pendentes, e falhas da action tornam o workflow vermelho.
+  O instalador upstream ainda não valida o digest do binário; o
   risco residual está registrado em ADMIAPP-12 e em
   `linear/linear-release-action#59`.
 


### PR DESCRIPTION
## Summary
- keep the seven-day Dependabot cooldown for third-party GitHub Actions
- exempt only official actions/* and github/* software
- queue every pending Linear Release run with queue: max
- fail visibly when the official Linear Release action fails
- preserve triggers, concurrency group, action pins, permissions, secrets, and actions.lock

## Validation
- YAML converted with yq and asserted with jq
- gh actions-lock --verify-local: valid
- Zizmor: no findings
- git diff --check: clean
- actions.lock: byte-identical
- commit: GPG signature verified

Closes #539

Linear: https://linear.app/lcv-ideas-software/issue/ADMIAPP-13
Refs LCV-Ideas-Software/github-operations#143

Official queue documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-queueing-multiple-pending-runs