### PR TITLE
docs: align Gemini fork prerequisite with Vertex AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Documentação
+
+- Corrigido o pré-requisito de Gemini no guia de fork: a integração existente usa Vertex AI
+  com credencial JSON de service account em `VERTEX_SA_KEY`, não uma API key do Google AI Studio.
+  Nenhuma credencial, configuração ou implementação foi alterada (GIT-202/GIT-203).
+
 ### Infraestrutura
 
 - **`npm audit` do `Deploy` distingue vulnerabilidade de requisição de advisories falha.**

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You will need:
 - A Cloudflare Zero Trust account (free for ≤50 users) for Access JWT auth.
 - The Cloudflare CLI [`wrangler`](https://developers.cloudflare.com/workers/wrangler/).
 - Node.js 24+.
-- A Google AI Studio API key for Gemini integration.
+- A Google Cloud project with Vertex AI enabled and a service-account JSON credential for the `VERTEX_SA_KEY` binding (see step 5); a Google AI Studio API key is not used by this integration.
 - A Resend API key (only if running e-mail dispatch features).
 
 ### 1. Clone + install

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ You will need:
 - A Cloudflare Zero Trust account (free for ≤50 users) for Access JWT auth.
 - The Cloudflare CLI [`wrangler`](https://developers.cloudflare.com/workers/wrangler/).
 - Node.js 24+.
-- A Google Cloud project with Vertex AI enabled and a service-account JSON credential for the `VERTEX_SA_KEY` binding (see step 5); a Google AI Studio API key is not used by this integration.
+- A Google Cloud project with Vertex AI enabled and a service-account JSON credential for the `VERTEX_SA_KEY` binding (see [Configure additional secrets](#6-configure-additional-secrets)); a Google AI Studio API key is not used by this integration.
 - A Resend API key (only if running e-mail dispatch features).
 
 ### 1. Clone + install


### PR DESCRIPTION
## Summary

Correct one fork prerequisite in the README: the existing Gemini integration uses a Vertex AI service-account JSON credential through VERTEX_SA_KEY, not a Google AI Studio API key. Link to the existing additional-secrets instructions and record the correction in CHANGELOG.

## Verification

- Compared with README's existing provider contract and additional-secrets section, the VERTEX_SA_KEY binding, and current Vertex credential handling.
- git diff --check passed.
- Documentation only. No runtime, dependency, credential, workflow or platform configuration changed.
- Normal repository CI remains required; no local deployment was run.
- Both commits are SSH-signed; signing settings were not modified.

Audit: https://linear.app/lcv-ideas-software/issue/GIT-202 and https://linear.app/lcv-ideas-software/issue/GIT-203.
This PR does not close either audit issue.