### PR TITLE
fix(compliance): harden legal Markdown boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@
 
 ### Corrigido
 
+- **Parser estrutural dos inventários legais fechado a bypasses de Markdown.**
+  O gate usa o parser GFM já adotado pelo projeto para validar o outline e a
+  cardinalidade completos dos documentos, além da prosa e dos blocos legais
+  auditados. Separadores inválidos, tabelas cercadas ou extras, HTML bruto,
+  headings duplicados ou confusáveis, campos fora da gramática, prosa
+  contraditória e licenças duplicadas ou sem cerca agora falham de modo
+  explícito. No Admin Motor, cada seção contém somente a lista canônica e um
+  bloco `text` equivalente ao aviso da versão instalada.
+
 - **Fallback do token dedicado de armazenamento.** O ambiente bruto do
   `admin-motor` tipa `CLOUDFLARE_STORAGE` como `SecretsStoreSecret`, lê o valor
   pela chamada assíncrona `get()` e, se a leitura do binding opcional falhar,

--- a/scripts/verify-thirdparty.mjs
+++ b/scripts/verify-thirdparty.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import { Window } from 'happy-dom';
 import { transform } from 'lightningcss';
+import { marked } from 'marked';
 
 const ROOT_INVENTORY = 'THIRDPARTY.md';
 const ROOT_NOTICE = 'NOTICE';
@@ -19,6 +20,7 @@ const ADMIN_WORKER_OUTDIR = 'admin-motor/dist/legal-audit';
 const ADMIN_WORKER_METAFILE = `${ADMIN_WORKER_OUTDIR}/bundle-meta.json`;
 const ADMIN_WORKER_NOTICE_SOURCE = 'admin-motor/src/legal/THIRDPARTY.md';
 const ADMIN_WORKER_NOTICE_ARTIFACT = `${ADMIN_WORKER_OUTDIR}/legal/THIRDPARTY.md`;
+const ADMIN_WORKER_TITLE = '# Avisos de componentes de terceiros — Admin Motor';
 const ADMIN_WORKER_INVENTORY_HEADER = Object.freeze([
   'Componente',
   'Versão',
@@ -34,6 +36,10 @@ const LAUNDER_AUDITED_ARTIFACT = Object.freeze({
   packageJsonSha256: 'b111ad703bae61d8cef17863c38f4618e813b24284a874d0b81db1b5cfbdf601',
   upstreamCommit: 'e9b0ab0849a5dfea0f75335fbdf99b5c6bf9e4b3',
 });
+const LAUNDER_DISCLOSURE =
+  'O pacote npm e a tag upstream `launder@1.7.1` declaram `MIT`, mas o pacote/tarball dessa versão não traz arquivo `LICENSE`. Por isso, os termos canônicos da MIT são reproduzidos abaixo sem inventar titular, ano ou aviso de copyright ausente no upstream.';
+const MARKED_DISCLOSURE =
+  'O `LICENSE` de Marked contém tanto os termos MIT de Marked quanto o aviso BSD-3-Clause integral do componente Markdown incorporado; ambos seguem reproduzidos sem redução.';
 const ROOT_HTML = 'index.html';
 const JSZIP_BROWSER_DISTRIBUTION = 'node_modules/jszip/dist/jszip.min.js';
 const JSZIP_BROWSER_DISTRIBUTION_SHA256 = 'ACC7E41455A80765B5FD9C7EE1B8078A6D160BBBCA455AEAE854DE65C947D59E';
@@ -261,6 +267,83 @@ export const REQUIRED_STATIC_NOTICE_SECTIONS = Object.freeze([
   }),
 ]);
 
+const ROOT_DOCUMENT_SCHEMA = (() => {
+  const paragraphDigests = Object.freeze([
+    '9bab20a62df1c95df7c4f41826b2043f57d13086b6fcb7dab7f7649dd57454a6',
+    '6368032d6cd1fb14fe34fb4303e56e053ccd824b296f84be0bd56c7d53e6d48e',
+    'f9217459944bc8d30a7083bbfe7ebfc051ea7e51429ea5f8642912ea6767ac93',
+    'f7ebc7c3f34069daf29f96bd17b27f0dda176a756ebc29258094b232ecea96d2',
+    'a287ef08363a2f9aa3e339cc54d4b02c97439f9cdb53e28d51daffd8f753eed5',
+    '2bd045c34c582095d72e33a3184ae3fa04aa13509b23d8161a36293abe6d468d',
+    '8aa9b4d5a20a0091628c62615c6dedf028cea06c539b1c397b140fb49771089c',
+    '6681f9df11fce09360a300b0d5b789ffdfbc9e476e8c051986f426fa421827d2',
+    '608e94a2b431b884dee76f739b85d4eaf3524cd74e20d00d316b0bafb575315e',
+    'e348e036ff14139783bd38220796591680b3db555e0c79f42ce23d91c9668fdd',
+    '44abe5998af13e517b197c592319e87e5ca4056947fe1886e56771d5058bcb09',
+    'e56a8cc6060745bdc403b9a66aa93983327e523612623698f3de6a36b8a158c3',
+  ]);
+  const codeBlockDigests = Object.freeze([
+    '8a3c2abaecf6a5d4af7b06f564727babf141aa3b1708ad399d2e9cffeb9c4692',
+    'e824161e0aab3814aca1883bd7058e67034d25fce254e6629495e78d3f8a53c3',
+    'f2c7bd8d9e43896c730ad9e095cc9b861c5aa8741119fb7237666ef03c21b608',
+    'ededb65e4fd8561af59d0ec209a3dd4012a458e8364e532ce320181757c9f4b6',
+    'dc0711f67148ef151102483996a3caa360c0aef631ba2562afed140ab9742daf',
+    'ceedc02ca6ecc228bec601367e8d3905331c33cd74f7131d4d45ad2562d23bb4',
+    'ac22553a5f529c8bca6305b6f445de70b384d922dc0560a6ad86c662bb9cad3e',
+    'f57e3a2cabf2b43ab2fc942a8e9f4b38366ab0d1f859c6439b1fb69e80d9af73',
+    'f4bb8f655fdb4d119878a0eea6dfcb871da509d83baa7426794f7c70b9bb9d46',
+    '5d72d08481a4760883a0242accc9cd076c78775e1735ccfdec443b3eae80d288',
+    '4cc9c2af4eb0056cd4d2297b7404819e3816b4c44b7f8012c42d5fd671d783d3',
+    '7f7a686a9e08517613587583611772c18a60ca99dabfabd96641d9ac210d0c7d',
+  ]);
+  const staticTableDigests = Object.freeze([
+    '811c781139c97acd137093850a7817293769002be642fc03823c1062df88b7ca',
+    '0cbd8ef384944e9223fdcf1acb98df4412c2fd6cbc6e322854bfa86201f5c1df',
+  ]);
+  const paragraph = (index) => ({ type: 'paragraph', digest: paragraphDigests[index] });
+  const code = (index) => ({ type: 'code', digest: codeBlockDigests[index] });
+  const sections = Object.freeze([
+    { heading: '# Inventário de componentes de terceiros', tokens: [paragraph(0), paragraph(1)] },
+    { heading: MANIFESTS[0].heading, tokens: [{ type: 'table' }] },
+    { heading: MANIFESTS[1].heading, tokens: [{ type: 'table' }] },
+    {
+      heading: '## Componente incorporado ao Worker TLS-RPT',
+      tokens: [paragraph(2), { type: 'table', digest: staticTableDigests[0] }],
+    },
+    { heading: '### base64ArrayBuffer — MIT', tokens: [code(0)] },
+    {
+      heading: '## Complementos para componentes incorporados ao bundle',
+      tokens: [paragraph(3), { type: 'table', digest: staticTableDigests[1] }],
+    },
+    { heading: '### Assets do scaffold create-vite 8.0.0 — MIT', tokens: [paragraph(4), code(1)] },
+    { heading: '### JSZip 3.10.1 — MIT', tokens: [paragraph(5)] },
+    { heading: '### Pako 1.0.5 — MIT e Zlib', tokens: [paragraph(6), code(2)] },
+    { heading: '### Spark MD5 3.0.2 — MIT', tokens: [paragraph(7), code(3)] },
+    { heading: '### dingbat-to-unicode 1.0.1 — BSD-2-Clause', tokens: [paragraph(8), code(4)] },
+    { heading: '### react-remove-scroll-bar 2.3.8 — MIT', tokens: [paragraph(9), code(5)] },
+    { heading: '## Cartografia local e dados Natural Earth', tokens: [paragraph(10), paragraph(11)] },
+    { heading: '## Avisos de licenças da cartografia', tokens: [] },
+    { heading: '### d3-geo 3.1.1 — ISC e GeographicLib — MIT', tokens: [code(6)] },
+    { heading: '### d3-array 3.2.4 — ISC', tokens: [code(7)] },
+    { heading: '### internmap 2.0.3 — ISC', tokens: [code(8)] },
+    { heading: '### topojson-client 3.1.0 — ISC', tokens: [code(9)] },
+    { heading: '### commander 2.20.3 — MIT', tokens: [code(10)] },
+    { heading: '### world-atlas 2.0.2 — ISC', tokens: [code(11)] },
+  ]);
+  return Object.freeze({
+    title: sections[0].heading,
+    headings: Object.freeze(sections.slice(1).map(({ heading }) => heading)),
+    paragraphCount: paragraphDigests.length,
+    tableCount: MANIFESTS.length + staticTableDigests.length,
+    codeBlockCount: codeBlockDigests.length,
+    dynamicTableCount: MANIFESTS.length,
+    paragraphDigests,
+    codeBlockDigests,
+    staticTableDigests,
+    sections,
+  });
+})();
+
 export const REQUIRED_BUNDLED_LICENSE_MARKERS = Object.freeze([
   '## jszip - 3.10.1 ((MIT OR GPL-3.0-or-later))',
   '## dingbat-to-unicode - 1.0.1 (BSD-2-Clause)',
@@ -361,8 +444,58 @@ function normalizeCell(value) {
   return value.trim().replace(/^`|`$/gu, '');
 }
 
+const INVISIBLE_CONTROL_PATTERN =
+  /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/u;
+
+function assertNoInvisibleControls(value, label = 'visible legal evidence') {
+  assert.equal(
+    INVISIBLE_CONTROL_PATTERN.test(value),
+    false,
+    `${label} must not contain invisible Unicode control characters`,
+  );
+}
+
 function normalizeNotice(value) {
-  return value.replace(/\s+/gu, ' ').trim();
+  return value.normalize('NFC').replace(/\s+/gu, ' ').trim();
+}
+
+function normalizeLegalText(value) {
+  return value.replace(/\r\n/gu, '\n').replace(/\n+$/u, '');
+}
+
+function normalizeEmbeddedLegalText(value) {
+  return normalizeLegalText(value)
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n');
+}
+
+function normalizedSha256(value, normalizer) {
+  return createHash('sha256').update(normalizer(value)).digest('hex');
+}
+
+function markdownTableDigest(table) {
+  const rows = [table.header, ...table.rows].map((row) =>
+    row.map((cell) => normalizeNotice(cell.text)),
+  );
+  return createHash('sha256').update(JSON.stringify(rows)).digest('hex');
+}
+
+function structuralTokenDigest(token) {
+  if (token.type === 'paragraph') return normalizedSha256(token.text, normalizeNotice);
+  if (token.type === 'code') return normalizedSha256(token.text, normalizeLegalText);
+  if (token.type === 'table') return markdownTableDigest(token);
+  return undefined;
+}
+
+function normalizeStructuralIdentifier(value) {
+  return value
+    .replace(/\p{Default_Ignorable_Code_Point}+/gu, '')
+    .normalize('NFKC')
+    .replace(/\s+/gu, ' ')
+    .replace(/\s*:\s*/gu, ':')
+    .toLowerCase()
+    .trim();
 }
 
 function assertContainsNotice(content, notice, label) {
@@ -372,117 +505,530 @@ function assertContainsNotice(content, notice, label) {
   );
 }
 
-function markdownStructuralLineRecords(markdown) {
-  const lines = markdown.split(/\r?\n/u);
-  const records = [];
-  let fence;
-  for (const [index, line] of lines.entries()) {
-    if (fence) {
-      const closing = /^ {0,3}(`+|~+)\s*$/u.exec(line);
-      if (
-        closing &&
-        closing[1][0] === fence.marker &&
-        closing[1].length >= fence.minimumLength
-      ) {
-        fence = undefined;
-      }
-      continue;
-    }
-
-    const opening = /^ {0,3}(`{3,}|~{3,})/u.exec(line);
-    if (opening) {
-      fence = { marker: opening[1][0], minimumLength: opening[1].length };
-      continue;
-    }
-
-    records.push({ index, line });
+function markdownTokenChildren(token) {
+  if (token.type === 'list') return token.items.flatMap((item) => item.tokens ?? []);
+  if (token.type === 'table') {
+    return [...token.header, ...token.rows.flat()].flatMap((cell) => cell.tokens ?? []);
   }
-  return { lines, records };
+  return Array.isArray(token.tokens) ? token.tokens : [];
+}
+
+function markdownTokensMatching(tokens, predicate) {
+  const matches = [];
+  for (const token of tokens) {
+    if (predicate(token)) matches.push(token);
+    matches.push(...markdownTokensMatching(markdownTokenChildren(token), predicate));
+  }
+  return matches;
+}
+
+function renderedMarkdownText(markdown) {
+  return withRenderedMarkdown(markdown, (document) => document.body.textContent ?? '');
+}
+
+function assertContainsMarkdownNotice(markdown, notice, label) {
+  assertContainsNotice(renderedMarkdownText(markdown), notice, label);
+}
+
+function assertContainsRenderedMarkdown(markdown, expectedMarkdown, label) {
+  const actualText = renderedMarkdownText(markdown);
+  const expectedText = expectedMarkdown.replace(/`([^`\r\n]+)`/gu, '$1');
+  assertContainsNotice(actualText, expectedText, label);
+}
+
+function assertVisibleMarkdownEvidence(markdown, label) {
+  assertNoInvisibleControls(markdown, `${label} visible legal evidence`);
+  assert.equal(
+    /\p{Bidi_Control}/u.test(markdown),
+    false,
+    `${label} visible legal evidence must not contain Unicode bidirectional controls`,
+  );
+  assert.equal(
+    markdownTokensMatching(marked.lexer(markdown, { gfm: true }), (token) => token.type === 'html')
+      .length,
+    0,
+    `${label} must not contain raw HTML; visible structural inventory and legal evidence must remain auditable`,
+  );
+  const rendered = withRenderedMarkdown(markdown, (document) => ({
+    deletedElementCount: document.querySelectorAll('del').length,
+    text: document.body.textContent ?? '',
+  }));
+  assert.equal(
+    /\p{Bidi_Control}/u.test(rendered.text),
+    false,
+    `${label} visible legal evidence must not contain encoded Unicode bidirectional controls`,
+  );
+  assertNoInvisibleControls(rendered.text, `${label} rendered visible legal evidence`);
+  assert.equal(
+    rendered.deletedElementCount,
+    0,
+    `${label} visible legal evidence must not contain struck-through Markdown`,
+  );
+}
+
+const markdownWindow = new Window({
+  url: 'https://legal.local.invalid/',
+  settings: {
+    disableCSSFileLoading: true,
+    disableIframePageLoading: true,
+    disableJavaScriptEvaluation: true,
+    disableJavaScriptFileLoading: true,
+  },
+});
+
+function withRenderedMarkdown(markdown, callback) {
+  const html = marked.parse(markdown, { gfm: true });
+  assert.equal(typeof html, 'string', 'GFM rendering must be synchronous');
+  const document = markdownWindow.document;
+  try {
+    document.body.innerHTML = html;
+    return callback(document);
+  } finally {
+    document.body.replaceChildren();
+  }
+}
+
+function renderedListItemRecords(markdown) {
+  return withRenderedMarkdown(markdown, (document) =>
+    [...document.querySelectorAll('li')].map((item) => ({
+      html: item.innerHTML,
+      topLevel:
+        (item.parentElement?.tagName === 'UL' || item.parentElement?.tagName === 'OL') &&
+        item.parentElement?.parentElement === document.body,
+    })),
+  );
+}
+
+function renderedExpectedListItem(expectedLine, label) {
+  const records = renderedListItemRecords(expectedLine);
+  assert.equal(records.length, 1, `${label} expected list item is invalid: ${expectedLine}`);
+  assert.equal(records[0].topLevel, true, `${label} expected list item must be top-level`);
+  return records[0].html;
 }
 
 function assertExactMarkdownLine(content, expectedLine, label) {
-  const occurrences = markdownStructuralLineRecords(content).records.filter(
-    ({ line }) => line === expectedLine,
+  const expectedHtml = renderedExpectedListItem(expectedLine, label);
+  const occurrences = renderedListItemRecords(content).filter(
+    ({ html, topLevel }) => topLevel && html === expectedHtml,
   ).length;
-  assert.equal(occurrences, 1, `${label} must contain exactly once: ${expectedLine}`);
-}
-
-function markdownFieldLines(content, field) {
-  const marker = `**${field}:**`;
-  return markdownStructuralLineRecords(content).records
-    .map(({ line }) => line)
-    .filter((line) => line.includes(marker));
+  assert.equal(
+    occurrences,
+    1,
+    `${label} must contain exactly one structural visible list item: ${expectedLine}`,
+  );
 }
 
 function assertExactMarkdownField(content, field, expectedLine, label) {
-  assert.deepEqual(
-    markdownFieldLines(content, field),
-    [expectedLine],
-    `${label} must contain exactly one structural ${field} field with the exact audited value`,
+  assertExactMarkdownLine(content, expectedLine, `${label} ${field} field`);
+}
+
+function adminWorkerPreamble(packageCount) {
+  return [
+    `Este arquivo acompanha o Worker \`admin-motor\` como módulo adicional do tipo \`Text\`. O inventário cobre exatamente os ${packageCount} pacotes npm com código efetivamente incorporado ao bundle Wrangler informado para este artefato. Pacotes de desenvolvimento, ferramentas externas e entradas desabilitadas de zero byte não pertencem a este escopo.`,
+    'Versão, licença declarada, URL `resolved` e SRI `integrity` foram conferidos na entrada `packages` de `package-lock.json`; o texto de cada aviso foi reproduzido integralmente do pacote da mesma versão instalado em `node_modules`. O caminho e o SHA-256 de cada fonte permitem verificar o texto sem confundi-lo com outra versão homônima.',
+  ];
+}
+
+function expectedAdminSectionProse(packageName) {
+  if (packageName === 'launder') return [LAUNDER_DISCLOSURE];
+  if (packageName === 'marked') return [MARKED_DISCLOSURE];
+  return [];
+}
+
+function assertAdminSectionStructure(
+  markdown,
+  expectedMetadataItems,
+  expectedProse,
+  expectedLegalText,
+  label,
+) {
+  const tokens = marked.lexer(markdown, { gfm: true });
+  const topLevelLists = tokens.filter((token) => token.type === 'list');
+  const allLists = markdownTokensMatching(tokens, (token) => token.type === 'list');
+  assert.equal(topLevelLists.length, 1, `${label} must contain exactly one top-level metadata list`);
+  assert.equal(allLists.length, 1, `${label} must not contain nested or additional metadata lists`);
+  assert.equal(topLevelLists[0].ordered, false, `${label} metadata must use one unordered list`);
+  assert.equal(
+    topLevelLists[0].items.length,
+    expectedMetadataItems,
+    `${label} metadata list must contain exactly ${expectedMetadataItems} canonical list items`,
   );
+
+  const structuralTokens = tokens.filter((token) => token.type !== 'space');
+  const expectedTypes = [
+    'list',
+    ...expectedProse.map(() => 'paragraph'),
+    'code',
+  ];
+  assert.deepEqual(
+    structuralTokens.map((token) => token.type),
+    expectedTypes,
+    `${label} must be one closed section: metadata, canonical prose when required, and one fenced legal-text block`,
+  );
+
+  const actualProse = structuralTokens
+    .filter((token) => token.type === 'paragraph')
+    .map((token) => normalizeNotice(token.text));
+  assert.deepEqual(
+    actualProse,
+    expectedProse.map(normalizeNotice),
+    `${label} must contain exactly its canonical prose`,
+  );
+
+  const codeBlocks = structuralTokens.filter((token) => token.type === 'code');
+  assert.equal(codeBlocks.length, 1, `${label} must contain exactly one fenced legal-text block`);
+  assert.equal(codeBlocks[0].lang, 'text', `${label} legal-text block must use the text info string`);
+  assert.equal(
+    normalizeEmbeddedLegalText(codeBlocks[0].text),
+    normalizeEmbeddedLegalText(expectedLegalText),
+    `${label} fenced legal text must equal its exact audited source after line-ending and trailing-whitespace normalization`,
+  );
+}
+
+function parseExpectedHeading(heading, label) {
+  const match = /^(#+)\s+(.+)$/u.exec(heading);
+  assert.ok(match, `${label} expected heading is invalid: ${heading}`);
+  return { depth: match[1].length, text: match[2].trim() };
 }
 
 function markdownHeadingRecords(markdown) {
-  const { lines, records } = markdownStructuralLineRecords(markdown);
-  const headings = [];
-  for (const { index, line } of records) {
-    const match = /^( {0,3})(#+)\s/u.exec(line);
-    if (match) {
-      headings.push({
-        heading: line.slice(match[1].length).trim(),
-        index,
-        level: match[2].length,
-      });
+  const tokens = marked.lexer(markdown, { gfm: true });
+  const headings = tokens
+    .map((token, index) => ({ token, index }))
+    .filter(({ token }) => token.type === 'heading')
+    .map(({ token, index }) => ({
+      heading: `${'#'.repeat(token.depth)} ${token.text.trim()}`,
+      index,
+      level: token.depth,
+    }));
+  return { headings, tokens };
+}
+
+function assertClosedMarkdownDocument(markdown, schema, label) {
+  const tokens = marked.lexer(markdown, { gfm: true });
+  const allowedTypes = new Set(['heading', 'space', 'paragraph', 'table', 'code']);
+  const unexpectedTypes = [
+    ...new Set(tokens.filter((token) => !allowedTypes.has(token.type)).map((token) => token.type)),
+  ];
+  assert.deepEqual(
+    unexpectedTypes,
+    [],
+    `${label} closed document contains unexpected top-level Markdown structures`,
+  );
+
+  const headings = tokens
+    .filter((token) => token.type === 'heading')
+    .map((token) => `${'#'.repeat(token.depth)} ${token.text.trim()}`);
+  assert.deepEqual(
+    headings,
+    [schema.title, ...schema.headings],
+    `${label} closed document heading outline must remain exact and canonical`,
+  );
+
+  const paragraphs = tokens.filter((token) => token.type === 'paragraph');
+  const tables = tokens.filter((token) => token.type === 'table');
+  const codeBlocks = tokens.filter((token) => token.type === 'code');
+  assert.equal(
+    paragraphs.length,
+    schema.paragraphCount,
+    `${label} closed document paragraph count changed`,
+  );
+  assert.equal(
+    tables.length,
+    schema.tableCount,
+    `${label} closed document must contain exactly ${schema.tableCount} visible Markdown tables`,
+  );
+  assert.equal(
+    codeBlocks.length,
+    schema.codeBlockCount,
+    `${label} closed document legal-text block count changed`,
+  );
+  assert.equal(
+    codeBlocks.every((token) => token.lang === 'text'),
+    true,
+    `${label} closed document legal-text blocks must use the text info string`,
+  );
+
+  if (schema.paragraphDigests) {
+    assert.deepEqual(
+      paragraphs.map((token) => normalizedSha256(token.text, normalizeNotice)),
+      schema.paragraphDigests,
+      `${label} closed document explanatory legal prose changed`,
+    );
+  }
+  if (schema.codeBlockDigests) {
+    assert.deepEqual(
+      codeBlocks.map((token) => normalizedSha256(token.text, normalizeLegalText)),
+      schema.codeBlockDigests,
+      `${label} closed document audited legal text changed`,
+    );
+  }
+  if (schema.staticTableDigests) {
+    assert.deepEqual(
+      tables.slice(schema.dynamicTableCount ?? 0).map(markdownTableDigest),
+      schema.staticTableDigests,
+      `${label} closed document static legal tables changed`,
+    );
+  }
+  if (schema.sections) {
+    const actualSections = [];
+    for (const token of tokens) {
+      if (token.type === 'heading') {
+        actualSections.push({
+          heading: `${'#'.repeat(token.depth)} ${token.text.trim()}`,
+          tokens: [],
+        });
+      } else if (token.type !== 'space') {
+        assert.ok(actualSections.length > 0, `${label} content appears before its canonical title`);
+        actualSections.at(-1).tokens.push({
+          type: token.type,
+          digest: structuralTokenDigest(token),
+        });
+      }
+    }
+
+    assert.equal(
+      actualSections.length,
+      schema.sections.length,
+      `${label} closed document section count changed`,
+    );
+    for (const [index, expectedSection] of schema.sections.entries()) {
+      const actualSection = actualSections[index];
+      assert.equal(
+        actualSection.heading,
+        expectedSection.heading,
+        `${label} closed document section order changed`,
+      );
+      assert.deepEqual(
+        actualSection.tokens.map(({ type }) => type),
+        expectedSection.tokens.map(({ type }) => type),
+        `${label} ${expectedSection.heading} section content types changed`,
+      );
+      for (const [tokenIndex, expectedToken] of expectedSection.tokens.entries()) {
+        if (!expectedToken.digest) continue;
+        assert.equal(
+          actualSection.tokens[tokenIndex].digest,
+          expectedToken.digest,
+          `${label} ${expectedSection.heading} section content changed or was assigned to another section`,
+        );
+      }
     }
   }
-  return { headings, lines };
+}
+
+function assertAdminDocumentStructure(markdown, expectedSectionHeadings, packageCount) {
+  const tokens = marked.lexer(markdown, { gfm: true });
+  const allowedTypes = new Set(['heading', 'space', 'paragraph', 'table', 'list', 'code']);
+  const unexpectedTypes = [
+    ...new Set(tokens.filter((token) => !allowedTypes.has(token.type)).map((token) => token.type)),
+  ];
+  assert.deepEqual(
+    unexpectedTypes,
+    [],
+    `${ADMIN_WORKER_NOTICE_SOURCE} closed document contains unexpected top-level Markdown structures`,
+  );
+
+  const headings = tokens
+    .filter((token) => token.type === 'heading')
+    .map((token) => `${'#'.repeat(token.depth)} ${token.text.trim()}`);
+  assert.deepEqual(
+    headings,
+    [ADMIN_WORKER_TITLE, '## Inventário efetivo', ...expectedSectionHeadings],
+    `${ADMIN_WORKER_NOTICE_SOURCE} heading outline and canonical title must remain exact`,
+  );
+
+  const inventoryHeadingIndex = tokens.findIndex(
+    (token) => token.type === 'heading' && token.depth === 2 && token.text === 'Inventário efetivo',
+  );
+  assert.notEqual(inventoryHeadingIndex, -1, `${ADMIN_WORKER_NOTICE_SOURCE} lacks its canonical inventory heading`);
+  const preamble = tokens.slice(1, inventoryHeadingIndex).filter((token) => token.type !== 'space');
+  assert.deepEqual(
+    preamble.map((token) => token.type),
+    ['paragraph', 'paragraph'],
+    `${ADMIN_WORKER_NOTICE_SOURCE} must contain only its two canonical preamble paragraphs before the inventory`,
+  );
+  assert.deepEqual(
+    preamble.map((token) => normalizeNotice(token.text)),
+    adminWorkerPreamble(packageCount).map((paragraph) => normalizeNotice(paragraph)),
+    `${ADMIN_WORKER_NOTICE_SOURCE} canonical preamble changed`,
+  );
+
+  const inventoryTokens = markdownSectionTokens(
+    markdown,
+    '## Inventário efetivo',
+    ADMIN_WORKER_NOTICE_SOURCE,
+  ).filter((token) => token.type !== 'space');
+  assert.deepEqual(
+    inventoryTokens.map((token) => token.type),
+    ['table'],
+    `${ADMIN_WORKER_NOTICE_SOURCE} effective inventory section must contain only its canonical table`,
+  );
+
+  assert.equal(
+    tokens.filter((token) => token.type === 'table').length,
+    1,
+    `${ADMIN_WORKER_NOTICE_SOURCE} closed document must contain exactly one table`,
+  );
+  assert.equal(
+    tokens.filter((token) => token.type === 'list').length,
+    expectedSectionHeadings.length,
+    `${ADMIN_WORKER_NOTICE_SOURCE} closed document must contain exactly one metadata list per package section`,
+  );
+  assert.equal(
+    tokens.filter((token) => token.type === 'code').length,
+    expectedSectionHeadings.length,
+    `${ADMIN_WORKER_NOTICE_SOURCE} closed document must contain exactly one legal-text block per package section`,
+  );
+  assert.equal(
+    tokens.filter((token) => token.type === 'paragraph').length,
+    2 + expectedSectionHeadings.filter((heading) => /^(?:## launder |## marked )/u.test(heading)).length,
+    `${ADMIN_WORKER_NOTICE_SOURCE} closed document contains noncanonical package prose`,
+  );
+}
+
+function renderedSectionInspection(markdown, heading, label, selector) {
+  const expected = parseExpectedHeading(heading, label);
+  return withRenderedMarkdown(markdown, (document) => {
+    const matches = [...document.querySelectorAll(`h${expected.depth}`)].filter(
+      (element) =>
+        normalizeStructuralIdentifier(element.textContent ?? '') ===
+        normalizeStructuralIdentifier(expected.text),
+    );
+    assert.equal(matches.length, 1, `${label} must contain exactly one semantic ${heading} section`);
+    const [sectionHeading] = matches;
+    assert.equal(
+      normalizeNotice(sectionHeading.textContent ?? ''),
+      normalizeNotice(expected.text),
+      `${label} ${heading} section must use the exact canonical rendered identifier`,
+    );
+    assert.equal(
+      sectionHeading.parentElement,
+      document.body,
+      `${label} ${heading} section must be top-level rendered GFM`,
+    );
+
+    const elements = [];
+    for (let sibling = sectionHeading.nextElementSibling; sibling; sibling = sibling.nextElementSibling) {
+      const headingMatch = /^H([1-6])$/u.exec(sibling.tagName);
+      if (headingMatch && Number(headingMatch[1]) <= expected.depth) break;
+      if (selector) {
+        if (sibling.matches(selector)) elements.push(sibling);
+        elements.push(...sibling.querySelectorAll(selector));
+      }
+    }
+    return {
+      elementCount: elements.length,
+      allElementsTopLevel: elements.every((element) => element.parentElement === document.body),
+    };
+  });
+}
+
+function renderedHeadingRecords(markdown, depth) {
+  return withRenderedMarkdown(markdown, (document) =>
+    [...document.querySelectorAll(`h${depth}`)].map((heading) => ({
+      heading: `${'#'.repeat(depth)} ${normalizeNotice(heading.textContent ?? '')}`,
+      topLevel: heading.parentElement === document.body,
+    })),
+  );
+}
+
+function assertSingleTopLevelSectionElement(markdown, heading, label, selector, elementLabel) {
+  const inspection = renderedSectionInspection(markdown, heading, label, selector);
+  assert.equal(
+    inspection.elementCount,
+    1,
+    `${heading} must contain exactly one visible Markdown ${elementLabel}`,
+  );
+  assert.equal(
+    inspection.allElementsTopLevel,
+    true,
+    `${heading} ${elementLabel} must be top-level rendered GFM`,
+  );
+}
+
+function renderedTableCountWithHeader(markdown, expectedHeader) {
+  return withRenderedMarkdown(markdown, (document) =>
+    [...document.querySelectorAll('table')].filter((table) => {
+      const firstRow = table.querySelector('thead tr') ?? table.querySelector('tr');
+      if (!firstRow) return false;
+      const header = [...firstRow.children].map((cell) =>
+        normalizeStructuralIdentifier(cell.textContent ?? ''),
+      );
+      return header.length === expectedHeader.length &&
+        header.every(
+          (cell, index) => cell === normalizeStructuralIdentifier(expectedHeader[index]),
+        );
+    }).length,
+  );
+}
+
+function renderedTableCountWithColumnCount(markdown, expectedColumnCount) {
+  return withRenderedMarkdown(markdown, (document) =>
+    [...document.querySelectorAll('table')].filter((table) => {
+      const firstRow = table.querySelector('thead tr') ?? table.querySelector('tr');
+      return firstRow?.children.length === expectedColumnCount;
+    }).length,
+  );
+}
+
+function renderedTableCount(markdown) {
+  return withRenderedMarkdown(markdown, (document) => document.querySelectorAll('table').length);
+}
+
+function markdownSectionTokens(markdown, heading, label) {
+  renderedSectionInspection(markdown, heading, label);
+  const { tokens } = markdownHeadingRecords(markdown);
+  const expected = parseExpectedHeading(heading, label);
+  const matches = tokens
+    .map((token, index) => ({ token, index }))
+    .filter(
+      ({ token }) =>
+        token.type === 'heading' && token.depth === expected.depth && token.text.trim() === expected.text,
+    );
+  assert.equal(matches.length, 1, `${label} must contain exactly one ${heading} section`);
+  const end = tokens.findIndex(
+    (token, index) =>
+      index > matches[0].index && token.type === 'heading' && token.depth <= expected.depth,
+  );
+  const sectionTokens = tokens.slice(matches[0].index + 1, end === -1 ? undefined : end);
+  assert.equal(
+    markdownTokensMatching(sectionTokens, (token) => token.type === 'html').length,
+    0,
+    `${label} ${heading} section must not contain raw HTML`,
+  );
+  return sectionTokens;
 }
 
 function markdownSection(markdown, heading, label) {
-  const { headings, lines } = markdownHeadingRecords(markdown);
-  const matches = headings.filter((record) => record.heading === heading);
-  assert.equal(matches.length, 1, `${label} must contain exactly one ${heading} section`);
-  const end = headings.find(
-    (record) => record.index > matches[0].index && record.level <= matches[0].level,
-  );
-  return lines.slice(matches[0].index + 1, end?.index).join('\n');
+  return markdownSectionTokens(markdown, heading, label)
+    .map((token) => token.raw)
+    .join('');
 }
 
 function assertNoticeSections(markdown, sections, label) {
   for (const section of sections) {
     const body = markdownSection(markdown, section.heading, label);
     for (const notice of section.notices) {
-      assertContainsNotice(body, notice, `${label} section ${section.heading}`);
+      assertContainsMarkdownNotice(body, notice, `${label} section ${section.heading}`);
     }
   }
 }
 
 function parseTable(markdown, heading) {
-  const lines = markdown.split(/\r?\n/u);
-  const headingIndex = lines.indexOf(heading);
-  assert.notEqual(headingIndex, -1, `${heading} is missing from THIRDPARTY`);
-
-  const headerIndex = lines.findIndex(
-    (line, index) =>
-      index > headingIndex && line.startsWith('|') && normalizeCell(line.split('|')[1] ?? '') === 'Escopo',
+  assertSingleTopLevelSectionElement(markdown, heading, 'THIRDPARTY', 'table', 'inventory table');
+  const tables = markdownSectionTokens(markdown, heading, 'THIRDPARTY').filter(
+    (token) => token.type === 'table',
   );
-  assert.notEqual(headerIndex, -1, `${heading} inventory table is missing`);
+  assert.equal(tables.length, 1, `${heading} must contain exactly one visible Markdown inventory table`);
+  const [table] = tables;
 
-  const nextHeadingIndex = lines.findIndex((line, index) => index > headingIndex && line.startsWith('## '));
-  assert.ok(
-    nextHeadingIndex === -1 || headerIndex < nextHeadingIndex,
-    `${heading} inventory table is outside its section`,
-  );
-
-  const header = lines[headerIndex].split('|').slice(1, -1).map(normalizeCell);
+  const header = table.header.map((cell) => normalizeCell(cell.text));
   assert.deepEqual(header, TABLE_HEADER, `${heading} inventory header changed`);
 
-  const records = [];
-  for (const line of lines.slice(headerIndex + 2)) {
-    if (!line.startsWith('|')) break;
-    const cells = line.split('|').slice(1, -1).map(normalizeCell);
-    assert.equal(cells.length, TABLE_HEADER.length, `invalid THIRDPARTY row: ${line}`);
-    records.push({
+  return table.rows.map((row) => {
+    const cells = row.map((cell) => normalizeCell(cell.text));
+    assert.equal(cells.length, TABLE_HEADER.length, `invalid THIRDPARTY row: ${table.raw}`);
+    return {
       scope: cells[0],
       name: cells[1],
       declaredVersion: cells[2],
@@ -491,12 +1037,28 @@ function parseTable(markdown, heading) {
       election: cells[5],
       integrity: cells[6],
       origin: cells[7],
-    });
-  }
-  return records;
+    };
+  });
 }
 
 function parseAdminWorkerInventory(markdown) {
+  assert.equal(
+    renderedTableCount(markdown),
+    1,
+    `${ADMIN_WORKER_NOTICE_SOURCE} must contain exactly one visible Markdown table`,
+  );
+  assert.equal(
+    renderedTableCountWithHeader(markdown, ADMIN_WORKER_INVENTORY_HEADER),
+    1,
+    `${ADMIN_WORKER_NOTICE_SOURCE} Inventário efetivo must contain exactly one visible contiguous table; separator is invalid when no such GFM table exists`,
+  );
+  assertSingleTopLevelSectionElement(
+    markdown,
+    '## Inventário efetivo',
+    ADMIN_WORKER_NOTICE_SOURCE,
+    'table',
+    'effective inventory table',
+  );
   const section = markdownSection(markdown, '## Inventário efetivo', ADMIN_WORKER_NOTICE_SOURCE);
   const tableLines = section.split(/\r?\n/u);
   while (tableLines[0]?.trim() === '') tableLines.shift();
@@ -659,17 +1221,37 @@ export function verifyThirdPartyInventory({
   workerArtifacts,
   requiredStaticNoticeMarkers = [],
   requiredStaticNoticeSections = [],
+  rootDocumentSchema,
   requiredBundledLicenseMarkers = [],
   bundledLicenseSupplementHeadings = [],
   requiredWorkerNoticeMarkers = [],
 }) {
   assert.equal(publicInventory, rootInventory, `${ROOT_INVENTORY} and ${PUBLIC_INVENTORY} must be byte-identical`);
   assert.equal(rootNotice, publicNotice, `${ROOT_NOTICE} and ${PUBLIC_NOTICE} must be byte-identical`);
+  assertVisibleMarkdownEvidence(rootInventory, 'THIRDPARTY');
+  if (rootDocumentSchema) {
+    assertClosedMarkdownDocument(rootInventory, rootDocumentSchema, 'THIRDPARTY');
+  }
 
   for (const marker of requiredStaticNoticeMarkers) {
-    assertContainsNotice(rootInventory, marker, 'THIRDPARTY');
+    if (/^#{1,6}\s/u.test(marker)) {
+      renderedSectionInspection(rootInventory, marker, 'THIRDPARTY');
+    } else {
+      assertContainsRenderedMarkdown(rootInventory, marker, 'THIRDPARTY');
+    }
   }
   assertNoticeSections(rootInventory, requiredStaticNoticeSections, 'THIRDPARTY');
+
+  assert.equal(
+    renderedTableCountWithHeader(rootInventory, TABLE_HEADER),
+    manifests.length,
+    `THIRDPARTY must contain exactly one visible Markdown inventory table per manifest (${manifests.length} total)`,
+  );
+  assert.equal(
+    renderedTableCountWithColumnCount(rootInventory, TABLE_HEADER.length),
+    manifests.length,
+    `THIRDPARTY must contain exactly ${manifests.length} eight-column inventory tables`,
+  );
 
   for (const manifest of manifests) {
     const actual = parseTable(rootInventory, manifest.heading);
@@ -860,10 +1442,7 @@ export async function verifyAdminWorkerBundle({
     sourceNotice,
     `${ADMIN_WORKER_NOTICE_ARTIFACT} must be byte-identical to ${ADMIN_WORKER_NOTICE_SOURCE}`,
   );
-  assert.ok(
-    !['<!--', '-->', '--!>'].some((marker) => sourceNotice.includes(marker)),
-    `${ADMIN_WORKER_NOTICE_SOURCE} must not contain HTML comments because all legal evidence must render visibly`,
-  );
+  assertVisibleMarkdownEvidence(sourceNotice, ADMIN_WORKER_NOTICE_SOURCE);
 
   const entryOutputs = Object.entries(metafile.outputs ?? {}).filter(
     ([, output]) => output.entryPoint !== undefined,
@@ -918,8 +1497,36 @@ export async function verifyAdminWorkerBundle({
       ),
     ),
   ].sort();
-  const documentHeadings = markdownHeadingRecords(sourceNotice).headings
-    .filter((record) => record.level === 2 && record.heading !== '## Inventário efetivo')
+  for (const { lockKey, packageName } of packages.values()) {
+    if (packageName !== 'launder') continue;
+    const lockEntry = packageLock.packages?.[lockKey];
+    assert.ok(lockEntry, `${lockKey} from the Admin Motor metafile is missing from package-lock.json`);
+    assert.deepEqual(
+      {
+        version: lockEntry.version,
+        license: lockEntry.license,
+        resolved: lockEntry.resolved,
+        integrity: lockEntry.integrity,
+      },
+      {
+        version: LAUNDER_AUDITED_ARTIFACT.version,
+        license: LAUNDER_AUDITED_ARTIFACT.license,
+        resolved: LAUNDER_AUDITED_ARTIFACT.resolved,
+        integrity: LAUNDER_AUDITED_ARTIFACT.integrity,
+      },
+      'launder must match the exact audited provenance; any drift requires a legal re-audit',
+    );
+  }
+  assertAdminDocumentStructure(sourceNotice, expectedSectionHeadings, packages.size);
+  const renderedPackageHeadings = renderedHeadingRecords(sourceNotice, 2).filter(
+    (record) => record.heading !== '## Inventário efetivo',
+  );
+  assert.equal(
+    renderedPackageHeadings.every((record) => record.topLevel),
+    true,
+    `${ADMIN_WORKER_NOTICE_SOURCE} dependency sections must all be top-level rendered GFM`,
+  );
+  const documentHeadings = renderedPackageHeadings
     .map((record) => record.heading)
     .sort();
   assert.deepEqual(
@@ -934,7 +1541,6 @@ export async function verifyAdminWorkerBundle({
     const lockEntry = packageLock.packages?.[lockKey];
     assert.ok(lockEntry, `${lockKey} from the Admin Motor metafile is missing from package-lock.json`);
     assertImmutableRegistryProvenance(`admin-motor:${lockKey}`, packageName, lockEntry);
-
     const sectionHeading = `## ${packageName} ${lockEntry.version} — ${lockEntry.license}`;
     const sectionBody = markdownSection(sourceNotice, sectionHeading, ADMIN_WORKER_NOTICE_SOURCE);
     const sectionPackageCount = expectedInventory.filter(
@@ -948,11 +1554,6 @@ export async function verifyAdminWorkerBundle({
       `- **Caminho no lockfile:** \`package-lock.json -> packages["${lockKey}"]\``,
       `${ADMIN_WORKER_NOTICE_SOURCE} section ${packageName} ${lockEntry.version}`,
     );
-    assert.equal(
-      markdownFieldLines(sectionBody, 'Caminho no lockfile').length,
-      sectionPackageCount,
-      `${ADMIN_WORKER_NOTICE_SOURCE} section ${packageName} ${lockEntry.version} must contain exactly one structural lockfile field per bundled artifact`,
-    );
     assertExactMarkdownField(
       sectionBody,
       'Resolved',
@@ -965,24 +1566,16 @@ export async function verifyAdminWorkerBundle({
       `- **Integrity:** \`${lockEntry.integrity}\``,
       `${ADMIN_WORKER_NOTICE_SOURCE} section ${packageName} ${lockEntry.version}`,
     );
+    assertExactMarkdownField(
+      sectionBody,
+      'Origem imutável/hash',
+      '- **Origem imutável/hash:** tarball npm versionado indicado em `Resolved`, autenticado pelo SRI SHA-512 indicado em `Integrity`.',
+      `${ADMIN_WORKER_NOTICE_SOURCE} section ${packageName} ${lockEntry.version}`,
+    );
 
     const upstreamNotice = await packageLicenseNotice(root, lockKey);
+    let expectedLegalText;
     if (packageName === 'launder') {
-      assert.deepEqual(
-        {
-          version: lockEntry.version,
-          license: lockEntry.license,
-          resolved: lockEntry.resolved,
-          integrity: lockEntry.integrity,
-        },
-        {
-          version: LAUNDER_AUDITED_ARTIFACT.version,
-          license: LAUNDER_AUDITED_ARTIFACT.license,
-          resolved: LAUNDER_AUDITED_ARTIFACT.resolved,
-          integrity: LAUNDER_AUDITED_ARTIFACT.integrity,
-        },
-        'launder must match the exact audited provenance; any drift requires a legal re-audit',
-      );
       assert.equal(
         upstreamNotice,
         undefined,
@@ -1011,21 +1604,25 @@ export async function verifyAdminWorkerBundle({
         `- **Origem upstream imutável:** tag anotada \`launder@1.7.1\`, commit \`${LAUNDER_AUDITED_ARTIFACT.upstreamCommit}\`, caminho \`packages/launder\` no repositório \`apostrophecms/apostrophe\`.`,
         'launder section',
       );
-      assertContainsNotice(sectionBody, LAUNDER_MIT_TERMS, 'launder section');
+      assertContainsMarkdownNotice(sectionBody, LAUNDER_MIT_TERMS, 'launder section');
+      expectedLegalText = `MIT License\n\n${LAUNDER_MIT_TERMS}`;
     } else {
       assert.ok(upstreamNotice, `${lockKey} must ship a legal notice file`);
-      assertContainsNotice(sectionBody, upstreamNotice.content, `${packageName} section`);
+      assertContainsMarkdownNotice(sectionBody, upstreamNotice.content, `${packageName} section`);
       assertExactMarkdownLine(
         sectionBody,
         `- **Fonte do aviso integral:** \`${lockKey}/${upstreamNotice.name}\` (\`SHA-256: ${upstreamNotice.sha256}\`).`,
         `${packageName} section`,
       );
-      assert.equal(
-        markdownFieldLines(sectionBody, 'Fonte do aviso integral').length,
-        sectionPackageCount,
-        `${packageName} section must contain exactly one structural legal-notice source field per bundled artifact`,
-      );
+      expectedLegalText = upstreamNotice.content;
     }
+    assertAdminSectionStructure(
+      sectionBody,
+      packageName === 'launder' ? sectionPackageCount + 5 : sectionPackageCount * 2 + 3,
+      expectedAdminSectionProse(packageName),
+      expectedLegalText,
+      `${ADMIN_WORKER_NOTICE_SOURCE} section ${packageName} ${lockEntry.version}`,
+    );
   }
 
   return {
@@ -1127,6 +1724,7 @@ async function main() {
     workerArtifacts,
     requiredStaticNoticeMarkers: REQUIRED_STATIC_NOTICE_MARKERS,
     requiredStaticNoticeSections: REQUIRED_STATIC_NOTICE_SECTIONS,
+    rootDocumentSchema: ROOT_DOCUMENT_SCHEMA,
     requiredBundledLicenseMarkers: REQUIRED_BUNDLED_LICENSE_MARKERS,
     bundledLicenseSupplementHeadings: BUNDLED_LICENSE_SUPPLEMENT_HEADINGS,
   });

--- a/scripts/verify-thirdparty.test.mjs
+++ b/scripts/verify-thirdparty.test.mjs
@@ -45,23 +45,34 @@ SOFTWARE.`;
 const TEST_LICENSE_SHA256 = createHash('sha256').update(TEST_LICENSE).digest('hex');
 const LAUNDER_MIT_TERMS = TEST_LICENSE.slice(TEST_LICENSE.indexOf('Permission is hereby granted'));
 
+function adminWorkerPreamble(packageCount) {
+  return `# Avisos de componentes de terceiros — Admin Motor
+
+Este arquivo acompanha o Worker \`admin-motor\` como módulo adicional do tipo \`Text\`. O inventário cobre exatamente os ${packageCount} pacotes npm com código efetivamente incorporado ao bundle Wrangler informado para este artefato. Pacotes de desenvolvimento, ferramentas externas e entradas desabilitadas de zero byte não pertencem a este escopo.
+
+Versão, licença declarada, URL \`resolved\` e SRI \`integrity\` foram conferidos na entrada \`packages\` de \`package-lock.json\`; o texto de cada aviso foi reproduzido integralmente do pacote da mesma versão instalado em \`node_modules\`. O caminho e o SHA-256 de cada fonte permitem verificar o texto sem confundi-lo com outra versão homônima.`;
+}
+
 function launderSectionBody({
-  license = 'MIT',
   resolved = 'https://registry.npmjs.org/launder/-/launder-1.7.1.tgz',
   integrity = LAUNDER_AUDITED_SRI,
   packageJsonSha256 = LAUNDER_PACKAGE_JSON_SHA256,
   upstreamCommit = LAUNDER_UPSTREAM_COMMIT,
 } = {}) {
   return `- **Caminho no lockfile:** \`package-lock.json -> packages["node_modules/launder"]\`
-- **Licença:** \`${license}\`
 - **Resolved:** \`${resolved}\`
 - **Integrity:** \`${integrity}\`
+- **Origem imutável/hash:** tarball npm versionado indicado em \`Resolved\`, autenticado pelo SRI SHA-512 indicado em \`Integrity\`.
 - **Evidência da licença declarada:** \`node_modules/launder/package.json\` (\`SHA-256: ${packageJsonSha256}\`).
 - **Origem upstream imutável:** tag anotada \`launder@1.7.1\`, commit \`${upstreamCommit}\`, caminho \`packages/launder\` no repositório \`apostrophecms/apostrophe\`.
 
-O pacote npm não contém arquivo LICENSE.
+O pacote npm e a tag upstream \`launder@1.7.1\` declaram \`MIT\`, mas o pacote/tarball dessa versão não traz arquivo \`LICENSE\`. Por isso, os termos canônicos da MIT são reproduzidos abaixo sem inventar titular, ano ou aviso de copyright ausente no upstream.
 
-${LAUNDER_MIT_TERMS}`;
+\`\`\`text
+MIT License
+
+${LAUNDER_MIT_TERMS}
+\`\`\``;
 }
 
 async function withAdminWorkerFixture(
@@ -73,6 +84,7 @@ async function withAdminWorkerFixture(
     resolved: resolvedOverride,
     integrity = `sha512-${Buffer.alloc(64, 4).toString('base64')}`,
     includeLicense = true,
+    licenseContent = TEST_LICENSE,
     sectionBody,
     sourceNoticeTransform = (notice) => notice,
     packageJsonTransform = (content) => content,
@@ -84,14 +96,17 @@ async function withAdminWorkerFixture(
   const entryContent = 'export default {};\n';
   const resolved =
     resolvedOverride ?? `https://registry.npmjs.org/${packageName}/-/${packageName}-${version}.tgz`;
-  const licenseSha256 = createHash('sha256').update(TEST_LICENSE).digest('hex');
+  const licenseSha256 = createHash('sha256').update(licenseContent).digest('hex');
   const defaultSectionBody = `- **Caminho no lockfile:** \`package-lock.json -> packages["${lockKey}"]\`
 - **Resolved:** \`${resolved}\`
 - **Integrity:** \`${integrity}\`
+- **Origem imutável/hash:** tarball npm versionado indicado em \`Resolved\`, autenticado pelo SRI SHA-512 indicado em \`Integrity\`.
 - **Fonte do aviso integral:** \`${lockKey}/LICENSE\` (\`SHA-256: ${licenseSha256}\`).
 
-${TEST_LICENSE}`;
-  const sourceNotice = sourceNoticeTransform(`# Admin Motor third-party notices
+\`\`\`text
+${licenseContent}
+\`\`\``;
+  const sourceNotice = sourceNoticeTransform(`${adminWorkerPreamble(1)}
 
 ## Inventário efetivo
 
@@ -108,7 +123,7 @@ ${sectionBody ?? defaultSectionBody}
     await mkdir(join(root, 'admin-motor', 'dist', 'legal-audit'), { recursive: true });
     await mkdir(join(root, lockKey), { recursive: true });
     await writeFile(join(root, 'admin-motor', 'dist', 'legal-audit', 'index.js'), entryContent);
-    if (includeLicense) await writeFile(join(root, lockKey, 'LICENSE'), TEST_LICENSE);
+    if (includeLicense) await writeFile(join(root, lockKey, 'LICENSE'), licenseContent);
     const packageJson =
       packageName === 'launder'
         ? await readFile(join(process.cwd(), 'node_modules', 'launder', 'package.json'))
@@ -153,7 +168,7 @@ async function withRepeatedAdminWorkerFixture({ includeBothLockPaths }, assertio
     (lockKey) =>
       `- **Fonte do aviso integral:** \`${lockKey}/LICENSE\` (\`SHA-256: ${licenseSha256}\`).`,
   );
-  const sourceNotice = `# Admin Motor third-party notices
+  const sourceNotice = `${adminWorkerPreamble(2)}
 
 ## Inventário efetivo
 
@@ -166,9 +181,12 @@ ${lockKeys.map((lockKey) => `| \`foo\` | \`${version}\` | \`MIT\` | \`packages["
 ${lockMarkers.join('\n')}
 - **Resolved:** \`${resolved}\`
 - **Integrity:** \`${integrity}\`
+- **Origem imutável/hash:** tarball npm versionado indicado em \`Resolved\`, autenticado pelo SRI SHA-512 indicado em \`Integrity\`.
 ${sourceMarkers.join('\n')}
 
+\`\`\`text
 ${TEST_LICENSE}
+\`\`\`
 `;
 
   try {
@@ -248,6 +266,14 @@ const motorManifest = {
   },
 };
 
+const ROOT_TEST_DOCUMENT_SCHEMA = Object.freeze({
+  title: '# Third-party inventory',
+  headings: Object.freeze([rootManifest.heading, motorManifest.heading]),
+  paragraphCount: 0,
+  tableCount: 2,
+  codeBlockCount: 0,
+});
+
 function inventory({ omitBeta = false } = {}) {
   return `# Third-party inventory
 
@@ -283,6 +309,7 @@ function verify(overrides = {}) {
     workerArtifacts: overrides.workerArtifacts,
     requiredStaticNoticeMarkers: overrides.requiredStaticNoticeMarkers,
     requiredStaticNoticeSections: overrides.requiredStaticNoticeSections,
+    rootDocumentSchema: overrides.rootDocumentSchema,
     requiredBundledLicenseMarkers: overrides.requiredBundledLicenseMarkers,
     bundledLicenseSupplementHeadings: overrides.bundledLicenseSupplementHeadings,
     requiredWorkerNoticeMarkers: overrides.requiredWorkerNoticeMarkers,
@@ -291,6 +318,301 @@ function verify(overrides = {}) {
 
 test('accepts complete inventories for both manifests', () => {
   expect(() => verify()).not.toThrow();
+});
+
+test('rejects a root inventory table with a malformed separator', () => {
+  const changed = inventory().replace(
+    '| --- | --- | --- | --- | --- | --- | --- | --- |',
+    'this is not a Markdown table separator',
+  );
+  expect(() => verify({ rootInventory: changed })).toThrow(/inventory table|separator/iu);
+});
+
+test.each([
+  ['tilde fence', (content) => `~~~markdown\n${content}\n~~~`],
+  ['HTML comment', (content) => `<!--\n${content}\n-->`],
+  ['raw pre block', (content) => `<pre>\n${content}\n</pre>`],
+])('rejects a root inventory rendered as %s', (_label, transform) => {
+  expect(() => verify({ rootInventory: transform(inventory()) })).toThrow(/Inventário|inventory/iu);
+});
+
+test('rejects a duplicate indented inventory heading', () => {
+  const changed = `${inventory()}\n  ## Inventário: package.json (raiz)\n\nContraditório.\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|inventory/iu);
+});
+
+test('rejects a rendered-equivalent duplicate inventory heading', () => {
+  const changed = `${inventory()}\n## Inventário&#58; *package.json* (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test('rejects a Unicode-normalized duplicate inventory heading', () => {
+  const changed = `${inventory()}\n## Inventa\u0301rio: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test('rejects a duplicate heading whose canonical form emerges after invisible formatting is removed', () => {
+  const changed = `${inventory()}\n## Inventa\u200b\u0301rio: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test.each([
+  ['combining grapheme joiner', '\u034f'],
+  ['variation selector', '\ufe0f'],
+])('rejects a duplicate inventory heading containing a default-ignorable %s', (_label, marker) => {
+  const changed = `${inventory()}\n## Inventário${marker}: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test.each([
+  ['backspace', '\u0008'],
+  ['delete', '\u007f'],
+])('rejects a duplicate inventory heading containing an invisible %s control', (_label, control) => {
+  const changed = `${inventory()}\n## Inventário${control}: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/control|visible legal evidence/iu);
+});
+
+test('rejects an NFKC-equivalent duplicate inventory heading', () => {
+  const changed = `${inventory()}\n## Inventário： package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|canonical|inventory/iu);
+});
+
+test.each([
+  ['lowercase', '## inventário: package.json (raiz)'],
+  ['space before colon', '## Inventário : package.json (raiz)'],
+])('rejects a %s duplicate inventory heading', (_variant, heading) => {
+  const changed = `${inventory()}\n${heading}\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|canonical|inventory/iu);
+});
+
+test('rejects a required legal notice rendered as struck-through Markdown', () => {
+  const changed = `${inventory()}\n### Review notice\n\n~~complete legal notice~~\n`;
+  expect(() =>
+    verify({
+      rootInventory: changed,
+      requiredStaticNoticeSections: [
+        { heading: '### Review notice', notices: ['complete legal notice'] },
+      ],
+    }),
+  ).toThrow(/struck-through|deleted|visible legal evidence/iu);
+});
+
+test('rejects a required heading rendered as struck-through Markdown', () => {
+  const changed = `${inventory()}\n### ~~JSZip 3.10.1 — MIT~~\n`;
+  expect(() =>
+    verify({
+      rootInventory: changed,
+      requiredStaticNoticeMarkers: ['### JSZip 3.10.1 — MIT'],
+    }),
+  ).toThrow(/struck-through|deleted|visible legal evidence/iu);
+});
+
+test('rejects bidirectional controls in visible legal evidence', () => {
+  const changed = `${inventory()}\n### Review notice\n\ncomplete \u202elegal\u202c notice\n`;
+  expect(() =>
+    verify({
+      rootInventory: changed,
+      requiredStaticNoticeSections: [
+        { heading: '### Review notice', notices: ['complete legal notice'] },
+      ],
+    }),
+  ).toThrow(/bidirectional|bidi|visible legal evidence/iu);
+});
+
+test('rejects a duplicate inventory heading nested in a blockquote', () => {
+  const changed = `${inventory()}\n> ## Inventário: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test('rejects a duplicate inventory heading nested in a list item', () => {
+  const changed = `${inventory()}\n- Wrapper\n\n  ## Inventário: package.json (raiz)\n`;
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one|top-level|inventory/iu);
+});
+
+test.each([
+  ['hidden div', (content) => `<div hidden>\n\n${content}\n\n</div>`],
+  ['closed details', (content) => `<details>\n\n${content}\n\n</details>`],
+  ['remote iframe', (content) => `<iframe src="https://example.invalid/probe"></iframe>\n\n${content}`],
+])('rejects a root inventory nested in a raw HTML %s', (_label, transform) => {
+  expect(() => verify({ rootInventory: transform(inventory()) })).toThrow(/top-level|raw HTML|inventory/iu);
+});
+
+test('rejects a second visible inventory table in the same section', () => {
+  const duplicate = `| Escopo | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  const changed = inventory().replace(
+    '## Inventário: tlsrpt-motor/package.json',
+    `${duplicate}\n\n## Inventário: tlsrpt-motor/package.json`,
+  );
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one visible Markdown inventory table/iu);
+});
+
+test('rejects a second inventory table nested in a blockquote', () => {
+  const nested = `> | Escopo | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+> | --- | --- | --- | --- | --- | --- | --- | --- |
+> | runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  const changed = inventory().replace(
+    '## Inventário: tlsrpt-motor/package.json',
+    `${nested}\n\n## Inventário: tlsrpt-motor/package.json`,
+  );
+  expect(() => verify({ rootInventory: changed })).toThrow(/exactly one visible Markdown inventory table/iu);
+});
+
+test('rejects an inventory-shaped table under a different heading', () => {
+  const extra = `## Inventário contraditório
+
+| Escopo | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  expect(() => verify({ rootInventory: `${inventory()}\n${extra}\n` })).toThrow(
+    /exactly one visible Markdown inventory table/iu,
+  );
+});
+
+test('rejects an additional noncanonical table outside the closed root inventory outline', () => {
+  const extra = `# Apêndice contraditório
+
+| Componente | Licença |
+| --- | --- |
+| pacote-fantasma | Proprietária |`;
+  expect(() =>
+    verify({
+      rootInventory: `${inventory()}\n${extra}\n`,
+      rootDocumentSchema: ROOT_TEST_DOCUMENT_SCHEMA,
+    }),
+  ).toThrow(/closed document|exactly two visible Markdown tables|table count/iu);
+});
+
+test('rejects an additional H1 and contradictory prose outside the closed root outline', () => {
+  const extra = `# Avisos revogados
+
+Este documento não concede qualquer permissão.`;
+  expect(() =>
+    verify({
+      rootInventory: `${inventory()}\n${extra}\n`,
+      rootDocumentSchema: ROOT_TEST_DOCUMENT_SCHEMA,
+    }),
+  ).toThrow(/closed document|heading outline|paragraph count|title/iu);
+});
+
+test('rejects legal drift inside a closed static root table', () => {
+  const staticTable = `## Complementos legais
+
+| Componente | Licença aplicada |
+| --- | --- |
+| JSZip | Proprietária; redistribuição proibida |`;
+  expect(() =>
+    verify({
+      rootInventory: `${inventory()}\n${staticTable}\n`,
+      rootDocumentSchema: {
+        ...ROOT_TEST_DOCUMENT_SCHEMA,
+        headings: [...ROOT_TEST_DOCUMENT_SCHEMA.headings, '## Complementos legais'],
+        tableCount: 3,
+        dynamicTableCount: 2,
+        staticTableDigests: [
+          '58c4b5700269607e51b0d6f2badcdd2d0304cbb0c230ecb3b726acad1cfb696f',
+        ],
+      },
+    }),
+  ).toThrow(/static legal table|audited table/iu);
+});
+
+test('rejects moving an unchanged legal block into a different root section', () => {
+  const misplaced = `## Componente incorporado
+
+### Aviso integral
+
+## Complementos
+
+\`\`\`text
+LEGAL
+\`\`\``;
+  const headings = [
+    ...ROOT_TEST_DOCUMENT_SCHEMA.headings,
+    '## Componente incorporado',
+    '### Aviso integral',
+    '## Complementos',
+  ];
+  expect(() =>
+    verify({
+      rootInventory: `${inventory()}\n${misplaced}\n`,
+      rootDocumentSchema: {
+        ...ROOT_TEST_DOCUMENT_SCHEMA,
+        headings,
+        codeBlockCount: 1,
+        codeBlockDigests: [
+          'ab0730acb114a4ef42c2b4e3d80cf0f3a580ff5d4cd54a2d6c2a3d75c05c952b',
+        ],
+        sections: [
+          { heading: '# Third-party inventory', tokens: [] },
+          { heading: rootManifest.heading, tokens: [{ type: 'table' }] },
+          { heading: motorManifest.heading, tokens: [{ type: 'table' }] },
+          { heading: '## Componente incorporado', tokens: [] },
+          {
+            heading: '### Aviso integral',
+            tokens: [
+              {
+                type: 'code',
+                digest: 'ab0730acb114a4ef42c2b4e3d80cf0f3a580ff5d4cd54a2d6c2a3d75c05c952b',
+              },
+            ],
+          },
+          { heading: '## Complementos', tokens: [] },
+        ],
+      },
+    }),
+  ).toThrow(/section content|assigned.*section|Aviso integral/iu);
+});
+
+test('rejects an inventory-shaped table with an NFKC-equivalent header', () => {
+  const extra = `## Inventário contraditório
+
+| Ｅｓｃｏｐｏ | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  expect(() => verify({ rootInventory: `${inventory()}\n${extra}\n` })).toThrow(
+    /exactly one visible Markdown inventory table/iu,
+  );
+});
+
+test.each([
+  ['a cross-script homograph', 'Escоpo'],
+  ['a simple typo', 'Escop'],
+])('rejects an additional eight-column inventory table with %s in its header', (_label, scopeHeader) => {
+  const extra = `## Inventário contraditório
+
+| ${scopeHeader} | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  expect(() => verify({ rootInventory: `${inventory()}\n${extra}\n` })).toThrow(
+    /exactly two|eight-column|inventory table/iu,
+  );
+});
+
+test('rejects an inventory-shaped table whose header contains a zero-width character', () => {
+  const extra = `## Inventário contraditório
+
+| Escopo\u200b | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  expect(() => verify({ rootInventory: `${inventory()}\n${extra}\n` })).toThrow(
+    /exactly one visible Markdown inventory table/iu,
+  );
+});
+
+test.each([
+  ['combining grapheme joiner', '\u034f'],
+  ['variation selector', '\ufe0f'],
+])('rejects an inventory-shaped table whose header contains a default-ignorable %s', (_label, marker) => {
+  const extra = `## Inventário contraditório
+
+| Escopo${marker} | Componente | Versão declarada | Versão resolvida | Licença do pacote | Eleição | Integridade | Origem imutável |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| runtime | attacker | 9.9.9 | 9.9.9 | MIT | — | ${ALPHA_SRI} | https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz |`;
+  expect(() => verify({ rootInventory: `${inventory()}\n${extra}\n` })).toThrow(
+    /exactly one visible Markdown inventory table/iu,
+  );
 });
 
 test('rejects drift in a vendored browser distribution', () => {
@@ -342,6 +664,22 @@ test('rejects a false visible field backed only by the exact value inside a code
   );
 });
 
+test('rejects a false visible field backed only by the exact value inside raw HTML', async () => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  const falseVisible = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(exact, `${falseVisible}\n\n<pre>\n${exact}\n</pre>`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/raw HTML|structural Resolved|exactly one/iu);
+    },
+  );
+});
+
 test('rejects a contradictory duplicate visible field beside the exact value', async () => {
   const exact = '- **Integrity:** `sha512-BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBA==`';
   const contradiction = `- **Integrity:** \`${ALPHA_SRI}\``;
@@ -352,7 +690,9 @@ test('rejects a contradictory duplicate visible field beside the exact value', a
       sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/visible Integrity field|exactly one/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /visible Integrity field|exactly one|metadata/iu,
+      );
     },
   );
 });
@@ -369,7 +709,176 @@ test.each([
       sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/exactly one structural Resolved/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one (?:structural Resolved|structural visible list item)|metadata/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  ['a blockquote', '> **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`'],
+  ['a paragraph', '**Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`'],
+])('rejects a contradictory duplicate field rendered as %s', async (_variant, contradiction) => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n\n${contradiction}`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one structural Resolved field|metadata|closed document/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  [
+    'adjacent strong elements',
+    '- **Resolved****:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`',
+  ],
+  [
+    'strong text and a plain colon',
+    '- **Resolved**: `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`',
+  ],
+])('rejects a contradictory field label split across %s', async (_variant, contradiction) => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one structural Resolved field|metadata/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  [
+    'an icon-prefixed fragmented strong label',
+    '- ⚠ **Resolved****:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`',
+    '\n',
+  ],
+  [
+    'an icon-prefixed strong label',
+    '- ⚠ **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`',
+    '\n',
+  ],
+  [
+    'a heading',
+    '### **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`',
+    '\n\n',
+  ],
+])(
+  'rejects a contradictory field label rendered inside %s',
+  async (_variant, contradiction, separator) => {
+    const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+    await withAdminWorkerFixture(
+      {
+        packageName: 'alpha',
+        version: '1.0.1',
+        sourceNoticeTransform: (notice) =>
+          notice.replace(exact, `${exact}${separator}${contradiction}`),
+      },
+      async (fixture) => {
+        await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+          /exactly one structural Resolved field|metadata|heading outline/iu,
+        );
+      },
+    );
+  },
+);
+
+test('rejects a contradictory NFKC-equivalent Admin Worker field label', async () => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  const contradiction =
+    '- **Ｒｅｓｏｌｖｅｄ:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one structural Resolved field|metadata/iu,
+      );
+    },
+  );
+});
+
+test('rejects an invisible control inside a contradictory Admin Worker field label', async () => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  const contradiction =
+    '- **Resolved\u0008:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /control|visible legal evidence/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  ['lowercase', '- **resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`'],
+  ['space before colon', '- **Resolved :** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`'],
+  ['cross-script homograph', '- **Rеsolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`'],
+])('rejects an additional %s metadata field', async (_variant, contradiction) => {
+  const exact = '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => notice.replace(exact, `${exact}\n${contradiction}`),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /metadata|list item|exactly one structural Resolved field/iu,
+      );
+    },
+  );
+});
+
+test('accepts an upstream legal notice whose prose contains a field-like word', async () => {
+  const licenseContent = `${TEST_LICENSE}\n\nThis historical dispute was Resolved: amicably.`;
+  await withAdminWorkerFixture(
+    { packageName: 'alpha', version: '1.0.1', licenseContent },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).resolves.toEqual({
+        entryOutputPath: 'dist/legal-audit/index.js',
+        packageCount: 1,
+      });
+    },
+  );
+});
+
+test('rejects drift in the Admin Worker immutable-origin metadata field', async () => {
+  const exact =
+    '- **Origem imutável/hash:** tarball npm versionado indicado em `Resolved`, autenticado pelo SRI SHA-512 indicado em `Integrity`.';
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(exact, '- **Origem imutável/hash:** origem mutável sem autenticação.'),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /Origem imutável\/hash|immutable-origin|metadata/iu,
+      );
     },
   );
 });
@@ -439,6 +948,64 @@ test('rejects a truncated legal notice inside its configured section', () => {
       ],
     }),
   ).toThrow(/complete required legal notice/u);
+});
+
+test('rejects a legal notice whose inline token boundaries do not render whitespace', () => {
+  const rootInventory = `${inventory()}\n### Review notice\n\ncomplete**MIT**notice\n`;
+  expect(() =>
+    verify({
+      rootInventory,
+      requiredStaticNoticeSections: [
+        {
+          heading: '### Review notice',
+          notices: ['complete MIT notice'],
+        },
+      ],
+    }),
+  ).toThrow(/complete required legal notice/u);
+});
+
+test('rejects a configured legal notice supplied only as raw HTML', () => {
+  const rootInventory = `${inventory()}\n### Pako 1.0.5 — MIT e Zlib\n\n<pre>\ncomplete MIT notice\ncomplete Zlib notice\n</pre>\n`;
+  expect(() =>
+    verify({
+      rootInventory,
+      requiredStaticNoticeSections: [
+        {
+          heading: '### Pako 1.0.5 — MIT e Zlib',
+          notices: ['complete MIT notice', 'complete Zlib notice'],
+        },
+      ],
+    }),
+  ).toThrow(/complete required legal notice|raw HTML/u);
+});
+
+test('rejects a configured legal notice supplied only as image alt text', () => {
+  const rootInventory = `${inventory()}\n### Review notice\n\n![complete legal notice](data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==)\n`;
+  expect(() =>
+    verify({
+      rootInventory,
+      requiredStaticNoticeSections: [
+        {
+          heading: '### Review notice',
+          notices: ['complete legal notice'],
+        },
+      ],
+    }),
+  ).toThrow(/complete required legal notice/u);
+});
+
+test('rejects a required legal heading supplied only as an invisible link title', () => {
+  const changed = inventory().replace(
+    '### JSZip 3.10.1 — MIT',
+    '[supplement](https://example.invalid "### JSZip 3.10.1 — MIT")',
+  );
+  expect(() =>
+    verify({
+      rootInventory: changed,
+      requiredStaticNoticeMarkers: ['### JSZip 3.10.1 — MIT'],
+    }),
+  ).toThrow(/exactly one semantic|section/u);
 });
 
 test('rejects a deployed Worker whose configured complete notice is absent', () => {
@@ -586,6 +1153,25 @@ test('accepts a Wrangler Worker artifact with its required legal notice', () => 
   ).not.toThrow();
 });
 
+test('accepts an unrelated control in Worker code when the complete legal notice is intact', () => {
+  expect(() =>
+    verify({
+      workerArtifact: `const sentinel = "\u0001";\n/*! ${BASE64_ARRAY_BUFFER_MIT_NOTICE} */`,
+      requiredWorkerNoticeMarkers: [BASE64_ARRAY_BUFFER_MIT_NOTICE],
+    }),
+  ).not.toThrow();
+});
+
+test('rejects a Worker legal notice altered with a default-ignorable character', () => {
+  const alteredNotice = BASE64_ARRAY_BUFFER_MIT_NOTICE.replace('Copyright', 'Copy\u200bright');
+  expect(() =>
+    verify({
+      workerArtifact: `/*! ${alteredNotice} */`,
+      requiredWorkerNoticeMarkers: [BASE64_ARRAY_BUFFER_MIT_NOTICE],
+    }),
+  ).toThrow(/complete required legal notice/u);
+});
+
 test('rejects a truncated Wrangler Worker legal notice', () => {
   expect(() =>
     verify({
@@ -614,6 +1200,104 @@ test('rejects drift in the Admin Worker effective inventory table', async () => 
   );
 });
 
+test('rejects a replaced Admin Worker title', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '# Avisos de componentes de terceiros — Admin Motor',
+          '# Licenças revogadas — Admin Motor',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/canonical title|heading outline/iu);
+    },
+  );
+});
+
+test('rejects an additional Admin Worker H1 and contradictory prose', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        `${notice}\n# Avisos revogados\n\nEste documento não concede qualquer permissão.\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/heading outline|closed document/iu);
+    },
+  );
+});
+
+test('rejects contradictory metadata before the Admin Worker inventory', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '## Inventário efetivo',
+          '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz`\n\n## Inventário efetivo',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/canonical preamble|closed document/iu);
+    },
+  );
+});
+
+test('rejects contradictory prose inside an Admin Worker package section', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '\n```text\n',
+          '\nEste aviso foi revogado e não concede qualquer permissão.\n\n```text\n',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /canonical prose|closed section|noncanonical package prose/iu,
+      );
+    },
+  );
+});
+
+test('rejects a duplicate integral license block in an Admin Worker package section', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => `${notice}\n\n\`\`\`text\n${TEST_LICENSE}\n\`\`\`\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /one fenced legal-text block|closed section|legal-text block per package/iu,
+      );
+    },
+  );
+});
+
+test('rejects an unfenced integral license in an Admin Worker package section', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(`\`\`\`text\n${TEST_LICENSE}\n\`\`\``, TEST_LICENSE),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /one fenced legal-text block|closed section|legal-text block per package/iu,
+      );
+    },
+  );
+});
+
 test('rejects an Admin Worker inventory hidden in an HTML comment', async () => {
   await withAdminWorkerFixture(
     {
@@ -626,7 +1310,7 @@ test('rejects an Admin Worker inventory hidden in an HTML comment', async () => 
         ),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/HTML comments|visible contiguous table/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/raw HTML|visible contiguous table/iu);
     },
   );
 });
@@ -644,7 +1328,7 @@ test('rejects an Admin Worker legal document hidden entirely in an HTML comment'
   );
 });
 
-test('rejects the HTML comment end-tag variant --!>', async () => {
+test('rejects an unexpected standalone HTML comment end-tag marker outside the closed outline', async () => {
   await withAdminWorkerFixture(
     {
       packageName: 'alpha',
@@ -652,7 +1336,141 @@ test('rejects the HTML comment end-tag variant --!>', async () => {
       sourceNoticeTransform: (notice) => `${notice}\n--!>`,
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/HTML comments/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/closed document|heading outline/iu);
+    },
+  );
+});
+
+test('rejects an Admin Worker legal document rendered as a raw pre block', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => `<pre>\n${notice}\n</pre>`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/Inventário efetivo|visible/iu);
+    },
+  );
+});
+
+test('rejects an encoded bidirectional control after GFM entity decoding', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '# Avisos de componentes de terceiros — Admin Motor',
+          '# Avisos de componentes de terceiros — Admin Motor &#x202e;etiqueta&#x202c;',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /bidirectional|bidi|visible legal evidence/iu,
+      );
+    },
+  );
+});
+
+test('rejects an encoded invisible control after GFM entity decoding', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '# Avisos de componentes de terceiros — Admin Motor',
+          '# Avisos de componentes de terceiros — Admin Motor &#x7f;',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /control|visible legal evidence/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  ['hidden div', (notice) => `<div hidden>\n\n${notice}\n\n</div>`],
+  ['closed details', (notice) => `<details>\n\n${notice}\n\n</details>`],
+])('rejects an Admin Worker legal document nested in a raw HTML %s', async (_label, transform) => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: transform,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/top-level|raw HTML|visible/iu);
+    },
+  );
+});
+
+test('rejects a duplicate Admin Worker inventory heading nested in a blockquote', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => `${notice}\n> ## Inventário efetivo\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/exactly one semantic|top-level/iu);
+    },
+  );
+});
+
+test('rejects an unexpected Admin Worker dependency heading nested in a blockquote', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        `${notice}\n> ## attacker 9.9.9 — MIT\n>\n> Contraditório.\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /dependency sections.*top-level|closed document/iu,
+      );
+    },
+  );
+});
+
+test('rejects an extra Admin Worker inventory-shaped table under another heading', async () => {
+  const extra = `## Inventário contraditório
+
+| Componente | Versão | Licença | Caminho no lockfile |
+| --- | --- | --- | --- |
+| \`attacker\` | \`9.9.9\` | \`MIT\` | \`packages["node_modules/attacker"]\` |`;
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => `${notice}\n${extra}\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one (?:effective inventory-shaped|visible contiguous|visible Markdown table)/iu,
+      );
+    },
+  );
+});
+
+test('rejects an extra noncanonical table inside an Admin Worker dependency section', async () => {
+  const extra = `| Componentе | Versão | Licença | Caminho no lockfile |
+| --- | --- | --- | --- |
+| \`attacker\` | \`9.9.9\` | \`MIT\` | \`packages["node_modules/attacker"]\` |`;
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) => `${notice}\n${extra}\n`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one visible Markdown table/iu,
+      );
     },
   );
 });
@@ -669,7 +1487,9 @@ test('rejects an Admin Worker inventory indented as a Markdown code block', asyn
         ),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/visible contiguous table/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /visible contiguous table|visible Markdown table/iu,
+      );
     },
   );
 });
@@ -686,7 +1506,9 @@ test('rejects an Admin Worker inventory whose first header row alone is a Markdo
         ),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/visible contiguous table/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /visible contiguous table|visible Markdown table/iu,
+      );
     },
   );
 });
@@ -699,7 +1521,9 @@ test('rejects an Admin Worker legal document hidden in a tilde code fence', asyn
       sourceNoticeTransform: (notice) => `~~~markdown\n${notice}\n~~~`,
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/Inventário efetivo|exact bundled npm artifact/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /Inventário efetivo|exact bundled npm artifact|visible Markdown table/iu,
+      );
     },
   );
 });
@@ -712,7 +1536,9 @@ test('rejects an Admin Worker legal document hidden by a longer backtick fence',
       sourceNoticeTransform: (notice) => `\`\`\`\`markdown\n\`\`\`\n${notice}\n\`\`\`\n\`\`\`\``,
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/Inventário efetivo|exact bundled npm artifact/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /Inventário efetivo|exact bundled npm artifact|visible Markdown table/iu,
+      );
     },
   );
 });
@@ -725,7 +1551,9 @@ test('rejects an Admin Worker inventory with a malformed separator cardinality',
       sourceNoticeTransform: (notice) => notice.replace('| --- | --- | --- | --- |', '| --- |'),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/separator is invalid/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /separator is invalid|visible Markdown table/iu,
+      );
     },
   );
 });
@@ -738,14 +1566,18 @@ test('rejects an Admin Worker package heading whose version only shares the expe
       sourceNoticeTransform: (notice) => notice.replace('## alpha 1.0.1 — MIT', '## alpha 1.0.10 — MIT'),
     },
     async (fixture) => {
-      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/exactly one section per.*artifact/iu);
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one section per.*artifact|heading outline/iu,
+      );
     },
   );
 });
 
 test('rejects a shared package section that omits one exact repeated lockfile path', async () => {
   await withRepeatedAdminWorkerFixture({ includeBothLockPaths: false }, async (fixture) => {
-    await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(/must contain exactly once.*node_modules\/foo/iu);
+    await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+      /must contain exactly (?:once|one structural).*node_modules\/foo/iu,
+    );
   });
 });
 
@@ -756,6 +1588,66 @@ test('accepts one exact package section that names every repeated lockfile path'
       packageCount: 2,
     });
   });
+});
+
+test('rejects a rendered-equivalent Admin Worker field label with collapsed whitespace', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '- **Caminho no lockfile:** `package-lock.json -> packages["node_modules/alpha"]`',
+          '- **Caminho no lockfile:** `package-lock.json -> packages["node_modules/alpha"]`\n' +
+            '- **Caminho  no lockfile:** `package-lock.json -> packages["node_modules/attacker"]`',
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one structural lockfile field|metadata/iu,
+      );
+    },
+  );
+});
+
+test.each([
+  ['zero-width character', '\u200b'],
+  ['combining grapheme joiner', '\u034f'],
+  ['variation selector', '\ufe0f'],
+])('rejects a rendered-equivalent Admin Worker field label containing a %s', async (_label, marker) => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      sourceNoticeTransform: (notice) =>
+        notice.replace(
+          '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`',
+          '- **Resolved:** `https://registry.npmjs.org/alpha/-/alpha-1.0.1.tgz`\n' +
+            `- **Resolved${marker}:** \`https://registry.npmjs.org/alpha/-/alpha-9.9.9.tgz\``,
+        ),
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).rejects.toThrow(
+        /exactly one structural Resolved field|metadata/iu,
+      );
+    },
+  );
+});
+
+test('accepts an HTML-comment marker when it belongs to the exact upstream legal text', async () => {
+  await withAdminWorkerFixture(
+    {
+      packageName: 'alpha',
+      version: '1.0.1',
+      licenseContent: `${TEST_LICENSE}\n\n<!-- literal upstream text -->`,
+    },
+    async (fixture) => {
+      await expect(verifyAdminWorkerBundle(fixture)).resolves.toEqual({
+        entryOutputPath: 'dist/legal-audit/index.js',
+        packageCount: 1,
+      });
+    },
+  );
 });
 
 test.each([


### PR DESCRIPTION
## Summary

- Close the rendered-document and section-boundary gaps in the repository-local third-party notice gate.
- Validate canonical GFM outline, tables, metadata cardinality, section association, fenced upstream license text, Unicode/control safety, and Vite/Wrangler artifact notices.
- Keep the implementation isolated to `admin-app`, using existing MIT-licensed `marked` and `happy-dom`; no dependency, workflow, credential, network service, or central controller was added.

Closes #565
Linear: https://linear.app/lcv-ideas-software/issue/ADMIAPP-17/completar-inventario-legal-dos-dois-manifestos-e-generalizar-o-gate

## Root cause

The previous checks validated selected lines and tables but did not close the complete rendered Markdown grammar or bind every legal block/token to its canonical section. Structurally altered documents could therefore preserve the checked fragments while changing meaning or placement.

## Native/official assessment

GitHub License Compliance and GitHub SBOM remain the native controls for detected-license policy and dependency inventory. They are complementary to this repository-local artifact gate: neither proves that the audited legal text reaches Vite/Wrangler outputs with the required source equivalence. The gate therefore remains local and fail-closed, without a cross-repository controller.

## Validation

- [x] Relevant local checks were run or the change is documentation/configuration only.
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs. (No Actions change.)
- [x] Dependabot automation remains non-blocking for routine patch/minor updates. (Unchanged.)
- [x] `npm run test:thirdparty` — 148/148
- [x] `npm test` — 522/522
- [x] `npm run test:admin-motor` — 625/625
- [x] `npm run verify:thirdparty`
- [x] `npm run verify:thirdparty:artifact`
- [x] `npm run verify:thirdparty:worker-artifacts` — 18 packages
- [x] `npm run build`, `npm run lint`, `npm run typecheck:admin-motor`, `npm run format:public:check`, `git diff --check`
- [x] Wrangler dry-runs for `tlsrpt-motor` and `admin-motor`
- [x] Two independent local reviews: READY
- [x] Cross Review `a82c6c90-c05b-4ff9-9a53-a2c4dc42af02`: Claude, Grok, and Perplexity returned READY; the stalled DeepSeek call was cancelled without a usable response.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] New deployment or cloud access uses short-lived credentials or OIDC where practical. (No deployment/cloud-access change.)
- [x] Commit `6f6a7605b7c9f1a08a0a76d8ad800d2e70b2dfd9` is GPG-signed and locally verified.