### PR TITLE
fix(deps): raise the @xmldom/xmldom override to ^0.9.12 (GHSA-6gmq-8vp8-gcm6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5159,9 +5159,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
       "undici": "7.29.0"
     },
     "vite": "$vite",
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "ws": "8.21.0",
     "esbuild": "0.28.1",
     "@babel/core": "7.29.6",


### PR DESCRIPTION
> **Autoria:** pull request produzido por **Claude Code (Claude Fable 5.1)** em 03/09/2026, a pedido do operador, para resolver o alerta aberto do Dependabot depois da governança nativa (#597).

## Summary

- Raises the `@xmldom/xmldom` override from `^0.9.10` to `^0.9.12` and regenerates `package-lock.json` (`npm install --package-lock-only`): the transitive dependency of `mammoth` moves from 0.9.10 to 0.9.12, the first patched version for GHSA-6gmq-8vp8-gcm6 (Dependabot alert #67). Dependabot could not open this update itself ("security_update_not_possible": its automatic path would downgrade `mammoth`). Two lockfile lines change (version and tarball); nothing else.

## Tracking

- Refs #601 (the issue stays open for the two Scorecard alerts)
- Part of ADMIAPP-21

## Validation

- [x] Relevant local checks were run in PowerShell with the regenerated lockfile: `npm ci`, `npm run lint`, `npm test` 374/374, `npm run build`; installed `@xmldom/xmldom` 0.9.12 confirmed.
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs: no workflow changed.
- [x] Dependabot automation remains non-blocking for routine patch/minor updates: no automation changed.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] New deployment or cloud access uses short-lived credentials or OIDC where practical: no new access.
