### PR TITLE
fix(dependabot): coordinate Vitest peer updates [ADMIAPP-23]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,11 @@ updates:
         applies-to: security-updates
         patterns:
           - '*'
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
       minor-e-patch:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
The root package uses `vitest`, `@vitest/coverage-v8` and `@vitest/ui`, which require coordinated versions. Separate major updates can produce the peer-resolution failure reproduced in the same package family during the Dependabot rollout.

Add a native version-update group for `vitest` and `@vitest/*` in the root npm directory, before the general minor/patch group. Include major updates and retain all existing schedules, cooldowns, security groups and required checks. The TLS worker has only standalone Vitest and keeps its existing groups.

Validation: parsed YAML comparison confirms only the intended root group changed; 374 frontend, 625 admin-motor and 5 TLS worker tests, lint/Biome, admin-motor typecheck, production build and both strict Wrangler dry runs passed. Exact-head repository checks and native update jobs remain required.

Closes #610.
Fixes ADMIAPP-23.
