### PR TITLE
chore: align Wrangler deployment inputs (ADMIAPP-24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,7 +168,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.129.0
           command: d1 migrations apply BIGDATA_DB --remote --config wrangler.json
 
       - name: Deploy TLS-RPT Motor with Wrangler
@@ -177,7 +177,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.129.0
           workingDirectory: tlsrpt-motor
           command: deploy --strict
 
@@ -187,7 +187,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.129.0
           command: deploy --strict --config admin-motor/wrangler.json
 
       - name: Deploy Admin Pages with Wrangler
@@ -196,5 +196,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: npm
-          wranglerVersion: 4.127.1
+          wranglerVersion: 4.129.0
           command: pages deploy dist --project-name=admin-app --branch=main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Infraestrutura
 
 - Atualizados os pins oficiais de CodeQL para 4.38.0 e zizmor-action para 0.6.4.
-  Os quatro inputs do deploy usam o Wrangler 4.127.1 já fixado nos lockfiles.
+  Alinhados os quatro inputs do deploy ao Wrangler 4.129.0 já fixado nos lockfiles.
 
 - **`npm audit` do `Deploy` distingue vulnerabilidade de requisição de advisories falha.**
   Os passos de auditoria (Admin App e TLS-RPT Motor) continuam reprovando o deploy quando


### PR DESCRIPTION
Os quatro inputs de publicação selecionavam Wrangler 4.127.1, embora os manifestos e lockfiles da raiz e do TLS-RPT Motor já selecionem 4.129.0. Este PR alinha os quatro inputs a 4.129.0 e atualiza a frase correspondente em Unreleased.

Validação: reprodução antes/depois; 374 testes da aplicação, 625 do Admin Motor e 5 do TLS-RPT Motor; ESLint, Biome, verificação de tipos, build e os dois dry-runs estritos aprovados. O diff contém somente cinco substituições em dois arquivos; pins das Actions, manifestos e lockfiles preservados.

Closes #621
Fixes ADMIAPP-24
Auditoria: [LCV-181](https://linear.app/lcv-ideas-software/issue/LCV-181).
