### PR TITLE
fix(deps): bump fflate to 0.8.3 in the lockfile (GHSA-px8p-9vwx-vf98)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6229,9 +6229,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
> **Autoria:** pull request produzido por **Claude Code (Claude Fable 5.1)** em 03/09/2026, a pedido do operador ("finalizar admin-app"), para fechar o alerta Scorecard #51 depois da governança nativa (#597) e do PR #602.

## Summary

- Bumps `fflate` from 0.8.2 to 0.8.3 in `package-lock.json` only (`npm update fflate --package-lock-only`). `fflate` is a development dependency of `@vitest/ui` (`^0.8.2`); 0.8.3 is the first patched version for GHSA-px8p-9vwx-vf98 (`unzipSync` infinite loop on a malformed ZIP), the single vulnerability the Scorecard Vulnerabilities check still reports as code-scanning alert #51 after #602. Dependabot raised no alert for it (development scope). Two lockfile lines change (version and tarball); nothing else.

## Tracking

- Refs #601 (the issue stays open for the Scorecard Dangerous-Workflow decision, alert #124)
- Part of ADMIAPP-21

## Validation

- [x] Relevant local checks were run in PowerShell with the updated lockfile: `npm ci`, `npm run lint`, `npm run biome`, `npm test`, `npm run test:admin-motor`, `npm run typecheck:admin-motor`, `npm run build`; `tlsrpt-motor` lint and tests; installed `fflate` 0.8.3 confirmed. Results in the first comment.
- [x] GitHub Actions changes use least-privilege permissions and immutable action SHAs: no workflow changed.
- [x] Dependabot automation remains non-blocking for routine patch/minor updates: no automation changed.

## Security Notes

- [x] No secrets, credentials, tokens, or private infrastructure details were added.
- [x] New deployment or cloud access uses short-lived credentials or OIDC where practical: no new access.
