### PR TITLE
fix(dependabot): retain compatible TLS Vitest updates [ADMIAPP-23]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,6 +72,12 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/tlsrpt-motor'
+    ignore:
+      # Cloudflare's Workers test integration currently requires Vitest ^4.1.0.
+      # Remove after the official integration supports Vitest 5 and CI passes.
+      - dependency-name: 'vitest'
+        versions:
+          - '>=5.0.0'
     schedule:
       interval: 'cron'
       cronjob: '0 5 * * *'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,13 @@ adjusting the native group configuration or recreating a pull request. Any
 configured version ignores also constrain security fixes, so review them when
 upstream compatibility changes. Native auto-merge remains subject to every required check.
 
+The TLS reporting worker retains Vitest 4 because Cloudflare's official Workers
+test integration requires `vitest: ^4.1.0`. Its scoped Dependabot ignore excludes
+Vitest 5 and later, including security updates in that range. Remove this ignore
+when the official integration supports the new Vitest version and the repository
+checks pass; investigate any security fix blocked by this compatibility constraint.
+See Cloudflare's [Workers testing prerequisites](https://developers.cloudflare.com/workers/testing/vitest-integration/write-your-first-test/).
+
 See the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference)
 and [security update documentation](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates).
 


### PR DESCRIPTION
Dependabot PR #613 updates the TLS reporting worker to Vitest 5, but npm CI fails with ERESOLVE because `@cloudflare/vitest-pool-workers@0.22.0` requires `vitest: ^4.1.0`. The latest renamed official package, `@cloudflare/vitest-plugin@1.1.7`, has the same peer constraint.

Keep TLS Vitest updates below 5 using a native ignore scoped to `/tlsrpt-motor`. Document that this also restricts security updates in the excluded range and must be removed once the official integration supports the new version and repository checks pass. Other npm roots retain their coordinated Vitest updates.

Validation: full repository suite passed (374 frontend, 625 admin-motor and 5 TLS worker tests), lint/Biome, admin-motor typecheck, production build and both strict Wrangler dry runs. The exact failing CI log, current official npm peer metadata and the [Cloudflare prerequisites](https://developers.cloudflare.com/workers/testing/vitest-integration/write-your-first-test/) support the scoped compatibility restriction.

Closes #610.
Fixes ADMIAPP-23.
